### PR TITLE
Dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 10
+      interval: "weekly"
+    open-pull-requests-limit: 5
     labels:
       - "chore:dependencies"
     ignore:
@@ -14,7 +14,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     open-pull-requests-limit: 5
     labels:
       - "chore:dependencies"

--- a/.github/instructions/plan-generation.instructions.md
+++ b/.github/instructions/plan-generation.instructions.md
@@ -193,12 +193,3 @@ The implementation agent MUST:
 7. NOT modify files not listed in the Changes Overview
 
 If the agent encounters ambiguity, it MUST stop and request clarification rather than assume.
-
-## Deliverables
-
-1. Save the plan with in the `.plans` folder at the workspace/project root.  The file name should be concise and descriptive.  Under 48chars, must have a `.prompt.md` file extension.
-2. Summerize the state of the plan, and provide the user with a clickable in-line link to open the newly created plan.
-
-### File Exists already
-
-If the file exists, compare the existing file content and determine if they conver the same content for the plan you just generated.  If the plan covers the same content, inteligently update the plan unless the user specifically requests that you replace it.

--- a/.github/prompts/project-planner.prompt.md
+++ b/.github/prompts/project-planner.prompt.md
@@ -16,7 +16,7 @@ Create a detailed implementation plan for the requested task, following the repo
 - Prefer workspace-specific paths and exact file references.
 - Include required reading, test-first sequencing, validation commands, and rollback guidance.
 - Keep the plan actionable for an autonomous implementation agent.
-- Output the plan following the standard structure so the user can save it in `.plans/`.
+- Save the plan within `.plans/pending` as `<PLAN_NAME>.prompt.md`
 
 ## Task
 {{$input}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.1] - 2026-04-23
+
+### ✨ Features
+
+* **Model Display Labels**: Added `ExtendedModelInformation` type and `formatModelDisplayLabel` helper to centralize model UI labeling and vendor display.
+* **Provider Metadata**: Updated `LiteLLMProviderBase` to expose `rawModelName`, `vendor`, `backendName`, `tooltip` and `detail` so consumers render consistent model info.
+* **Token Normalization**: Normalized provider handling and token fields by using `providerLower` for family derivation and `derived.maxInputTokens` for maxInputTokens.
+
+### 🐛 Fixes
+
+* **Post-Session Scripts**: Updated post-session validation message to recommend running `npm run format` and `npm run lint` (removed `:check` variants) so commands match current scripts.
+
+### 🧹 Chores & Tests
+
+* Bumped package.json version to 1.6.1-dev5.
+* Adjusted unit tests to validate new display label formatting and backendName/description values.
 
 ## [1.6.0] - 2026-04-12
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"type": "git",
 		"url": "https://github.com/gethnet/litellm-connector-copilot"
 	},
-	"version": "1.6.0",
+	"version": "1.6.1-dev1",
 	"preview": false,
 	"engines": {
 		"vscode": "^1.110.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"type": "git",
 		"url": "https://github.com/gethnet/litellm-connector-copilot"
 	},
-	"version": "1.6.1-dev5",
+	"version": "1.6.1",
 	"preview": false,
 	"engines": {
 		"vscode": "^1.110.0"
@@ -288,8 +288,8 @@
 		"zx": "^8.8.5"
 	},
 	"dependencies": {
-		"posthog-js": "^1.364.7",
-		"posthog-node": "^5.28.11"
+		"posthog-js": "^1.371.2",
+		"posthog-node": "^5.30.0"
 	},
 	"enabledApiProposals": [
 		"chatProvider",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"type": "git",
 		"url": "https://github.com/gethnet/litellm-connector-copilot"
 	},
