### PR TITLE
🧭 Modernize provider-group config and refresh telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.1] - 2026-05-14
+
+### 🧭 Improvements
+
+* **Modern Provider-Group Config**: The extension now detects VS Code per-group provider configuration during model discovery and treats it as the preferred configuration path.
+* **Legacy Prompt Suppression**: Once modern provider configuration is validated, the extension suppresses legacy configuration prompts for the rest of the session.
+* **Model Picker Grouping**: Discovered models now carry backend category metadata so multi-backend groups stay visually separated in the picker.
+
+### 📊 Telemetry & Validation
+
+* **Configuration-Flow Telemetry Refresh**: Added telemetry hooks around modern configuration detection so activation and discovery flows can be tracked more accurately.
+* **Regression Coverage**: Added and updated tests for provider discovery, telemetry behavior, and extension activation/integration paths.
+
 ## [2.0.0] - 2026-05-13
 
 ### 💥 Breaking / Behavior Changes

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"type": "git",
 		"url": "https://github.com/gethnet/litellm-connector-copilot"
 	},
-	"version": "2.0.0",
+	"version": "2.0.1-dev1",
 	"preview": true,
 	"engines": {
 		"vscode": "^1.120.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"type": "git",
 		"url": "https://github.com/gethnet/litellm-connector-copilot"
 	},
