### PR TITLE
🐛 fix: make forceResponsesEndpoint opt-in by default (v2.1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.5] - 2026-06-17
+
+### 🐛 Fixes
+
+* **🔧 forceResponsesEndpoint default corrected to opt-in (bug [#102](https://github.com/gethnet/litellm-connector-copilot/issues/102))**: The hidden configuration flag `litellm-connector.forceResponsesEndpoint` now defaults to `false`, requiring explicit user opt-in. Previously, this flag was introduced in v2.1.0 with an unintended `true` default, causing all models to route through the `/responses` endpoint when `enableResponsesApi` was enabled — even without the user explicitly setting the flag. Hidden config flags should follow the principle of least surprise; they must not change default routing behavior unless explicitly enabled. (`src/config/configManager.ts`)
+
+### 📚 Documentation
+
+* **🧾 Updated JSDoc for forceResponsesEndpoint**: Clarified that the flag is opt-in, JSON-only, and not exposed in the Settings UI. (`src/types.ts`)
+
 ## [2.1.4] - 2026-06-17
 
 ### 🐛 Fixes

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"type": "git",
 		"url": "https://github.com/gethnet/litellm-connector-copilot"
 	},
-	"version": "2.1.4",
+	"version": "2.1.5",
 	"preview": true,
 	"engines": {
 		"vscode": "^1.120.0"

--- a/src/config/configManager.ts
+++ b/src/config/configManager.ts
@@ -168,7 +168,7 @@ export class ConfigManager {
             .get<string>(ConfigManager.SCM_COMMIT_MSG_MODEL_ID_KEY, "")
             .trim();
         const v2ApiEnabled = workspaceConfig.get<boolean>(ConfigManager.ENABLE_RESPONSES_API, false);
-        const forceResponsesEndpoint = workspaceConfig.get<boolean>(ConfigManager.FORCE_RESPONSES_ENDPOINT_KEY, true);
+        const forceResponsesEndpoint = workspaceConfig.get<boolean>(ConfigManager.FORCE_RESPONSES_ENDPOINT_KEY, false);
         const allowChatCompletionsFallback = workspaceConfig.get<boolean>(
             ConfigManager.ALLOW_CHAT_COMPLETIONS_FALLBACK_KEY,
             false

--- a/src/config/test/config.test.ts
+++ b/src/config/test/config.test.ts
@@ -237,10 +237,10 @@ suite("ConfigManager Unit Tests", () => {
         assert.strictEqual(config.forceResponsesEndpoint, false);
     });
 
-    test("should default forceResponsesEndpoint to true when not set", async () => {
+    test("should default forceResponsesEndpoint to false when not set", async () => {
         settingsMap.delete("litellm-connector.forceResponsesEndpoint");
         const config = await configManager.getConfig();
-        assert.strictEqual(config.forceResponsesEndpoint, true);
+        assert.strictEqual(config.forceResponsesEndpoint, false);
     });
 
     test("should read allowChatCompletionsFallback from workspace settings", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,7 +186,7 @@ export interface LiteLLMConfig {
     /**
      * When true, forces all models to use the `/responses` endpoint instead of per-model mode selection.
      * This ensures consistent behavior across models, especially for those that require reasoning support.
-     * Default: true (JSON-only, not in Settings UI).
+     * Default: false (opt-in, JSON-only, not in Settings UI).
      */
     forceResponsesEndpoint?: boolean;
 


### PR DESCRIPTION
## Summary

Fixes a bug where the hidden configuration flag `forceResponsesEndpoint` was introduced in v2.1.0 with an unintended default value of `true`, causing all models to route through the `/responses` endpoint when `enableResponsesApi` was enabled — even without the user explicitly setting the flag.

Hidden config flags should follow the principle of least surprise: they must not change default routing behavior unless explicitly enabled by the user.

## Changes

### 🐛 Bug Fix
- **`src/config/configManager.ts`**: Changed `forceResponsesEndpoint` default from `true` to `false` (opt-in)
- **`src/config/test/config.test.ts`**: Updated test expectations to verify the new default behavior

### 📚 Documentation  
- **`src/types.ts`**: Updated JSDoc to clarify the flag is opt-in, JSON-only, and not exposed in Settings UI
- **`CHANGELOG.md`**: Added v2.1.5 release notes documenting the fix

## Testing

- ✅ All 768 tests passing
- ✅ Code coverage: 89.91% (no regressions)
- ✅ `npm run lint` clean
- ✅ `npm run format` applied

## Related

- Fixes #102