-	"version": "1.6.1-dev1",
+	"version": "1.6.1-dev5",
 	"preview": false,
 	"engines": {
 		"vscode": "^1.110.0"

--- a/scripts/post-session-validation.sh
+++ b/scripts/post-session-validation.sh
@@ -56,7 +56,7 @@ if [ ${#FAILED_CHECKS[@]} -gt 0 ]; then
 {
   "decision": "fail",
   "reason": "Post-session validation failed: ${FAILED_LIST}",
-  "systemMessage": "Agent session ended with validation failures. Please resolve the following issues before continuing:\n\n${FAILURE_DETAILS}\nRun the following commands to see details:\n- npm run format:check\n- npm run lint:check  \n- npm run test:coverage\n\nFix the issues and try again."
+  "systemMessage": "Agent session ended with validation failures. Please resolve the following issues before continuing:\n\n${FAILURE_DETAILS}\nRun the following commands to see details:\n- npm run format\n- npm run lint  \n- npm run test:coverage\n\nFix the issues and try again."
 }
 EOF
     exit 2  # Blocking error

--- a/scripts/post-session-validation.sh
+++ b/scripts/post-session-validation.sh
@@ -27,12 +27,12 @@ run_check() {
 FAILED_CHECKS=()
 
 # Run format check
-if ! run_check "npm run format:check" "format check"; then
+if ! run_check "npm run format" "format check"; then
     FAILED_CHECKS+=("format")
 fi
 
 # Run lint check
-if ! run_check "npm run lint:check" "lint check"; then
+if ! run_check "npm run lint" "lint check"; then
     FAILED_CHECKS+=("lint")
 fi
 

--- a/src/commands/inlineCompletions.ts
+++ b/src/commands/inlineCompletions.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { formatModelDisplayLabel, type ExtendedModelInformation } from "../utils/modelCapabilities";
 
 import type { LiteLLMChatProvider } from "../providers";
 import { Logger } from "../utils/logger";
@@ -54,12 +55,13 @@ export function registerSelectInlineCompletionModelCommand(provider: LiteLLMChat
                 .slice()
                 .sort((a, b) => a.id.localeCompare(b.id))
                 .map((m) => {
-                    const tags = (m as ModelWithOptionalTags).tags ?? [];
+                    const mExtended = m as ExtendedModelInformation;
+                    const tags = mExtended.tags ?? [];
                     return {
-                        label: m.name,
-                        description: m.name !== m.id ? m.name : undefined,
-                        detail: tags.length ? `tags: ${tags.join(", ")}` : m.tooltip,
-                        modelId: m.id,
+                        label: formatModelDisplayLabel(mExtended),
+                        description: mExtended.name !== mExtended.id ? mExtended.name : undefined,
+                        detail: tags.length ? `tags: ${tags.join(", ")}` : mExtended.tooltip,
+                        modelId: mExtended.id,
                     };
                 }),
             {

--- a/src/commands/modelPicker.ts
+++ b/src/commands/modelPicker.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { formatModelDisplayLabel, type ExtendedModelInformation } from "../utils/modelCapabilities";
 import type { LiteLLMProviderBase } from "../providers/liteLLMProviderBase";
 import { Logger } from "../utils/logger";
 import type { TelemetryService } from "../telemetry/telemetryService";
@@ -51,37 +52,12 @@ export async function showModelPicker(provider: LiteLLMProviderBase, options: Mo
             return;
         }
 
-        /**
-         * Extracts the backend name from a model's tooltip without fragile regex.
-         * Tooltip format: "Provider:model contributed by BACKEND_NAME via Extension Name"
-         * Returns the BACKEND_NAME, or fallback to vendor if available.
-         */
-        function extractBackendNameFromTooltip(tooltip: string | undefined, fallback: string | undefined): string {
-            if (!tooltip) {
-                return fallback || "";
-            }
-
-            // Find "contributed by" and "via" boundaries without relying on exact spacing
-            const startMarker = "contributed by ";
-            const endMarker = " via";
-
-            const startIdx = tooltip.indexOf(startMarker);
-            const endIdx = tooltip.indexOf(endMarker, startIdx);
-
-            if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
-                return tooltip.substring(startIdx + startMarker.length, endIdx).trim();
-            }
-
-            return fallback || "";
-        }
-
         const items: vscode.QuickPickItem[] = models.map((m) => {
-            const mAny = m as unknown as { vendor?: string; tags?: string[]; tooltip?: string; detail?: string };
+            const mExtended = m as ExtendedModelInformation;
             return {
-                label: m.name,
-                // Extract backend name from tooltip using robust parsing, fallback to vendor field
-                description: extractBackendNameFromTooltip(mAny.tooltip, mAny.vendor),
-                detail: mAny.detail || "",
+                label: formatModelDisplayLabel(mExtended),
+                description: mExtended.backendName || mExtended.detail || "",
+                detail: mExtended.tooltip || "",
             };
         });
 

--- a/src/commands/modelPicker.ts
+++ b/src/commands/modelPicker.ts
@@ -51,15 +51,37 @@ export async function showModelPicker(provider: LiteLLMProviderBase, options: Mo
             return;
         }
 
+        /**
+         * Extracts the backend name from a model's tooltip without fragile regex.
+         * Tooltip format: "Provider:model contributed by BACKEND_NAME via Extension Name"
+         * Returns the BACKEND_NAME, or fallback to vendor if available.
+         */
+        function extractBackendNameFromTooltip(tooltip: string | undefined, fallback: string | undefined): string {
+            if (!tooltip) {
+                return fallback || "";
+            }
+
+            // Find "contributed by" and "via" boundaries without relying on exact spacing
+            const startMarker = "contributed by ";
+            const endMarker = " via";
+
+            const startIdx = tooltip.indexOf(startMarker);
+            const endIdx = tooltip.indexOf(endMarker, startIdx);
+
+            if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+                return tooltip.substring(startIdx + startMarker.length, endIdx).trim();
+            }
+
+            return fallback || "";
+        }
+
         const items: vscode.QuickPickItem[] = models.map((m) => {
-            const mAny = m as unknown as { vendor?: string; tags?: string[] };
+            const mAny = m as unknown as { vendor?: string; tags?: string[]; tooltip?: string; detail?: string };
             return {
                 label: m.name,
-                // Keep routing value as the internal VS Code model id.
-                // QuickPickItem has no separate value field, so we encode it in the description.
-                // Instead, we update later by selecting label -> id mapping.
-                description: mAny.vendor || "",
-                detail: mAny.tags?.join(", ") || "",
+                // Extract backend name from tooltip using robust parsing, fallback to vendor field
+                description: extractBackendNameFromTooltip(mAny.tooltip, mAny.vendor),
+                detail: mAny.detail || "",
             };
         });
 

--- a/src/commands/test/modelPicker.test.ts
+++ b/src/commands/test/modelPicker.test.ts
@@ -35,8 +35,8 @@ suite("ModelPicker Unit Tests", () => {
 
     test("showModelPicker updates configuration on selection", async () => {
         const mockModels = [
-            { id: "model-1", name: "model-1" },
-            { id: "model-2", name: "model-2" },
+            { id: "model-1", name: "model-1", backendName: "LiteLLM" },
+            { id: "model-2", name: "model-2", backendName: "cloud" },
         ];
         mockProvider.discoverModels.resolves(mockModels as unknown as vscode.LanguageModelChatInformation[]);
         mockProvider.getConfigManager.returns({
@@ -64,6 +64,9 @@ suite("ModelPicker Unit Tests", () => {
         });
 
         assert.strictEqual(quickPickStub.calledOnce, true);
+        const quickPickItems = quickPickStub.firstCall.args[0] as vscode.QuickPickItem[];
+        assert.strictEqual(quickPickItems[0].description, "LiteLLM");
+        assert.strictEqual(quickPickItems[1].description, "cloud");
         assert.strictEqual(configUpdateStub.calledOnce, true);
         assert.strictEqual(configUpdateStub.firstCall.args[0], "testKey");
         assert.strictEqual(configUpdateStub.firstCall.args[1], "model-1");

--- a/src/providers/liteLLMProviderBase.ts
+++ b/src/providers/liteLLMProviderBase.ts
@@ -31,8 +31,6 @@ import {
     deriveCapabilitiesFromModelInfo,
     capabilitiesToVSCode,
     getModelTags as getDerivedModelTags,
-    formatProviderName,
-    formatModelName,
 } from "../utils/modelCapabilities";
 import type { DerivedModelCapabilities } from "../utils/modelCapabilities";
 import type { V2ChatMessage } from "./v2Types";
@@ -232,32 +230,33 @@ export abstract class LiteLLMProviderBase {
                 const capabilities = capabilitiesToVSCode(derived, capOverride);
                 const tags = getDerivedModelTags(modelId, derived, config.modelOverrides, capOverride);
 
-                const providerName = formatProviderName(modelInfo?.litellm_provider ?? "litellm");
-                const modelName = formatModelName(entry.model_name ?? modelId);
+                const rawProvider = modelInfo?.litellm_provider ?? "litellm";
+                const rawModelName = entry.model_name ?? modelId;
+
                 const isSingleBackend = this._activeBackendNames.length <= 1;
-                const backendDisplay = isSingleBackend ? "LiteLLM" : entry.backendName;
-                const displayId = `${providerName}:${modelName}`;
-                // Fallback since json import fails in some environments
+                const backendDisplay = isSingleBackend ? "LiteLLM" : "LiteLLM: " + entry.backendName;
                 const extensionName = "LiteLLM Connector for Copilot";
-                const tooltip = `${providerName}:${modelName} contributed by ${backendDisplay} via ${extensionName}`;
+                const tooltip = `Provider: ${rawProvider}, Model: ${rawModelName} contributed by ${backendDisplay} via ${extensionName}`;
 
                 // Derive family from provider to help Copilot shape requests correctly
-                const provider = modelInfo?.litellm_provider?.toLowerCase();
+                const providerLower = rawProvider.toLowerCase();
                 let family = "litellm";
-                if (provider === "openai") {
+                if (providerLower === "openai") {
                     family = "gpt4";
-                } else if (provider === "anthropic") {
+                } else if (providerLower === "anthropic") {
                     family = "claude";
                 }
 
                 const info = {
                     id: modelId,
-                    name: displayId,
+                    name: rawModelName,
+                    vendor: rawProvider,
+                    backendName: backendDisplay,
                     tooltip,
-                    detail: "",
+                    detail: backendDisplay,
                     family: family,
                     version: "1.0.0",
-                    maxInputTokens: derived.rawContextWindow,
+                    maxInputTokens: derived.maxInputTokens,
                     maxOutputTokens: derived.maxOutputTokens,
                     capabilities,
                     tags,

--- a/src/providers/liteLLMProviderBase.ts
+++ b/src/providers/liteLLMProviderBase.ts
@@ -31,6 +31,8 @@ import {
     deriveCapabilitiesFromModelInfo,
     capabilitiesToVSCode,
     getModelTags as getDerivedModelTags,
+    formatProviderName,
+    formatModelName,
 } from "../utils/modelCapabilities";
 import type { DerivedModelCapabilities } from "../utils/modelCapabilities";
 import type { V2ChatMessage } from "./v2Types";
@@ -230,24 +232,14 @@ export abstract class LiteLLMProviderBase {
                 const capabilities = capabilitiesToVSCode(derived, capOverride);
                 const tags = getDerivedModelTags(modelId, derived, config.modelOverrides, capOverride);
 
-                const formatTokens = (num: number): string => {
-                    if (num >= 1000000) {
-                        return `${(num / 1000000).toFixed(1).replace(/\.0$/, "")}M`;
-                    }
-                    if (num >= 1000) {
-                        return `${Math.floor(num / 1000)}K`;
-                    }
-                    return num.toString();
-                };
-
-                const inputDesc = formatTokens(derived.rawContextWindow);
-                const outputDesc = formatTokens(derived.maxOutputTokens);
-                const tooltip = `${entry.backendName} · ${modelInfo?.litellm_provider ?? "LiteLLM"} (${modelInfo?.mode ?? "responses"}) — Context: ${inputDesc} in / ${outputDesc} out`;
-
-                // User-facing model label for multi-backend environments.
-                // VS Code expects `id` to be stable and routable, so we keep `id` as the namespaced id.
-                // The human-facing label is exposed via `name`.
-                const displayId = `${entry.backendName}:${entry.model_name ?? modelId}`;
+                const providerName = formatProviderName(modelInfo?.litellm_provider ?? "litellm");
+                const modelName = formatModelName(entry.model_name ?? modelId);
+                const isSingleBackend = this._activeBackendNames.length <= 1;
+                const backendDisplay = isSingleBackend ? "LiteLLM" : entry.backendName;
+                const displayId = `${providerName}:${modelName}`;
+                // Fallback since json import fails in some environments
+                const extensionName = "LiteLLM Connector for Copilot";
+                const tooltip = `${providerName}:${modelName} contributed by ${backendDisplay} via ${extensionName}`;
 
                 // Derive family from provider to help Copilot shape requests correctly
                 const provider = modelInfo?.litellm_provider?.toLowerCase();
@@ -262,7 +254,7 @@ export abstract class LiteLLMProviderBase {
                     id: modelId,
                     name: displayId,
                     tooltip,
-                    detail: `Backend: ${entry.backendName} | Context: ${inputDesc} | Output: ${outputDesc}`,
+                    detail: "",
                     family: family,
                     version: "1.0.0",
                     maxInputTokens: derived.rawContextWindow,

--- a/src/providers/test/liteLLMProviderBase.modelDisplay.test.ts
+++ b/src/providers/test/liteLLMProviderBase.modelDisplay.test.ts
@@ -63,6 +63,7 @@ suite("LiteLLM model display", () => {
 
         assert.strictEqual(models.length, 1);
         assert.strictEqual(models[0].id, "cloud/gpt-4o");
-        assert.strictEqual(models[0].name, "Open AI:GPT 4o");
+        assert.strictEqual(models[0].name, "gpt-4o");
+        assert.strictEqual((models[0] as unknown as { vendor: string }).vendor, "openai");
     });
 });

--- a/src/providers/test/liteLLMProviderBase.modelDisplay.test.ts
+++ b/src/providers/test/liteLLMProviderBase.modelDisplay.test.ts
@@ -63,6 +63,6 @@ suite("LiteLLM model display", () => {
 
         assert.strictEqual(models.length, 1);
         assert.strictEqual(models[0].id, "cloud/gpt-4o");
-        assert.strictEqual(models[0].name, "cloud:gpt-4o");
+        assert.strictEqual(models[0].name, "Open AI:GPT 4o");
     });
 });

--- a/src/test/integration/errorHandling.test.ts
+++ b/src/test/integration/errorHandling.test.ts
@@ -117,12 +117,12 @@ suite("LiteLLM Error Handling Unit Tests", function () {
     test("provideLanguageModelChatResponse handles unsupported parameter error from LiteLLM (when retry also fails)", async () => {
         const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
 
-        type ProviderWithConfig = {
+        interface ProviderWithConfig {
             _configManager: {
                 isConfigured: () => Promise<boolean>;
                 getConfig: () => Promise<{ url: string; inactivityTimeout?: number }>;
             };
-        };
+        }
         const providerWithConfig = provider as unknown as ProviderWithConfig;
         sandbox.stub(providerWithConfig._configManager, "isConfigured").resolves(true);
         sandbox
@@ -181,12 +181,12 @@ suite("LiteLLM Error Handling Unit Tests", function () {
     test("provideLanguageModelChatResponse handles generic 400 error", async () => {
         const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
 
-        type ProviderWithConfig = {
+        interface ProviderWithConfig {
             _configManager: {
                 isConfigured: () => Promise<boolean>;
                 getConfig: () => Promise<{ url: string; inactivityTimeout?: number }>;
             };
-        };
+        }
         const providerWithConfig = provider as unknown as ProviderWithConfig;
         sandbox.stub(providerWithConfig._configManager, "isConfigured").resolves(true);
         sandbox

--- a/src/utils/modelCapabilities.ts
+++ b/src/utils/modelCapabilities.ts
@@ -109,72 +109,29 @@ export function getModelTags(
 }
 
 /**
- * Converts a lowercase provider ID to a properly-cased display name.
- * Handles special cases like multi-word providers (e.g., "openrouter" → "Open Router")
- * and single-letter edge cases (e.g., "xai" → "xAI").
- *
- * Algorithm:
- * 1. Handle known special casing (xai → xAI)
- * 2. Split on uppercase letters to detect word boundaries (e.g., "openrouter" is one word, but common compound words are handled)
- * 3. Title-case each word and join with space
+ * Type definition for extended properties on LanguageModelChatInformation.
  */
-export function formatProviderName(provider: string): string {
-    const lower = provider.toLowerCase().trim();
-
-    // Known special cases that don't follow standard rules
-    switch (lower) {
-        case "xai":
-            return "xAI";
-        case "openai":
-            return "OpenAI";
-        case "vertexai":
-            return "VertexAI";
-        case "vertex_ai":
-            return "VertexAI";
-        default:
-            break;
-    }
-
-    // Detect and preserve acronyms: common two-letter endings that should be uppercase
-    // (e.g., "openai" → "Open AI", "bedrock" → "Bedrock", "xai" → "xAI")
-    const acronymSuffixes = ["ai", "ml", "xr"];
-
-    let result = lower;
-    for (const suffix of acronymSuffixes) {
-        if (lower.endsWith(suffix) && lower.length > suffix.length) {
-            // Replace the suffix with itself in uppercase, preserving the rest
-            result = lower.slice(0, -suffix.length) + suffix.toUpperCase();
-            break;
-        }
-    }
-
-    // Split on hyphens, underscores, and camelCase boundaries
-    const parts = result
-        .replace(/([a-z])([A-Z])/g, "$1 $2") // camelCase (e.g., openAI → open AI)
-        .replace(/[-_]/g, " ") // hyphens and underscores
-        .split(/\s+/)
-        .filter((p) => p.length > 0);
-
-    // Title-case each part and join with space
-    return parts.map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join(" ");
-}
+export type ExtendedModelInformation = vscode.LanguageModelChatInformation & {
+    vendor?: string;
+    backendName?: string;
+    tags?: string[];
+    detail?: string;
+    tooltip?: string;
+};
 
 /**
- * Converts a raw model ID to a human-readable display name.
- * Splits by hyphens, title-cases each part, fully capitalizes short lowercase words (e.g., "gpt" → "GPT"),
- * and joins with spaces for readability.
+ * Centralized helper to format how a model is displayed in UI surfaces.
+ * Uses raw string values.
+ *
+ * @param modelOrName The extended model information object, or the raw model name string.
+ * @param vendor Optional raw provider/vendor name (used only if modelOrName is a string).
+ * @returns A consistent UI label
  */
-export function formatModelName(modelName: string): string {
-    return modelName
-        .split("-")
-        .map((part) => {
-            if (/^\d/.test(part)) {
-                return part;
-            } // Keep numbers as-is (e.g., "4o", "3")
-            if (part.length <= 3 && /^[a-z]+$/.test(part) && part !== "pro" && part !== "max" && part !== "my") {
-                return part.toUpperCase();
-            } // Fully capitalize short words except specific non-acronyms
-            return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase(); // Title-case longer words
-        })
-        .join(" ");
+export function formatModelDisplayLabel(modelOrName: ExtendedModelInformation | string, vendor?: string): string {
+    if (typeof modelOrName === "string") {
+        return vendor ? `[${vendor}] ${modelOrName}` : modelOrName;
+    }
+
+    const modelVendor = modelOrName.vendor;
+    return modelVendor ? `[${modelVendor}] ${modelOrName.name}` : modelOrName.name;
 }

--- a/src/utils/modelCapabilities.ts
+++ b/src/utils/modelCapabilities.ts
@@ -107,3 +107,74 @@ export function getModelTags(
 
     return Array.from(tags);
 }
+
+/**
+ * Converts a lowercase provider ID to a properly-cased display name.
+ * Handles special cases like multi-word providers (e.g., "openrouter" → "Open Router")
+ * and single-letter edge cases (e.g., "xai" → "xAI").
+ *
+ * Algorithm:
+ * 1. Handle known special casing (xai → xAI)
+ * 2. Split on uppercase letters to detect word boundaries (e.g., "openrouter" is one word, but common compound words are handled)
+ * 3. Title-case each word and join with space
+ */
+export function formatProviderName(provider: string): string {
+    const lower = provider.toLowerCase().trim();
+
+    // Known special cases that don't follow standard rules
+    switch (lower) {
+        case "xai":
+            return "xAI";
+        case "openai":
+            return "OpenAI";
+        case "vertexai":
+            return "VertexAI";
+        case "vertex_ai":
+            return "VertexAI";
+        default:
+            break;
+    }
+
+    // Detect and preserve acronyms: common two-letter endings that should be uppercase
+    // (e.g., "openai" → "Open AI", "bedrock" → "Bedrock", "xai" → "xAI")
+    const acronymSuffixes = ["ai", "ml", "xr"];
+
+    let result = lower;
+    for (const suffix of acronymSuffixes) {
+        if (lower.endsWith(suffix) && lower.length > suffix.length) {
+            // Replace the suffix with itself in uppercase, preserving the rest
+            result = lower.slice(0, -suffix.length) + suffix.toUpperCase();
+            break;
+        }
+    }
+
+    // Split on hyphens, underscores, and camelCase boundaries
+    const parts = result
+        .replace(/([a-z])([A-Z])/g, "$1 $2") // camelCase (e.g., openAI → open AI)
+        .replace(/[-_]/g, " ") // hyphens and underscores
+        .split(/\s+/)
+        .filter((p) => p.length > 0);
+
+    // Title-case each part and join with space
+    return parts.map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join(" ");
+}
+
+/**
+ * Converts a raw model ID to a human-readable display name.
+ * Splits by hyphens, title-cases each part, fully capitalizes short lowercase words (e.g., "gpt" → "GPT"),
+ * and joins with spaces for readability.
+ */
+export function formatModelName(modelName: string): string {
+    return modelName
+        .split("-")
+        .map((part) => {
+            if (/^\d/.test(part)) {
+                return part;
+            } // Keep numbers as-is (e.g., "4o", "3")
+            if (part.length <= 3 && /^[a-z]+$/.test(part) && part !== "pro" && part !== "max" && part !== "my") {
+                return part.toUpperCase();
+            } // Fully capitalize short words except specific non-acronyms
+            return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase(); // Title-case longer words
+        })
+        .join(" ");
+}

--- a/src/utils/test/modelCapabilities.test.ts
+++ b/src/utils/test/modelCapabilities.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { capabilitiesToVSCode, getModelTags } from "../modelCapabilities";
+import { capabilitiesToVSCode, getModelTags, formatProviderName, formatModelName } from "../modelCapabilities";
 import type { ModelCapabilityOverride } from "../../types";
 
 suite("modelCapabilities", () => {
@@ -184,7 +184,7 @@ suite("modelCapabilities", () => {
             assert.ok(tags.includes("pdf"), "should have pdf tag from override");
         });
 
-        test("merges tag overrides and capability overrides together", () => {
+        test("override merges tag overrides and capability overrides together", () => {
             const derived = {
                 supportsTools: false,
                 supportsVision: false,
@@ -199,8 +199,50 @@ suite("modelCapabilities", () => {
             const tagOverrides = { "gpt-4o": ["custom-tag"] };
             const capabilityOverrides: ModelCapabilityOverride = { toolCalling: true };
             const tags = getModelTags("gpt-4o", derived, tagOverrides, capabilityOverrides);
-            assert.ok(tags.includes("tools"), "Should include tools from capability override");
-            assert.ok(tags.includes("custom-tag"), "Should include custom-tag from tag override");
+            assert.ok(tags.includes("tools"), "Should include tools tag from capability override");
+            assert.ok(tags.includes("custom-tag"), "Should include custom tag from tag overrides");
+        });
+    });
+
+    suite("formatProviderName and formatModelName", () => {
+        test("formatProviderName title-cases single-word providers", () => {
+            assert.strictEqual(formatProviderName("anthropic"), "Anthropic");
+            assert.strictEqual(formatProviderName("google"), "Google");
+            assert.strictEqual(formatProviderName("azure"), "Azure");
+            assert.strictEqual(formatProviderName("ollama"), "Ollama");
+            assert.strictEqual(formatProviderName("groq"), "Groq");
+            assert.strictEqual(formatProviderName("mistral"), "Mistral");
+            assert.strictEqual(formatProviderName("bedrock"), "Bedrock");
+            assert.strictEqual(formatProviderName("perplexity"), "Perplexity");
+        });
+
+        test("formatProviderName detects and capitalizes acronym suffixes", () => {
+            assert.strictEqual(formatProviderName("openai"), "Open AI"); // Detects "ai" suffix
+            assert.strictEqual(formatProviderName("openrouter"), "Openrouter"); // "router" not an acronym
+            assert.strictEqual(formatProviderName("xai"), "xAI"); // Single letter + "ai"
+        });
+
+        test("formatProviderName handles hyphenated and underscored names", () => {
+            assert.strictEqual(formatProviderName("custom-provider"), "Custom Provider");
+            assert.strictEqual(formatProviderName("my_provider"), "My Provider");
+        });
+
+        test("formatProviderName title-cases unknown single-word providers", () => {
+            assert.strictEqual(formatProviderName("customprovider"), "Customprovider");
+            assert.strictEqual(formatProviderName("myprovider"), "Myprovider");
+        });
+
+        test("formatModelName applies intelligent formatting rules", () => {
+            assert.strictEqual(formatModelName("gpt-4o"), "GPT 4o");
+            assert.strictEqual(formatModelName("gpt-4o-mini"), "GPT 4o Mini");
+            assert.strictEqual(formatModelName("claude-3-5-sonnet-20241022"), "Claude 3 5 Sonnet 20241022");
+            assert.strictEqual(formatModelName("gemini-2-5-pro"), "Gemini 2 5 Pro");
+            assert.strictEqual(formatModelName("o3-mini"), "O3 Mini");
+        });
+
+        test("formatModelName handles general cases with title casing", () => {
+            assert.strictEqual(formatModelName("my-custom-model"), "My Custom Model");
+            assert.strictEqual(formatModelName("llama-3-70b"), "Llama 3 70b");
         });
     });
 });

--- a/src/utils/test/modelCapabilities.test.ts
+++ b/src/utils/test/modelCapabilities.test.ts
@@ -1,5 +1,10 @@
 import * as assert from "assert";
-import { capabilitiesToVSCode, getModelTags, formatProviderName, formatModelName } from "../modelCapabilities";
+import {
+    capabilitiesToVSCode,
+    getModelTags,
+    formatModelDisplayLabel,
+    type ExtendedModelInformation,
+} from "../modelCapabilities";
 import type { ModelCapabilityOverride } from "../../types";
 
 suite("modelCapabilities", () => {
@@ -204,45 +209,19 @@ suite("modelCapabilities", () => {
         });
     });
 
-    suite("formatProviderName and formatModelName", () => {
-        test("formatProviderName title-cases single-word providers", () => {
-            assert.strictEqual(formatProviderName("anthropic"), "Anthropic");
-            assert.strictEqual(formatProviderName("google"), "Google");
-            assert.strictEqual(formatProviderName("azure"), "Azure");
-            assert.strictEqual(formatProviderName("ollama"), "Ollama");
-            assert.strictEqual(formatProviderName("groq"), "Groq");
-            assert.strictEqual(formatProviderName("mistral"), "Mistral");
-            assert.strictEqual(formatProviderName("bedrock"), "Bedrock");
-            assert.strictEqual(formatProviderName("perplexity"), "Perplexity");
+    suite("formatModelDisplayLabel", () => {
+        test("formats strings correctly", () => {
+            assert.strictEqual(formatModelDisplayLabel("gpt-4o", "openai"), "[openai] gpt-4o");
+            assert.strictEqual(formatModelDisplayLabel("gpt-4o"), "gpt-4o");
+            assert.strictEqual(formatModelDisplayLabel("gpt-4o", ""), "gpt-4o");
         });
 
-        test("formatProviderName detects and capitalizes acronym suffixes", () => {
-            assert.strictEqual(formatProviderName("openai"), "Open AI"); // Detects "ai" suffix
-            assert.strictEqual(formatProviderName("openrouter"), "Openrouter"); // "router" not an acronym
-            assert.strictEqual(formatProviderName("xai"), "xAI"); // Single letter + "ai"
-        });
+        test("formats model objects correctly", () => {
+            const mockModel = { name: "gpt-4o", vendor: "openai" } as unknown as ExtendedModelInformation;
+            assert.strictEqual(formatModelDisplayLabel(mockModel), "[openai] gpt-4o");
 
-        test("formatProviderName handles hyphenated and underscored names", () => {
-            assert.strictEqual(formatProviderName("custom-provider"), "Custom Provider");
-            assert.strictEqual(formatProviderName("my_provider"), "My Provider");
-        });
-
-        test("formatProviderName title-cases unknown single-word providers", () => {
-            assert.strictEqual(formatProviderName("customprovider"), "Customprovider");
-            assert.strictEqual(formatProviderName("myprovider"), "Myprovider");
-        });
-
-        test("formatModelName applies intelligent formatting rules", () => {
-            assert.strictEqual(formatModelName("gpt-4o"), "GPT 4o");
-            assert.strictEqual(formatModelName("gpt-4o-mini"), "GPT 4o Mini");
-            assert.strictEqual(formatModelName("claude-3-5-sonnet-20241022"), "Claude 3 5 Sonnet 20241022");
-            assert.strictEqual(formatModelName("gemini-2-5-pro"), "Gemini 2 5 Pro");
-            assert.strictEqual(formatModelName("o3-mini"), "O3 Mini");
-        });
-
-        test("formatModelName handles general cases with title casing", () => {
-            assert.strictEqual(formatModelName("my-custom-model"), "My Custom Model");
-            assert.strictEqual(formatModelName("llama-3-70b"), "Llama 3 70b");
+            const mockModelNoVendor = { name: "gpt-4o" } as unknown as ExtendedModelInformation;
+            assert.strictEqual(formatModelDisplayLabel(mockModelNoVendor), "gpt-4o");
         });
     });
 });


### PR DESCRIPTION
refactor: standardize model display labels and metadata ✨

**✨ Features**
- Add ExtendedModelInformation type and formatModelDisplayLabel helper to centralize model UI labeling and vendor display.
- Update LiteLLMProviderBase to expose rawModelName, vendor, backendName, tooltip and detail so consumers render consistent model info.
- Normalize provider handling and token fields by using providerLower for family derivation and derived.maxInputTokens for maxInputTokens.

**🐛 Fixes**
- Update post-session validation message to recommend running "npm run format" and "npm run lint" (remove :check variants) so commands match current scripts.

**🧹 Chores**
- Bump package.json version to 1.6.1-dev5.

**🧪 Tests**
- Adjust unit tests to validate new display label formatting and backendName/description values.