### PR TITLE
🛡️ Harden quota tool redaction against Copilot scaffolding (issue #106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 🐛 Fixes
+
+* **Stop redacting `insert_edit_into_file` on the first turn of every session**: Quota detection now only redacts on high-confidence matches: a real `LanguageModelToolResultPart` whose `callId` resolves to a redactable tool name. The previous regex-pair detector matched Copilot's own `<reminderInstructions>` scaffolding (which describes quota handling) and stripped file-edit tools on every turn. Low-confidence matches are logged at DEBUG and no longer emit a fake `quota_exceeded:<tool>` failure event into telemetry. (`src/providers/liteLLMProviderBase.ts`)
+
 ## [2.1.6] - 2026-06-21
 
 ### 🐛 Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.1.7] - 2026-06-24
+
 ### 🐛 Fixes
 
-* **Stop redacting `insert_edit_into_file` on the first turn of every session**: Quota detection now only redacts on high-confidence matches: a real `LanguageModelToolResultPart` whose `callId` resolves to a redactable tool name. The previous regex-pair detector matched Copilot's own `<reminderInstructions>` scaffolding (which describes quota handling) and stripped file-edit tools on every turn. Low-confidence matches are logged at DEBUG and no longer emit a fake `quota_exceeded:<tool>` failure event into telemetry. (`src/providers/liteLLMProviderBase.ts`)
+* **🛡️ Stop redacting `insert_edit_into_file` on the first turn of every session (bug [#106](https://github.com/gethnet/litellm-connector-copilot/issues/106))**: Quota detection now only redacts on **high-confidence** matches — a real `LanguageModelToolResultPart` whose `callId` resolves to a redactable tool name. The previous regex-pair detector matched Copilot's own `<reminderInstructions>` scaffolding (which describes quota handling as guidance to the model) and stripped file-edit tools on every turn, even when no actual quota error had occurred. A low-confidence branch still logs a DEBUG trace and **does not** mutate the request or emit a fake `quota_exceeded:<tool>` failure event into telemetry, eliminating the noisy PostHog signal. (`src/providers/liteLLMProviderBase.ts`, `src/providers/base/requestBuilder.ts`, `src/providers/base/types.ts`)
+
+### 🧪 Tests
+
+* **High-confidence redaction coverage**: Updated the redaction tests to cover high-confidence `LanguageModelToolResultPart` matches, wrapper-only false positives (`<reminderInstructions>`-style echoed text), and non-redactable tool results. The detector is now verified to leave the tool list alone when only prompt scaffolding references the tool name. (`src/providers/test/liteLLMProviderBase.test.ts`)
+* **Request builder fixtures**: Adjusted request builder test fixtures for the new confidence field on the redaction result so the pipeline stays deterministic. (`src/providers/test/liteLLMProviderBase.requestBuilder.test.ts`)
+
+### 🧹 Chores
+
+* **📦 Version bump to `2.1.7`**: Promoted the package from `2.1.6` to `2.1.7` to ship the redaction fix. (`package.json`)
 
 ## [2.1.6] - 2026-06-21
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"type": "git",
 		"url": "https://github.com/gethnet/litellm-connector-copilot"
 	},
-	"version": "2.1.7-dev1",
+	"version": "2.1.7",
 	"preview": true,
 	"engines": {
 		"vscode": "^1.120.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"type": "git",
 		"url": "https://github.com/gethnet/litellm-connector-copilot"
 	},
-	"version": "2.1.6",
+	"version": "2.1.7-dev1",
 	"preview": true,
 	"engines": {
 		"vscode": "^1.120.0"

--- a/src/providers/base/requestBuilder.ts
+++ b/src/providers/base/requestBuilder.ts
@@ -55,6 +55,9 @@ export class RequestBuilder {
             config.disableQuotaToolRedaction === true,
             _caller
         );
+        // `confidence` is intentionally not threaded into the request body
+        // today. It is consumed by the base for logging/telemetry already;
+        // this call site only needs the (possibly redacted) tool list.
         const toolConfig = convertTools({ ...options, tools: toolRedaction.tools });
         const messagesToUse = trimMessagesToFitBudget(messages, toolConfig.tools, model, modelInfo);
         const openaiMessages = convertMessages(messagesToUse);

--- a/src/providers/base/types.ts
+++ b/src/providers/base/types.ts
@@ -17,7 +17,10 @@ export interface RequestBuilderDeps {
         modelId: string,
         disableRedaction: boolean,
         caller?: string
-    ) => { tools: readonly vscode.LanguageModelChatTool[] };
+    ) => {
+        tools: readonly vscode.LanguageModelChatTool[];
+        confidence: "none" | "low" | "high";
+    };
     stripUnsupportedParametersFromRequest: (
         requestBody: Record<string, unknown>,
         modelInfo: LiteLLMModelInfo | undefined,

--- a/src/providers/liteLLMProviderBase.ts
+++ b/src/providers/liteLLMProviderBase.ts
@@ -969,21 +969,46 @@ export abstract class LiteLLMProviderBase {
         modelId: string,
         disableRedaction: boolean,
         caller?: string
-    ): { tools: readonly vscode.LanguageModelChatTool[] } {
+    ): {
+        tools: readonly vscode.LanguageModelChatTool[];
+        confidence: "none" | "low" | "high";
+    } {
         if (disableRedaction || !tools.length || !messages.length) {
-            return { tools };
+            return { tools, confidence: "none" };
         }
 
         const quotaMatch = this.findQuotaErrorInMessages(messages);
         if (!quotaMatch) {
-            return { tools };
+            return { tools, confidence: "none" };
         }
 
-        const { toolName, errorText, turnIndex } = quotaMatch;
+        const { toolName, errorText, turnIndex, confidence } = quotaMatch;
+
+        // Low-confidence matches (e.g. a quota phrase mentioned in
+        // <reminderInstructions> or a user prompt about quotas) are logged
+        // at DEBUG and do NOT trigger redaction or telemetry. High-confidence
+        // matches (a real provider 429 in a tool result) keep the existing
+        // WARN + telemetry behavior.
+        if (confidence !== "high") {
+            // For low-confidence matches, only report as "low" if there's a
+            // redactable tool in the tools list. Otherwise, treat as "none"
+            // since there's nothing actionable.
+            const hasRedactableTool = tools.some((t) => LiteLLMProviderBase.REDACTABLE_TOOL_NAMES.includes(t.name));
+            const reportedConfidence = hasRedactableTool ? confidence : "none";
+            Logger.debug("Quota phrase detected in non-tool-result text; not redacting", {
+                toolName,
+                modelId,
+                requestId,
+                turnIndex,
+                confidence: reportedConfidence,
+            });
+            return { tools, confidence: reportedConfidence };
+        }
+
         const toolNames = new Set(tools.map((tool) => tool.name));
         if (!toolNames.has(toolName)) {
             Logger.debug("Quota error detected, but tool not present", { toolName, requestId, modelId, turnIndex });
-            return { tools };
+            return { tools, confidence };
         }
 
         const filteredTools = tools.filter((tool) => tool.name !== toolName);
@@ -1002,38 +1027,171 @@ export abstract class LiteLLMProviderBase {
             ...(caller && { caller }),
         });
 
-        return { tools: filteredTools };
+        return { tools: filteredTools, confidence };
     }
 
-    private findQuotaErrorInMessages(
-        messages: readonly LanguageModelChatRequestMessage[]
-    ): { toolName: string; errorText: string; turnIndex: number } | undefined {
-        const quotaRegex =
-            /(\b429\b|rate\s*limit\s*exceeded|rate\s*limited|too\s*many\s*requests|insufficient\s*quota|quota\s*exceeded|exceeded\s*your\s*current\s*quota)/i;
-        const toolRegex = /(insert_edit_into_file|replace_string_in_file)/i;
+    /**
+     * Tools the detector knows how to redact. Kept narrow on purpose — the
+     * legacy detector only knew `insert_edit_into_file` and
+     * `replace_string_in_file`. Adding more here is a deliberate code change
+     * and must come with a test that exercises a real tool result for the new
+     * tool name (not just a substring match in prompt scaffolding).
+     */
+    private static readonly REDACTABLE_TOOL_NAMES: readonly string[] = [
+        "insert_edit_into_file",
+        "replace_string_in_file",
+    ] as const;
 
+    private static readonly QUOTA_PHRASE_REGEX =
+        /(\b429\b|rate\s*limit\s*exceeded|rate\s*limited|too\s*many\s*requests|insufficient\s*quota|quota\s*exceeded|exceeded\s*your\s*current\s*quota)/i;
+
+    /**
+     * Detects whether the conversation history contains a real provider-side
+     * quota error attached to a tool call we know how to redact.
+     *
+     * High-confidence match: a `LanguageModelToolResultPart` whose text
+     * contains a quota phrase AND whose `callId` resolves to one of the
+     * `REDACTABLE_TOOL_NAMES` tools (verified by walking the messages in
+     * reverse to find the matching `LanguageModelToolCallPart`).
+     *
+     * Low-confidence match: a quota phrase appearing in any other text
+     * content. This is returned for observability (DEBUG log, telemetry
+     * counter) but does NOT trigger redaction.
+     *
+     * None: no quota phrase anywhere in the message text.
+     */
+    private findQuotaErrorInMessages(messages: readonly LanguageModelChatRequestMessage[]):
+        | {
+              toolName: string;
+              errorText: string;
+              turnIndex: number;
+              confidence: "none" | "low" | "high";
+          }
+        | undefined {
+        // 1. Walk messages in reverse to find a tool result that contains a
+        //    quota phrase. The result's `callId` anchors the match.
+        for (let i = messages.length - 1; i >= 0; i--) {
+            const message = messages[i];
+            const toolResultHit = this.findQuotaInToolResults(message);
+            if (toolResultHit) {
+                const owningToolName = this.lookupToolNameForCallId(messages, toolResultHit.callId);
+                if (owningToolName && LiteLLMProviderBase.REDACTABLE_TOOL_NAMES.includes(owningToolName)) {
+                    return {
+                        toolName: owningToolName,
+                        errorText: this.sanitizeErrorTextForLogs(toolResultHit.text),
+                        turnIndex: i,
+                        confidence: "high",
+                    };
+                }
+                // Tool result is for a tool we don't redact. Treat as
+                // low-confidence (observability only) and keep walking.
+                return {
+                    toolName: owningToolName ?? toolResultHit.callId,
+                    errorText: this.sanitizeErrorTextForLogs(toolResultHit.text),
+                    turnIndex: i,
+                    confidence: "low",
+                };
+            }
+        }
+
+        // 2. No qualifying tool result. Look for a quota phrase in any
+        //    OTHER text content. Strip Copilot wrappers first so we never
+        //    match the scaffolding. Only report as "low" if we find BOTH
+        //    a quota phrase AND a tool name in the text (mimicking original
+        //    behavior). If only quota is found without a tool name, treat
+        //    as "none" since there's nothing to redact.
+        const toolRegex = /(insert_edit_into_file|replace_string_in_file)/i;
         for (let i = messages.length - 1; i >= 0; i--) {
             const message = messages[i];
             const text = this.collectMessageText(message);
             if (!text) {
                 continue;
             }
-            if (!quotaRegex.test(text)) {
+            const stripped = this.stripCopilotWrappers(text);
+            if (!stripped) {
                 continue;
             }
-            const toolMatch = text.match(toolRegex);
+            if (!LiteLLMProviderBase.QUOTA_PHRASE_REGEX.test(stripped)) {
+                continue;
+            }
+            // Check if there's also a tool name in the text
+            const toolMatch = stripped.match(toolRegex);
             if (!toolMatch) {
+                // Quota phrase found but no tool name - not actionable
                 continue;
             }
-
             return {
-                toolName: toolMatch[1],
+                toolName: "",
                 errorText: this.sanitizeErrorTextForLogs(text),
                 turnIndex: i,
+                confidence: "low",
             };
         }
 
         return undefined;
+    }
+
+    /**
+     * Returns the first quota phrase match that lives inside a
+     * `LanguageModelToolResultPart` on this message, plus the `callId` of
+     * that tool result. Returns `undefined` if no tool result part contains
+     * a quota phrase.
+     */
+    private findQuotaInToolResults(
+        message: LanguageModelChatRequestMessage
+    ): { callId: string; text: string } | undefined {
+        const parts = message.content ?? [];
+        for (const part of parts) {
+            if (!(part instanceof vscode.LanguageModelToolResultPart)) {
+                continue;
+            }
+            const text = this.collectPartText(part.content);
+            if (!text) {
+                continue;
+            }
+            if (!LiteLLMProviderBase.QUOTA_PHRASE_REGEX.test(text)) {
+                continue;
+            }
+            return { callId: part.callId, text };
+        }
+        return undefined;
+    }
+
+    /**
+     * Walks messages in reverse to find the assistant turn that produced
+     * `callId` via a `LanguageModelToolCallPart` and returns the tool name
+     * declared there. Returns `undefined` if no matching tool call is found.
+     */
+    private lookupToolNameForCallId(
+        messages: readonly LanguageModelChatRequestMessage[],
+        callId: string
+    ): string | undefined {
+        for (let i = messages.length - 1; i >= 0; i--) {
+            const parts = messages[i].content ?? [];
+            for (const part of parts) {
+                if (part instanceof vscode.LanguageModelToolCallPart && part.callId === callId) {
+                    return part.name;
+                }
+            }
+        }
+        return undefined;
+    }
+
+    /**
+     * Text-only projection of a tool result's content array. Mirrors
+     * `collectMessageText` but operates on a single part's `content` field
+     * (which is itself an array of `LanguageModelTextPart`-shaped objects).
+     */
+    private collectPartText(content: ReadonlyArray<unknown>): string {
+        let text = "";
+        for (const part of content) {
+            if (part instanceof vscode.LanguageModelTextPart) {
+                text += part.value;
+            } else if (typeof part === "string") {
+                text += part;
+            }
+        }
+        return text.trim();
     }
 
     private sanitizeErrorTextForLogs(text: string): string {
@@ -1130,6 +1288,35 @@ export abstract class LiteLLMProviderBase {
             }
         }
         return text.trim();
+    }
+
+    /**
+     * Strips Copilot-injected prompt scaffolding wrappers from `text` and
+     * returns the cleaned, trimmed result. This is the SAME list of wrappers
+     * the log sanitizer collapses, but applied *before* the quota regex runs
+     * so the detector never matches on prompt scaffolding.
+     *
+     * Why this lives here: Copilot Chat injects `<context>`, `<editorContext>`,
+     * `<reminderInstructions>`, and `<userRequest>` blocks into every user
+     * message. The `<reminderInstructions>` block routinely documents the
+     * exact tool-error handling rules that contain both the quota phrase
+     * and the `insert_edit_into_file` / `replace_string_in_file` tool names
+     * — a structural false positive for the legacy regex-pair detector.
+     *
+     * Invariant: this function is pure (no I/O, no side effects). The
+     * original `text` is not mutated.
+     */
+    private stripCopilotWrappers(text: string): string {
+        const trimmed = (text || "").trim();
+        if (!trimmed) {
+            return "";
+        }
+        return trimmed
+            .replace(/<context>[\s\S]*?<\/context>/gi, "")
+            .replace(/<editorContext>[\s\S]*?<\/editorContext>/gi, "")
+            .replace(/<reminderInstructions>[\s\S]*?<\/reminderInstructions>/gi, "")
+            .replace(/<userRequest>[\s\S]*?<\/userRequest>/gi, "")
+            .trim();
     }
 
     protected buildCapabilities(modelInfo: LiteLLMModelInfo | undefined): vscode.LanguageModelChatCapabilities {

--- a/src/providers/test/liteLLMProviderBase.requestBuilder.test.ts
+++ b/src/providers/test/liteLLMProviderBase.requestBuilder.test.ts
@@ -15,7 +15,7 @@ suite("RequestBuilder", () => {
         builder = new RequestBuilder({
             configManager,
             getReasoningEffort: () => undefined,
-            detectQuotaToolRedaction: (messages, tools) => ({ tools }),
+            detectQuotaToolRedaction: (messages, tools) => ({ tools, confidence: "none" as const }),
             stripUnsupportedParametersFromRequest: () => {},
             isParameterSupported: () => true,
             getTelemetryOptions: () => ({ caller: "test", justification: undefined, modelConfiguration: {} }),

--- a/src/providers/test/liteLLMProviderBase.test.ts
+++ b/src/providers/test/liteLLMProviderBase.test.ts
@@ -89,7 +89,10 @@ interface BaseTestAccess {
         requestId: string,
         modelId: string,
         disableRedaction: boolean
-    ) => { tools: readonly vscode.LanguageModelChatTool[] };
+    ) => {
+        tools: readonly vscode.LanguageModelChatTool[];
+        confidence: "none" | "low" | "high";
+    };
     isParameterSupported: (param: string, modelInfo: LiteLLMModelInfo | undefined, modelId?: string) => boolean;
     sanitizeErrorTextForLogs: (text: string) => string;
     collectMessageText: (m: vscode.LanguageModelChatRequestMessage) => string;
@@ -1282,14 +1285,27 @@ suite("LiteLLMProviderBase", () => {
 
         test("removes failing tool when enabled", () => {
             const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
-            const result = access(provider).detectQuotaToolRedaction(
-                [makeText("Error: 429 rate limit exceeded when calling insert_edit_into_file")],
-                tools,
-                "rid",
-                "m",
-                false
-            );
+            const messages: vscode.LanguageModelChatRequestMessage[] = [
+                {
+                    role: vscode.LanguageModelChatMessageRole.Assistant,
+                    name: undefined,
+                    content: [new vscode.LanguageModelToolCallPart("call_legacy_1", "insert_edit_into_file", {})],
+                } as unknown as vscode.LanguageModelChatRequestMessage,
+                {
+                    role: vscode.LanguageModelChatMessageRole.User,
+                    name: undefined,
+                    content: [
+                        new vscode.LanguageModelToolResultPart("call_legacy_1", [
+                            new vscode.LanguageModelTextPart(
+                                "Error: 429 rate limit exceeded when calling insert_edit_into_file"
+                            ),
+                        ]),
+                    ],
+                } as unknown as vscode.LanguageModelChatRequestMessage,
+            ];
+            const result = access(provider).detectQuotaToolRedaction(messages, tools, "rid", "m", false);
             assert.strictEqual(result.tools.length, 0);
+            assert.strictEqual(result.confidence, "high");
         });
 
         test("does not remove tool when disabled", () => {
@@ -1302,6 +1318,7 @@ suite("LiteLLMProviderBase", () => {
                 true
             );
             assert.strictEqual(result.tools.length, 1);
+            assert.strictEqual(result.confidence, "none");
         });
 
         test("does not redact when quota tool is not present", () => {
@@ -1314,6 +1331,7 @@ suite("LiteLLMProviderBase", () => {
                 false
             );
             assert.strictEqual(result.tools.length, 1);
+            assert.strictEqual(result.confidence, "none");
         });
 
         test("does not redact when message has no text", () => {
@@ -1332,6 +1350,7 @@ suite("LiteLLMProviderBase", () => {
                 false
             );
             assert.strictEqual(result.tools.length, 1);
+            assert.strictEqual(result.confidence, "none");
         });
 
         test("does not redact when quota regex does not match", () => {
@@ -1344,6 +1363,7 @@ suite("LiteLLMProviderBase", () => {
                 false
             );
             assert.strictEqual(result.tools.length, 1);
+            assert.strictEqual(result.confidence, "none");
         });
 
         test("does not redact when tool regex does not match", () => {
@@ -1356,6 +1376,7 @@ suite("LiteLLMProviderBase", () => {
                 false
             );
             assert.strictEqual(result.tools.length, 1);
+            assert.strictEqual(result.confidence, "low");
         });
 
         test("does not redact on echoed Copilot context without rate/quota signal", () => {
@@ -1368,6 +1389,100 @@ suite("LiteLLMProviderBase", () => {
                 false
             );
             assert.strictEqual(result.tools.length, 1);
+            assert.strictEqual(result.confidence, "none");
+        });
+
+        // Helper functions for new confidence-aware tests
+        const makeToolResultMessage = (
+            callId: string,
+            _toolName: string,
+            resultText: string
+        ): vscode.LanguageModelChatRequestMessage =>
+            ({
+                role: vscode.LanguageModelChatMessageRole.User,
+                name: undefined,
+                content: [
+                    new vscode.LanguageModelToolResultPart(callId, [new vscode.LanguageModelTextPart(resultText)]),
+                ],
+            }) as unknown as vscode.LanguageModelChatRequestMessage;
+
+        const makeAssistantToolCall = (callId: string, toolName: string): vscode.LanguageModelChatRequestMessage =>
+            ({
+                role: vscode.LanguageModelChatMessageRole.Assistant,
+                name: undefined,
+                content: [new vscode.LanguageModelToolCallPart(callId, toolName, {})],
+            }) as unknown as vscode.LanguageModelChatRequestMessage;
+
+        test("redacts on real tool-result quota error for the matching tool", () => {
+            const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
+            const messages = [
+                makeAssistantToolCall("call_1", "insert_edit_into_file"),
+                makeToolResultMessage(
+                    "call_1",
+                    "insert_edit_into_file",
+                    "Error: 429 rate limit exceeded while writing file"
+                ),
+            ];
+            const tools: vscode.LanguageModelChatTool[] = [
+                { name: "insert_edit_into_file", description: "", inputSchema: {} },
+            ];
+            const result = access(provider).detectQuotaToolRedaction(messages, tools, "rid", "m", false);
+            assert.strictEqual(result.tools.length, 0);
+            assert.strictEqual(result.confidence, "high");
+        });
+
+        test("does not redact when reminderInstructions body mentions both patterns", () => {
+            const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
+            // A plausible <reminderInstructions> body — text content only, no tool parts.
+            const reminder =
+                "If a tool returns 429 / rate limit exceeded / quota exceeded when calling " +
+                "tools like insert_edit_into_file or replace_string_in_file, do not retry.";
+            const result = access(provider).detectQuotaToolRedaction([makeText(reminder)], tools, "rid", "m", false);
+            assert.strictEqual(result.tools.length, 1);
+            assert.strictEqual(result.confidence, "low");
+        });
+
+        test("does not redact when userRequest body mentions both patterns", () => {
+            const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
+            const userRequest =
+                "Help me debug a 429 quota exceeded error coming from insert_edit_into_file in our e2e tests.";
+            const result = access(provider).detectQuotaToolRedaction([makeText(userRequest)], tools, "rid", "m", false);
+            assert.strictEqual(result.tools.length, 1);
+            assert.strictEqual(result.confidence, "low");
+        });
+
+        test("does not redact when quota error is in an older turn (not the most recent tool result)", () => {
+            const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
+            const messages = [
+                // Older assistant turn that did NOT call insert_edit_into_file.
+                makeText("Earlier in the conversation."),
+                // Old quota tool result for a different tool.
+                makeToolResultMessage("call_old", "run_in_terminal", "Error: 429 rate limit exceeded"),
+                // Most recent user turn: a clean new request with no quota signal.
+                makeText("Now please continue with the on-boarding flow."),
+            ];
+            const result = access(provider).detectQuotaToolRedaction(messages, tools, "rid", "m", false);
+            assert.strictEqual(result.tools.length, 1);
+            // We find the quota error in an old tool result, but since it's for a
+            // non-redactable tool, we return "low" confidence (not our concern).
+            assert.strictEqual(result.confidence, "low");
+        });
+
+        test("does not redact when tool result is for a different tool than the matched one", () => {
+            const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
+            const messages = [
+                makeAssistantToolCall("call_2", "run_in_terminal"),
+                makeToolResultMessage("call_2", "run_in_terminal", "Error: 429 rate limit exceeded from upstream"),
+            ];
+            const tools: vscode.LanguageModelChatTool[] = [
+                { name: "insert_edit_into_file", description: "", inputSchema: {} },
+                { name: "run_in_terminal", description: "", inputSchema: {} },
+            ];
+            const result = access(provider).detectQuotaToolRedaction(messages, tools, "rid", "m", false);
+            assert.strictEqual(result.tools.length, 2);
+            // We find a real quota error in a tool result, but it's for run_in_terminal
+            // which we don't redact, so it's "low" confidence (observability only).
+            assert.strictEqual(result.confidence, "low");
         });
     });
 


### PR DESCRIPTION
## Summary

Fixes [issue #106](https://github.com/gethnet/litellm-connector-copilot/issues/106) — quota tool redaction was firing on the **first turn of every new session** because the detector matched Copilot's own `<reminderInstructions>` scaffolding (which describes quota handling as guidance to the model) instead of an actual quota failure.

## Root Cause

The previous detector in `LiteLLMProviderBase.detectQuotaToolRedaction` used two regexes applied to the full prompt text:
- A quota phrase regex (`429`, `rate limit exceeded`, `quota exceeded`, etc.)
- A redactable tool regex (`insert_edit_into_file`, `replace_string_in_file`)

Any prompt body that mentioned both — including Copilot's injected `<reminderInstructions>` wrapper describing how the model should *handle* quota errors — caused the regex pair to match. The detector then stripped `insert_edit_into_file` from the tool list and emitted a fake `quota_exceeded:insert_edit_into_file` failure event into PostHog telemetry, every turn.

## Fix

Quota redaction is now **confidence-aware** and only fires on a **high-confidence** signal:

- **High confidence** — a real `LanguageModelToolResultPart` whose `callId` resolves to a redactable tool name. The tool is removed from the request and a `quota_exceeded:<tool>` event is emitted.
- **Low confidence** — any other heuristic match (e.g. prompt scaffolding). A DEBUG log entry is produced, the request is **unchanged**, and **no** telemetry failure event is emitted.

This keeps the safety net for genuine quota failures while eliminating the false positives on normal sessions.

## Changes

- `src/providers/liteLLMProviderBase.ts` — confidence-aware redaction; only `LanguageModelToolResultPart` paths trigger high-confidence redaction
- `src/providers/base/requestBuilder.ts`, `src/providers/base/types.ts` — propagate the new confidence field through the pipeline
- Tests updated to cover high-confidence matches, wrapper-only false positives, and non-redactable tool results
- `package.json` → `2.1.7`
- `CHANGELOG.md` — promoted the entry to a dated `2.1.7` release section

## Testing

- `npm run lint` ✅
- `npm run format` ✅
- `npm run test:coverage` ✅

## References

- Closes #106
- Commit: `b85111a` (fix) + `066c801` (release chores)