### PR TITLE
fix: 🛠️ make `tool_choice` capability-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.9] - 2026-07-09
+
+### 🐛 Fixes
+
+* **🛠️ Capability-aware `tool_choice` filtering (bug [#114](https://github.com/gethnet/litellm-connector-copilot/issues/114))**: Tool-enabled requests now omit the `tool_choice` parameter when LiteLLM's `supported_openai_params` metadata explicitly does not list it. Models with explicit support continue to receive `tool_choice: "auto"` for automatic tool selection, while models without capability metadata retain the previous compatibility behavior. This prevents Azure GPT-5.6 and similar deployments from rejecting requests because of an unsupported parameter. (`src/utils.ts`, `src/providers/base/requestBuilder.ts`, `src/providers/liteLLMProviderBase.ts`)
+
+### 🧪 Tests
+
+* Added regression coverage for `tool_choice` capability detection, request construction, unsupported-parameter filtering, and automatic-mode behavior. (`src/providers/test/parameterValidation.test.ts`, `src/providers/test/liteLLMProviderBase.requestBuilder.test.ts`, `src/providers/test/liteLLMProviderBase.test.ts`, `src/utils/test/utils.test.ts`)
+
 ## [2.1.8] - 2026-07-04
 
 ### 🚀 Features

--- a/README.marketplace.md
+++ b/README.marketplace.md
@@ -10,7 +10,12 @@ Bring **any LiteLLM-supported model** into the Copilot Chat model picker — Ope
 
 ---
 
-## 🆕 What's New in 2.1.8
+## 🆕 What's New in 2.1.9
+
+- 🛠️ **Capability-aware tool choice** — Omits `tool_choice` when LiteLLM model metadata explicitly says the parameter is unsupported, while preserving compatibility for models without explicit capability metadata.
+- ☁️ **Azure GPT-5.6 compatibility** — Prevents unsupported `tool_choice` fields from being sent in tool-enabled requests to affected Azure deployments.
+
+## Previous Release: 2.1.8
 
 - 💭 Full Anthropic thinking content support (signatures, redacted thinking, display metadata)
 - 🔢 Token accounting fixes — reasoning tokens now flow correctly to telemetry

--- a/README.md
+++ b/README.md
@@ -8,7 +8,14 @@
 
 [![License](https://img.shields.io/github/license/gethnet/litellm-connector-copilot)](LICENSE)
 
-## 🆕 What's New in 2.1.8
+## 🆕 What's New in 2.1.9
+
+> Version 2.1.9 improves tool-calling compatibility with LiteLLM models that explicitly do not support the `tool_choice` parameter.
+
+- 🛠️ **Capability-aware tool choice** — The connector now omits `tool_choice` when LiteLLM's model metadata does not list it as supported, while preserving the existing default for models without explicit capability metadata.
+- ☁️ **Azure GPT-5.6 compatibility** — Tool-enabled requests no longer send the unsupported `tool_choice` field to affected Azure deployments.
+
+## Previous Release: 2.1.8
 
 > Version 2.1.8 delivers full Anthropic thinking content coverage, token accounting correctness fixes, and reasoning effort object format support for GPT-5.4+.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "litellm-connector-copilot",
   "displayName": "LiteLLM Connector for Copilot",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "An extension that integrates LiteLLM proxy into Copilot",
   "categories": [
     "AI",
@@ -286,7 +286,7 @@
     "@eslint/js": "^10.0.0",
     "@stylistic/eslint-plugin": "^5.7.1",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^26.0.1",
+    "@types/node": "^26.1.1",
     "@types/sinon": "^21.0.0",
     "@types/vscode": "^1.125.0",
     "@vscode/dts": "^0.4.1",

--- a/src/providers/base/requestBuilder.ts
+++ b/src/providers/base/requestBuilder.ts
@@ -107,8 +107,24 @@ export class RequestBuilder {
         if (toolConfig.tools) {
             requestBody.tools = toolConfig.tools as unknown as OpenAIFunctionToolDef[];
         }
-        if (toolConfig.tool_choice) {
-            requestBody.tool_choice = toolConfig.tool_choice;
+
+        // Only include tool_choice when:
+        // 1. Model supports tool_choice (per isParameterSupported), AND
+        // 2. Tools are present, AND
+        //    a. Explicitly required by toolMode (toolConfig.tool_choice is set), OR
+        //    b. Model supports it - default to "auto" for backward compatibility
+        if (toolConfig.tools && toolConfig.tools.length > 0) {
+            if (this.isParameterSupported("tool_choice", modelInfo, rawModelId)) {
+                if (toolConfig.tool_choice) {
+                    // Explicitly required tool (toolMode === Required)
+                    requestBody.tool_choice = toolConfig.tool_choice;
+                } else {
+                    // Model supports tool_choice, tools present, but no explicit required mode
+                    // Default to "auto" for backward compatibility
+                    requestBody.tool_choice = "auto";
+                }
+            }
+            // If model doesn't support tool_choice, omit it entirely
         }
 
         this.stripUnsupportedParametersFromRequest(
@@ -171,8 +187,24 @@ export class RequestBuilder {
         if (toolConfig.tools) {
             requestBody.tools = toolConfig.tools as unknown as OpenAIFunctionToolDef[];
         }
-        if (toolConfig.tool_choice) {
-            requestBody.tool_choice = toolConfig.tool_choice;
+
+        // Only include tool_choice when:
+        // 1. Model supports tool_choice (per isParameterSupported), AND
+        // 2. Tools are present, AND
+        //    a. Explicitly required by toolMode (toolConfig.tool_choice is set), OR
+        //    b. Model supports it - default to "auto" for backward compatibility
+        if (toolConfig.tools && toolConfig.tools.length > 0) {
+            if (this.isParameterSupported("tool_choice", modelInfo, rawModelId)) {
+                if (toolConfig.tool_choice) {
+                    // Explicitly required tool (toolMode === Required)
+                    requestBody.tool_choice = toolConfig.tool_choice;
+                } else {
+                    // Model supports tool_choice, tools present, but no explicit required mode
+                    // Default to "auto" for backward compatibility
+                    requestBody.tool_choice = "auto";
+                }
+            }
+            // If model doesn't support tool_choice, omit it entirely
         }
 
         this.stripUnsupportedParametersFromRequest(

--- a/src/providers/liteLLMProviderBase.ts
+++ b/src/providers/liteLLMProviderBase.ts
@@ -950,6 +950,7 @@ export abstract class LiteLLMProviderBase {
             "frequency_penalty",
             "stop",
             "reasoning_effort",
+            "tool_choice",
         ]);
         return restrictableParams.has(param.toLowerCase());
     }
@@ -969,6 +970,7 @@ export abstract class LiteLLMProviderBase {
             "no_cache",
             "no-cache",
             "extra_body",
+            "tool_choice", // Added for GPT-5.6 Azure and similar models that don't support tool_choice
         ];
         for (const p of paramsToCheck) {
             if (!this.isParameterSupported(p, modelInfo, modelId) && p in requestBody) {

--- a/src/providers/test/liteLLMProviderBase.requestBuilder.test.ts
+++ b/src/providers/test/liteLLMProviderBase.requestBuilder.test.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import * as sinon from "sinon";
+import * as assert from "assert";
 import { RequestBuilder } from "../base/requestBuilder";
 import { ConfigManager } from "../../config/configManager";
 import type { LiteLLMModelInfo } from "../../types";
@@ -81,5 +82,86 @@ suite("RequestBuilder", () => {
             type: "function",
             function: { name: "test_tool" },
         });
+    });
+
+    test("buildOpenAIChatRequest omits tool_choice when not supported by model", async () => {
+        // Create a builder where isParameterSupported returns false for tool_choice
+        const builderWithGating = new RequestBuilder({
+            configManager,
+            getReasoningEffort: () => undefined,
+            detectQuotaToolRedaction: (messages, tools) => ({ tools, confidence: "none" as const }),
+            stripUnsupportedParametersFromRequest: () => {},
+            isParameterSupported: (param: string) => param !== "tool_choice", // tool_choice not supported
+            getTelemetryOptions: () => ({ caller: "test", justification: undefined, modelConfiguration: {} }),
+            usageOptOutModels: new Set(),
+            extractRawModelName: (id: string) => {
+                const slash = id.indexOf("/");
+                return slash < 0 ? id : id.slice(slash + 1);
+            },
+        });
+
+        configManager.getConfig.resolves({});
+        const model = {
+            id: "azure/gpt-5.6",
+            maxInputTokens: 100000,
+            maxOutputTokens: 4096,
+        } as vscode.LanguageModelChatInformation;
+        const messages: vscode.LanguageModelChatRequestMessage[] = [
+            {
+                role: vscode.LanguageModelChatMessageRole.User,
+                content: [new vscode.LanguageModelTextPart("test")],
+                name: undefined,
+            },
+        ];
+        const modelInfo = { model: "gpt-5.6", supported_openai_params: ["tools"] } as LiteLLMModelInfo;
+
+        const req = await builderWithGating.buildOpenAIChatRequest(
+            messages,
+            model,
+            {
+                tools: [{ name: "tool1", description: "test", inputSchema: {} }],
+                toolMode: vscode.LanguageModelChatToolMode.Auto,
+                modelOptions: {},
+                requestInitiator: "test",
+            } as vscode.ProvideLanguageModelChatResponseOptions,
+            modelInfo,
+            "test"
+        );
+
+        // tool_choice should be undefined when not supported by model
+        assert.strictEqual(req.tool_choice, undefined);
+    });
+
+    test("buildOpenAIChatRequest adds tool_choice: auto when supported and tools present", async () => {
+        configManager.getConfig.resolves({});
+        const model = {
+            id: "openai/gpt-4",
+            maxInputTokens: 100000,
+            maxOutputTokens: 4096,
+        } as vscode.LanguageModelChatInformation;
+        const messages: vscode.LanguageModelChatRequestMessage[] = [
+            {
+                role: vscode.LanguageModelChatMessageRole.User,
+                content: [new vscode.LanguageModelTextPart("test")],
+                name: undefined,
+            },
+        ];
+        const modelInfo = { model: "gpt-4", supported_openai_params: ["tools", "tool_choice"] } as LiteLLMModelInfo;
+
+        const req = await builder.buildOpenAIChatRequest(
+            messages,
+            model,
+            {
+                tools: [{ name: "tool1", description: "test", inputSchema: {} }],
+                toolMode: vscode.LanguageModelChatToolMode.Auto,
+                modelOptions: {},
+                requestInitiator: "test",
+            } as vscode.ProvideLanguageModelChatResponseOptions,
+            modelInfo,
+            "test"
+        );
+
+        // tool_choice should be "auto" when model supports it and tools are present
+        assert.strictEqual(req.tool_choice, "auto");
     });
 });

--- a/src/providers/test/liteLLMProviderBase.test.ts
+++ b/src/providers/test/liteLLMProviderBase.test.ts
@@ -1169,6 +1169,22 @@ suite("LiteLLMProviderBase", () => {
             access(provider).stripUnsupportedParametersFromRequest(body, {} as LiteLLMModelInfo, "any-model");
             assert.strictEqual(body.temperature, 0.5);
         });
+
+        test("removes tool_choice when not in supported_openai_params", () => {
+            const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
+            const body: Record<string, unknown> = { tools: [], tool_choice: "auto", model: "gpt-5.6" };
+            const modelInfo: LiteLLMModelInfo = { model: "gpt-5.6", supported_openai_params: ["tools"] };
+            access(provider).stripUnsupportedParametersFromRequest(body, modelInfo, "gpt-5.6");
+            assert.strictEqual(body.tool_choice, undefined);
+        });
+
+        test("preserves tool_choice when model supports it", () => {
+            const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
+            const body: Record<string, unknown> = { tools: [], tool_choice: "auto", model: "gpt-4" };
+            const modelInfo: LiteLLMModelInfo = { model: "gpt-4", supported_openai_params: ["tools", "tool_choice"] };
+            access(provider).stripUnsupportedParametersFromRequest(body, modelInfo, "gpt-4");
+            assert.strictEqual(body.tool_choice, "auto");
+        });
     });
 
     suite("isParameterSupported", () => {

--- a/src/providers/test/parameterValidation.test.ts
+++ b/src/providers/test/parameterValidation.test.ts
@@ -94,4 +94,38 @@ suite("Parameter Validation from supported_openai_params", () => {
         // Without supported_openai_params the parameter is allowed
         assert.strictEqual(result, true);
     });
+
+    test("tool_choice is restrictable and requires explicit support", () => {
+        const modelInfo: LiteLLMModelInfo = {
+            supported_openai_params: ["temperature", "top_p", "stream"],
+        };
+        const result = provider.testIsParameterSupported("tool_choice", modelInfo, "test-model");
+        // tool_choice should be restrictable like temperature/reasoning_effort
+        // should return false when not in supported_openai_params
+        assert.strictEqual(result, false);
+    });
+
+    test("tool_choice is supported when listed in supported_openai_params", () => {
+        const modelInfo: LiteLLMModelInfo = {
+            supported_openai_params: ["temperature", "tool_choice", "stream"],
+        };
+        const result = provider.testIsParameterSupported("tool_choice", modelInfo, "test-model");
+        // tool_choice is listed, should return true
+        assert.strictEqual(result, true);
+    });
+
+    test("tool_choice defaults to true when supported_openai_params is undefined", () => {
+        const result = provider.testIsParameterSupported("tool_choice", undefined, "test-model");
+        // Without supported_openai_params the parameter is allowed (backward compat)
+        assert.strictEqual(result, true);
+    });
+
+    test("tool_choice returns false for GPT-5.6 Azure models not listing it in supported params", () => {
+        const modelInfo: LiteLLMModelInfo = {
+            model: "gpt-5.6",
+            supported_openai_params: ["tools", "temperature", "top_p"],
+        };
+        const result = provider.testIsParameterSupported("tool_choice", modelInfo, "gpt-5.6");
+        assert.strictEqual(result, false);
+    });
 });

--- a/src/test/integration/mockLiteLLMBackend.test.ts
+++ b/src/test/integration/mockLiteLLMBackend.test.ts
@@ -571,7 +571,11 @@ suite("MockLiteLLMBackend", () => {
 
     suite("Tool Call Support", () => {
         test("should support tool calls in non-streaming responses when enabled", async () => {
-            backend = new MockLiteLLMBackend({ port: testPort, toolCallSupport: true });
+            backend = new MockLiteLLMBackend({
+                port: testPort,
+                toolCallSupport: true,
+                random: () => 0.99,
+            });
             await backend.start();
 
             let toolCallFound = false;
@@ -597,7 +601,7 @@ suite("MockLiteLLMBackend", () => {
                 }
             }
 
-            assert.ok(toolCallFound, "Should eventually generate a tool call response (30% probability per request)");
+            assert.ok(toolCallFound, "Should generate a tool call response when tool-call selection is enabled");
         });
 
         test("should disable tool calls when toolCallSupport is false", async () => {
@@ -621,7 +625,11 @@ suite("MockLiteLLMBackend", () => {
         });
 
         test("should handle streaming tool calls", async () => {
-            backend = new MockLiteLLMBackend({ port: testPort, toolCallSupport: true });
+            backend = new MockLiteLLMBackend({
+                port: testPort,
+                toolCallSupport: true,
+                random: () => 0.99,
+            });
             await backend.start();
 
             let toolCallStreamFound = false;

--- a/src/test/integration/mockLiteLLMBackend.ts
+++ b/src/test/integration/mockLiteLLMBackend.ts
@@ -22,6 +22,7 @@ export interface MockBackendOptions {
     port: number;
     latencyMs?: number;
     toolCallSupport?: boolean;
+    random?: () => number;
     reasoningSupport?: boolean;
 }
 
@@ -30,6 +31,7 @@ export class MockLiteLLMBackend {
     private port: number;
     private latencyMs: number;
     private toolCallSupport: boolean;
+    private readonly random: () => number;
     private reasoningSupport: boolean;
     private requestCount = 0;
 
@@ -37,6 +39,7 @@ export class MockLiteLLMBackend {
         this.port = options.port;
         this.latencyMs = options.latencyMs ?? 50;
         this.toolCallSupport = options.toolCallSupport ?? true;
+        this.random = options.random ?? Math.random;
         this.reasoningSupport = options.reasoningSupport ?? true;
     }
 
@@ -165,7 +168,7 @@ export class MockLiteLLMBackend {
         const request = JSON.parse(body) as Record<string, unknown>;
 
         // Simulate tool call if requested
-        if (this.toolCallSupport && Math.random() > 0.7) {
+        if (this.toolCallSupport && this.random() > 0.7) {
             this.sendToolCallResponse(res, request);
             return;
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -726,7 +726,7 @@ export function convertTools(options: vscode.ProvideLanguageModelChatResponseOpt
             } satisfies OpenAIFunctionToolDef;
         });
 
-    let tool_choice: "auto" | { type: "function"; function: { name: string } } = "auto";
+    let tool_choice: "auto" | { type: "function"; function: { name: string } } | undefined = undefined;
     if (options.toolMode === vscode.LanguageModelChatToolMode.Required) {
         if (tools.length !== 1) {
             Logger.error("ToolMode.Required but multiple tools:", tools.length);
@@ -734,8 +734,12 @@ export function convertTools(options: vscode.ProvideLanguageModelChatResponseOpt
         }
         tool_choice = { type: "function", function: { name: sanitizeFunctionName(tools[0].name) } };
     }
+    // Note: tool_choice is NOT set to "auto" by default - only when explicitly Required.
+    // The request builder will add tool_choice: "auto" if tools are present AND the model
+    // supports tool_choice per its capabilities. This prevents passing unsupported tool_choice
+    // to models like GPT-5.6 Azure that don't support the parameter.
 
-    return { tools: toolDefs, tool_choice };
+    return { tools: toolDefs, ...(tool_choice !== undefined && { tool_choice }) };
 }
 
 /**

--- a/src/utils/test/utils.test.ts
+++ b/src/utils/test/utils.test.ts
@@ -307,6 +307,18 @@ suite("Utility Unit Tests", () => {
         assert.strictEqual(res.tool_choice?.function.name, "tool_-bad_name");
     });
 
+    test("convertTools should NOT return tool_choice when toolMode is Auto/undefined", () => {
+        const tools: vscode.LanguageModelChatTool[] = [{ name: "tool1", description: "test", inputSchema: {} }];
+
+        const res = convertTools({
+            tools,
+            toolMode: vscode.LanguageModelChatToolMode.Auto,
+            requestInitiator: "test",
+        });
+
+        assert.strictEqual(res.tool_choice, undefined, "tool_choice should be undefined when toolMode is Auto");
+    });
+
     test("convertTools returns empty when no tools", () => {
         const res = convertTools({
             tools: [],


### PR DESCRIPTION
**🐛 Fixes**
- [Bug]: tool_choice parameter not supported on GPT-5.6 Azure models Fixes #114
- Omit `tool_choice` when LiteLLM metadata does not list it in `supported_openai_params`, preventing unsupported-parameter rejections on Azure GPT-5.6 and similar deployments.
- Keep `tool_choice: "auto"` only for models that explicitly support it, while preserving the previous compatibility behavior when capability metadata is missing.

**🧪 Tests**
- Add regression coverage for parameter support checks, request construction, unsupported-parameter stripping, and `convertTools` auto-mode behavior.

**📚 Docs**
- Update the changelog and README copy to document the 2.1.9 tool-calling compatibility fix.

**🧹 Chores**
- Bump the package version to 2.1.9 and refresh `@types/node`.

Fixes #114