-	"version": "2.0.1-dev1",
+	"version": "2.0.1",
 	"preview": true,
 	"engines": {
 		"vscode": "^1.120.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,8 @@ import { EffortFallbackCache } from "./utils/reasoningEffortFallback";
 let configManagerInstance: ConfigManager | undefined;
 let telemetryServiceInstance: TelemetryService | undefined;
 
+const MODERN_CONFIG_SESSION_KEY = "litellm-connector.isOnModernConfig";
+
 export function activate(context: vscode.ExtensionContext): void {
     // Initialize telemetry first so logger can use it
     telemetryServiceInstance = new TelemetryService();
@@ -110,6 +112,19 @@ export function activate(context: vscode.ExtensionContext): void {
     const configManager = configManagerInstance;
     configManager.setTelemetryService(telemetryService);
 
+    const getModernConfigSessionFlag = (): boolean => {
+        return context.workspaceState?.get<boolean>(MODERN_CONFIG_SESSION_KEY, false) === true;
+    };
+
+    const persistModernConfigSessionFlag = async (): Promise<boolean> => {
+        if (!context.workspaceState) {
+            Logger.warn("workspaceState unavailable; cannot persist modern configuration session flag");
+            return false;
+        }
+        await context.workspaceState.update(MODERN_CONFIG_SESSION_KEY, true);
+        return true;
+    };
+
     const effortFallbackCache = new EffortFallbackCache();
 
     // Track feature adoption
@@ -134,6 +149,39 @@ export function activate(context: vscode.ExtensionContext): void {
 
     const activeProvider = new LiteLLMChatProvider(context.secrets, ua, effortFallbackCache);
     activeProvider.setTelemetryService(telemetryService);
+
+    const isOnModernConfigAtStartup = getModernConfigSessionFlag();
+    telemetryService.captureModernConfigStatus({
+        is_on_modern_config: isOnModernConfigAtStartup,
+        source: "startup",
+    });
+
+    activeProvider.setModernConfigurationDetectedHandler(() => {
+        const alreadyMarked = getModernConfigSessionFlag();
+        if (alreadyMarked) {
+            telemetryService.captureModernConfigStatus({
+                is_on_modern_config: true,
+                source: "provider_configuration_detected",
+            });
+            return;
+        }
+
+        void (async () => {
+            try {
+                const persisted = await persistModernConfigSessionFlag();
+                if (!persisted) {
+                    return;
+                }
+                Logger.info("Marked session as modern-configured from provider configuration detection");
+                telemetryService.captureModernConfigStatus({
+                    is_on_modern_config: true,
+                    source: "provider_configuration_detected",
+                });
+            } catch (err: unknown) {
+                Logger.error("Failed to persist modern configuration session flag", err);
+            }
+        })();
+    });
 
     // Commit message provider (version-agnostic)
     const commitProvider = new LiteLLMCommitMessageProvider(context.secrets, ua, effortFallbackCache);
@@ -246,7 +294,8 @@ export function activate(context: vscode.ExtensionContext): void {
     configManager
         .isConfigured()
         .then((configured) => {
-            if (!configured) {
+            const isOnModernConfig = getModernConfigSessionFlag();
+            if (!configured && !isOnModernConfig) {
                 Logger.info("Extension not configured. Prompting user...");
                 vscode.window
                     .showInformationMessage(

--- a/src/providers/liteLLMProviderBase.ts
+++ b/src/providers/liteLLMProviderBase.ts
@@ -112,6 +112,8 @@ export abstract class LiteLLMProviderBase {
 
     protected _telemetryService?: TelemetryService;
 
+    private _onModernConfigurationDetected?: () => void;
+
     constructor(
         protected readonly secrets: vscode.SecretStorage,
         protected readonly userAgent: string,
@@ -123,6 +125,15 @@ export abstract class LiteLLMProviderBase {
 
     public setTelemetryService(service: TelemetryService): void {
         this._telemetryService = service;
+    }
+
+    /**
+     * Registers a callback fired when VS Code per-group provider configuration is
+     * present and passes syntactic validation. Extension activation uses this to
+     * persist a one-time "modern config seen" session flag and suppress legacy prompts.
+     */
+    public setModernConfigurationDetectedHandler(handler: () => void): void {
+        this._onModernConfigurationDetected = handler;
     }
 
     /** Exposes the ConfigManager for external access (e.g., commands that need configuration). */
@@ -265,6 +276,7 @@ export abstract class LiteLLMProviderBase {
                     // when VS Code omits or provides incomplete per-group configuration.
                 }
                 if (session) {
+                    this._onModernConfigurationDetected?.();
                     return this._discoverModelsFromSession(session, token);
                 }
             }

--- a/src/providers/test/liteLLMProviderBase.test.ts
+++ b/src/providers/test/liteLLMProviderBase.test.ts
@@ -28,7 +28,7 @@ interface BaseTestAccess {
     _parameterProbeCache: Map<string, Set<string>>;
     _effortFallbackCache: EffortFallbackCache;
     _doDiscoverModels: (
-        options: { silent?: boolean; configuration?: Record<string, unknown> },
+        options: { silent?: boolean; configuration?: Record<string, unknown>; groupName?: string },
         token: vscode.CancellationToken
     ) => Promise<vscode.LanguageModelChatInformation[]>;
     buildOpenAIChatRequest: (
@@ -1901,6 +1901,53 @@ suite("LiteLLM Provider Unit Tests", () => {
 
         assert.strictEqual(models.length, 1);
         assert.strictEqual(models[0].id, "cloud/gpt-4o-mini");
+    });
+
+    test("_doDiscoverModels marks modern configuration detection when provider configuration is valid", async () => {
+        const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
+        const configManager = access(provider)._configManager;
+        const modernDetected = sandbox.spy();
+
+        provider.setModernConfigurationDetectedHandler(modernDetected);
+
+        const session: BackendSession = {
+            backendName: "modern-group",
+            baseUrl: "http://localhost:4000",
+            apiKey: "k",
+            client: {
+                getModelInfo: async () => ({
+                    data: [
+                        {
+                            model_name: "gpt-4o",
+                            model_info: {
+                                litellm_provider: "openai",
+                                mode: "chat",
+                                supports_native_streaming: true,
+                                max_input_tokens: 8192,
+                                max_output_tokens: 4096,
+                            } as LiteLLMModelInfo,
+                        },
+                    ],
+                }),
+            } as unknown as LiteLLMClient,
+        };
+
+        sandbox.stub(configManager, "convertProviderConfiguration").returns(session);
+
+        const models = await access(provider)._doDiscoverModels(
+            {
+                silent: true,
+                groupName: "modern-group",
+                configuration: {
+                    baseUrl: "http://localhost:4000",
+                    apiKey: "k",
+                },
+            },
+            new vscode.CancellationTokenSource().token
+        );
+
+        assert.strictEqual(models.length, 1);
+        assert.strictEqual(modernDetected.calledOnce, true);
     });
 
     test("_doDiscoverModels handles error gracefully", async () => {

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -259,6 +259,10 @@ export class TelemetryService implements vscode.Disposable {
         });
     }
 
+    captureModernConfigStatus(props: { is_on_modern_config: boolean; source: string }): void {
+        this.capture("modern_config_status", props);
+    }
+
     captureFeatureUsed(featureName: string, _caller: string): void {
         this._captureAggregatedFeatureUsage(featureName);
     }

--- a/src/telemetry/test/telemetryService.test.ts
+++ b/src/telemetry/test/telemetryService.test.ts
@@ -305,6 +305,24 @@ suite("TelemetryService", () => {
         assert.strictEqual(event.properties.source, "config_change");
     });
 
+    test("captureModernConfigStatus sends correct event", () => {
+        const mockContext = {
+            extension: { packageJSON: { version: "1.0.0" } },
+        } as unknown as vscode.ExtensionContext;
+        telemetryService.initialize(mockContext);
+
+        telemetryService.captureModernConfigStatus({
+            is_on_modern_config: true,
+            source: "startup",
+        });
+
+        assert.strictEqual(adapterMock.capture.calledOnce, true);
+        const event = adapterMock.capture.firstCall.args[0];
+        assert.strictEqual(event.event, "modern_config_status");
+        assert.strictEqual(event.properties.is_on_modern_config, true);
+        assert.strictEqual(event.properties.source, "startup");
+    });
+
     test("captureFeatureUsed aggregates events", () => {
         const mockContext = {
             extension: { packageJSON: { version: "1.0.0" } },

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -11,6 +11,22 @@ import { createMockSecrets, createMockOutputChannel } from "../utils/testMocks";
 suite("Extension Activation Unit Tests", () => {
     let sandbox: sinon.SinonSandbox;
 
+    const createMockMemento = (seed?: Record<string, unknown>): vscode.Memento => {
+        const store = new Map<string, unknown>(Object.entries(seed ?? {}));
+        return {
+            get: <T>(key: string, defaultValue?: T): T | undefined => {
+                if (store.has(key)) {
+                    return store.get(key) as T;
+                }
+                return defaultValue;
+            },
+            update: async (key: string, value: unknown) => {
+                store.set(key, value);
+            },
+            keys: () => [...store.keys()],
+        } as vscode.Memento;
+    };
+
     setup(() => {
         sandbox = sinon.createSandbox();
     });
@@ -192,6 +208,67 @@ suite("Extension Activation Unit Tests", () => {
 
         assert.strictEqual(isConfiguredStub.called, true);
         assert.strictEqual(executeCommandStub.calledWith("litellm-connector.manage"), false);
+    });
+
+    test("activate skips classic configuration prompt when modern config session flag is set", async () => {
+        const mockSecrets = createMockSecrets();
+
+        const context = {
+            subscriptions: [],
+            secrets: mockSecrets,
+            workspaceState: createMockMemento({ "litellm-connector.isOnModernConfig": true }),
+        } as unknown as vscode.ExtensionContext;
+
+        sandbox.stub(vscode.window, "createOutputChannel").returns(createMockOutputChannel());
+        sandbox.stub(vscode.extensions, "getExtension").returns({ packageJSON: { version: "1.2.3" } } as never);
+        sandbox.stub(InlineCompletionsRegistrar.prototype, "initialize");
+        sandbox.stub(ConfigManager.prototype, "isConfigured").resolves(false);
+
+        const executeCommandStub = sandbox.stub(vscode.commands, "executeCommand").resolves(undefined);
+        const infoStub = sandbox.stub(vscode.window, "showInformationMessage");
+
+        sandbox.stub(vscode.lm, "registerLanguageModelChatProvider").returns({ dispose() {} } as vscode.Disposable);
+        sandbox.stub(vscode.commands, "registerCommand").returns({ dispose() {} } as vscode.Disposable);
+
+        extension.activate(context);
+
+        await new Promise((r) => setTimeout(r, 0));
+
+        assert.strictEqual(infoStub.called, false);
+        assert.strictEqual(executeCommandStub.calledWith("litellm-connector.manage"), false);
+    });
+
+    test("activate persists modern config session flag when provider detects valid config", async () => {
+        const mockSecrets = createMockSecrets();
+        const workspaceState = createMockMemento();
+        const updateSpy = sandbox.spy(workspaceState, "update");
+
+        const context = {
+            subscriptions: [],
+            secrets: mockSecrets,
+            workspaceState,
+        } as unknown as vscode.ExtensionContext;
+
+        let onModernConfigDetected: (() => void) | undefined;
+        sandbox
+            .stub(providers.LiteLLMChatProvider.prototype, "setModernConfigurationDetectedHandler")
+            .callsFake((handler: () => void) => {
+                onModernConfigDetected = handler;
+            });
+
+        sandbox.stub(vscode.window, "createOutputChannel").returns(createMockOutputChannel());
+        sandbox.stub(vscode.extensions, "getExtension").returns({ packageJSON: { version: "1.2.3" } } as never);
+        sandbox.stub(InlineCompletionsRegistrar.prototype, "initialize");
+        sandbox.stub(ConfigManager.prototype, "isConfigured").resolves(false);
+        sandbox.stub(vscode.window, "showInformationMessage");
+        sandbox.stub(vscode.lm, "registerLanguageModelChatProvider").returns({ dispose() {} } as vscode.Disposable);
+        sandbox.stub(vscode.commands, "registerCommand").returns({ dispose() {} } as vscode.Disposable);
+
+        extension.activate(context);
+
+        onModernConfigDetected?.();
+
+        assert.strictEqual(updateSpy.calledWith("litellm-connector.isOnModernConfig", true), true);
     });
 
     test("deactivate tolerates repeated disposal", async () => {


### PR DESCRIPTION
Optional body:
- detect modern per-group configuration
- suppress legacy prompts after validation
- update model grouping metadata and tests
- bump dev version for release readiness