### PR TITLE
fix: expand reasoning effort levels

### DIFF
--- a/src/config/modelOverrides.ts
+++ b/src/config/modelOverrides.ts
@@ -11,6 +11,7 @@ const bundledOverridesData: unknown = bundledOverridesSource;
  * Kept in sync with src/utils/modelCapabilities.ts.
  */
 const LITELLM_REASONING_EFFORT_MAPPING: Record<string, SupportedReasoningEffort> = {
+    supports_none_reasoning_effort: "none",
     supports_minimal_reasoning_effort: "minimal",
     supports_low_reasoning_effort: "low",
     supports_xlow_reasoning_effort: "low",
@@ -20,7 +21,15 @@ const LITELLM_REASONING_EFFORT_MAPPING: Record<string, SupportedReasoningEffort>
     supports_max_reasoning_effort: "max",
 } as const satisfies Record<string, SupportedReasoningEffort>;
 
-const CANONICAL_REASONING_EFFORTS: readonly SupportedReasoningEffort[] = ["none", "low", "medium", "high"];
+const CANONICAL_REASONING_EFFORTS: readonly SupportedReasoningEffort[] = [
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+];
 
 const CANONICAL_DEFAULT_EFFORT: SupportedReasoningEffort = "medium";
 
@@ -29,7 +38,15 @@ const MODEL_OVERRIDES_SETTING_KEY = "litellm-connector.modelOverrides";
 let bundledOverridesCache: ModelOverride[] | undefined;
 
 function isSupportedReasoningEffort(value: unknown): value is SupportedReasoningEffort {
-    return value === "none" || value === "low" || value === "medium" || value === "high";
+    return (
+        value === "none" ||
+        value === "minimal" ||
+        value === "low" ||
+        value === "medium" ||
+        value === "high" ||
+        value === "xhigh" ||
+        value === "max"
+    );
 }
 
 /**
@@ -168,12 +185,17 @@ function getExplicitReasoningEfforts(modelInfo?: LiteLLMModelInfo): SupportedRea
         return undefined;
     }
     const explicitEfforts: SupportedReasoningEffort[] = [];
+    let hasAnyExplicitField = false;
     for (const [key, value] of Object.entries(LITELLM_REASONING_EFFORT_MAPPING)) {
-        if (modelInfo[key as keyof LiteLLMModelInfo] === true) {
+        const fieldValue = modelInfo[key as keyof LiteLLMModelInfo];
+        if (fieldValue === true) {
             explicitEfforts.push(value as SupportedReasoningEffort);
         }
+        if (fieldValue !== undefined && fieldValue !== null) {
+            hasAnyExplicitField = true;
+        }
     }
-    return explicitEfforts.length > 0 ? explicitEfforts : undefined;
+    return hasAnyExplicitField ? explicitEfforts : undefined;
 }
 
 export function getEffectiveEfforts(
@@ -207,10 +229,12 @@ export function getEffectiveEfforts(
         }
 
         // When the proxy exposes explicit effort flags, prefer those over non-mandatory overrides.
+        // explicitEfforts is undefined when no effort fields are present (fall back to defaults),
+        // or an array (possibly empty) when fields are present — respect explicit false values.
         const explicitEfforts = getExplicitReasoningEfforts(modelInfo)
             ?.filter(isSupportedReasoningEffort)
             .filter((effort, index, arr) => arr.indexOf(effort) === index);
-        if (explicitEfforts && explicitEfforts.length > 0) {
+        if (explicitEfforts !== undefined) {
             return explicitEfforts;
         }
 
@@ -231,6 +255,14 @@ export function getEffectiveEfforts(
         }
 
         return [];
+    }
+
+    // No override: check explicit effort fields first, then fall back to canonical.
+    const explicitEfforts = getExplicitReasoningEfforts(modelInfo)
+        ?.filter(isSupportedReasoningEffort)
+        .filter((effort, index, arr) => arr.indexOf(effort) === index);
+    if (explicitEfforts !== undefined) {
+        return explicitEfforts;
     }
 
     if (modelInfo?.supports_reasoning) {

--- a/src/config/test/modelOverrides.test.ts
+++ b/src/config/test/modelOverrides.test.ts
@@ -12,7 +12,7 @@ import {
 import type { LiteLLMModelInfo } from "../../types";
 import { Logger } from "../../utils/logger";
 
-const CANONICAL_REASONING_EFFORTS = ["none", "low", "medium", "high"] as const;
+const CANONICAL_REASONING_EFFORTS = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 
 suite("modelOverrides", () => {
     let getConfigurationStub: sinon.SinonStub;
@@ -165,8 +165,8 @@ suite("modelOverrides", () => {
 
         const result = getEffectiveEfforts("test-model", modelInfo);
         // If LiteLLM has valid data, returns enumeration. When supports_reasoning is true
-        // but no effort flags are set, falls back to DEFAULT_REASONING_EFFORTS.
-        assert.deepStrictEqual(result, ["none", "low", "medium", "high"]);
+        // but no effort flags are set, falls back to CANONICAL_REASONING_EFFORTS.
+        assert.deepStrictEqual(result, [...CANONICAL_REASONING_EFFORTS]);
     });
 
     test("findOverride returns undefined when enableModelOverrides is false", () => {
@@ -202,7 +202,7 @@ suite("modelOverrides", () => {
 
         // When overrides are disabled, forceMandatory should have no effect.
         // Model has supports_reasoning but no explicit effort flags, so falls back to canonical.
-        assert.deepStrictEqual(result, ["none", "low", "medium", "high"]);
+        assert.deepStrictEqual(result, [...CANONICAL_REASONING_EFFORTS]);
     });
 
     test("getDefaultEffort ignores overrides when enableModelOverrides is false", () => {

--- a/src/providers/base/requestBuilder.ts
+++ b/src/providers/base/requestBuilder.ts
@@ -75,8 +75,7 @@ export class RequestBuilder {
                     ? Math.min(mo.max_tokens, model.maxOutputTokens)
                     : model.maxOutputTokens,
             ...(this.isParameterSupported("reasoning_effort", modelInfo, rawModelId) &&
-            reasoningEffort &&
-            reasoningEffort !== "none"
+            reasoningEffort
                 ? { reasoning_effort: reasoningEffort }
                 : {}),
         };
@@ -162,8 +161,7 @@ export class RequestBuilder {
                     ? Math.min(options.modelOptions.max_tokens, model.maxOutputTokens)
                     : model.maxOutputTokens,
             ...(this.isParameterSupported("reasoning_effort", modelInfo, rawModelId) &&
-            reasoningEffort &&
-            reasoningEffort !== "none"
+            reasoningEffort
                 ? { reasoning_effort: reasoningEffort }
                 : {}),
         };

--- a/src/providers/liteLLMProviderBase.ts
+++ b/src/providers/liteLLMProviderBase.ts
@@ -460,10 +460,6 @@ export abstract class LiteLLMProviderBase {
         const pickerEffort = telemetry.modelConfiguration?.reasoningEffort;
         Logger.debug(`[getReasoningEffort] pickerEffort (from modelConfiguration): ${pickerEffort}`);
         if (typeof pickerEffort === "string") {
-            if (pickerEffort === "none") {
-                Logger.trace(`[reasoning] Picker selected "none" for ${model.id}; suppressing reasoning_effort field.`);
-                return undefined;
-            }
             Logger.debug(`[getReasoningEffort] Returning pickerEffort without validation: ${pickerEffort}`);
             return pickerEffort;
         }
@@ -471,9 +467,6 @@ export abstract class LiteLLMProviderBase {
         const modelOptions = (options.modelOptions as Record<string, unknown> | undefined) ?? {};
         const overrideEffort = modelOptions.reasoning_effort ?? modelOptions.reasoningEffort;
         if (typeof overrideEffort === "string") {
-            if (overrideEffort === "none") {
-                return undefined;
-            }
             if (this.isReasoningEffortSupported(overrideEffort, modelInfo, model.id)) {
                 return overrideEffort;
             }
@@ -699,7 +692,7 @@ export abstract class LiteLLMProviderBase {
         effort: SupportedReasoningEffort | undefined,
         summary?: "auto" | "concise" | "detailed"
     ): void {
-        if (!effort || effort === "none") {
+        if (!effort) {
             const requestRecord = request as unknown as Record<string, unknown>;
             delete requestRecord.reasoning_effort;
             return;

--- a/src/providers/test/liteLLMProviderBase.test.ts
+++ b/src/providers/test/liteLLMProviderBase.test.ts
@@ -197,15 +197,14 @@ suite("LiteLLMProviderBase", () => {
         };
 
         suite("applyReasoningEffort", () => {
-            test("omits reasoning_effort field when effort is 'none'", () => {
+            test("sends reasoning_effort='none' as a real value", () => {
                 const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
                 const request = { model: "test-model", messages: [] } as OpenAIChatCompletionRequest;
 
                 access(provider).applyReasoningEffort(request, "none");
 
                 const recordRequest = request as unknown as Record<string, unknown>;
-                assert.strictEqual(recordRequest.reasoning_effort, undefined);
-                assert.ok(!("reasoning_effort" in request));
+                assert.strictEqual(recordRequest.reasoning_effort, "none");
             });
 
             test("sets reasoning_effort field for non-none values", () => {
@@ -286,7 +285,7 @@ suite("LiteLLMProviderBase", () => {
             assert.strictEqual(request.reasoning_effort, undefined);
         });
 
-        test("treats picker 'none' as opt-out and omits reasoning_effort", async () => {
+        test("sends picker 'none' as reasoning_effort value", async () => {
             const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
             const request = await access(provider).buildOpenAIChatRequest(
                 [
@@ -303,7 +302,7 @@ suite("LiteLLMProviderBase", () => {
                 undefined,
                 "test"
             );
-            assert.strictEqual(request.reasoning_effort, undefined);
+            assert.strictEqual(request.reasoning_effort, "none");
         });
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -247,7 +247,7 @@ export interface LiteLLMModelInfo {
     cache_read_input_token_cost?: number | null;
     cache_creation_input_token_cost?: number | null;
     // Extended reasoning effort support fields from LiteLLM
-    // (for future use when LiteLLM provides explicit effort level fields)
+    supports_none_reasoning_effort?: boolean | null;
     supports_minimal_reasoning_effort?: boolean | null;
     supports_low_reasoning_effort?: boolean | null;
     supports_medium_reasoning_effort?: boolean | null;

--- a/src/utils/modelCapabilities.ts
+++ b/src/utils/modelCapabilities.ts
@@ -170,6 +170,7 @@ export function getModelTags(
  * This supports the 5 LiteLLM reasoning effort levels for model picker UI.
  */
 const LITELLM_REASONING_EFFORT_MAPPING: Record<string, SupportedReasoningEffort> = {
+    supports_none_reasoning_effort: "none",
     supports_minimal_reasoning_effort: "minimal",
     supports_low_reasoning_effort: "low",
     supports_xlow_reasoning_effort: "low",
@@ -184,7 +185,15 @@ const LITELLM_REASONING_EFFORT_MAPPING: Record<string, SupportedReasoningEffort>
  * but doesn't specify exact effort levels (supports_reasoning: true).
  * Uses a conservative set to avoid unsupported effort flags being exposed in the UI.
  */
-const DEFAULT_REASONING_EFFORTS: readonly SupportedReasoningEffort[] = ["none", "low", "medium", "high"];
+const DEFAULT_REASONING_EFFORTS: readonly SupportedReasoningEffort[] = [
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+];
 
 /**
  * Type definition for extended properties on LanguageModelChatInformation.
@@ -271,7 +280,7 @@ export function getSupportedReasoningEfforts(
         }
         // Still check for explicit effort fields as some models may have them
         const explicitEfforts = extractExplicitReasoningEfforts(modelInfo);
-        if (explicitEfforts.length > 0) {
+        if (explicitEfforts !== undefined) {
             return explicitEfforts;
         }
         return [];
@@ -285,7 +294,7 @@ export function getSupportedReasoningEfforts(
     // treat it as unknown and do not block effort exposure.
     const paramStatus = reasoningEffortParamStatus(modelInfo);
     const explicitEfforts = extractExplicitReasoningEfforts(modelInfo);
-    if (paramStatus === false && explicitEfforts.length === 0) {
+    if (paramStatus === false && explicitEfforts === undefined) {
         // reasoning_effort explicitly excluded and no fine-grained effort fields — hide picker
         return [];
     }
@@ -297,8 +306,9 @@ export function getSupportedReasoningEfforts(
         overrideEfforts = getEffectiveEfforts(modelId, modelInfo, config);
     }
 
-    if (explicitEfforts.length > 0) {
-        // If overrides provide a broader or different ladder, prefer them when non-empty
+    if (explicitEfforts !== undefined) {
+        // Explicit fields present (even if all false → empty array): respect them.
+        // Overrides take precedence only when non-empty.
         if (overrideEfforts.length > 0) {
             return overrideEfforts;
         }
@@ -320,19 +330,31 @@ export function getSupportedReasoningEfforts(
 /**
  * Extract reasoning efforts from explicit effort level fields in LiteLLM model info.
  * Example: supports_high_reasoning_effort: true → includes "high"
+ *
+ * Returns `undefined` when no explicit effort fields are present at all (so callers
+ * can fall back to defaults). Returns an array (possibly empty) when at least one
+ * explicit effort field is present — this respects explicit `false` values from
+ * LiteLLM rather than falling back to the full default ladder.
  */
-function extractExplicitReasoningEfforts(modelInfo?: LiteLLMModelInfo): SupportedReasoningEffort[] {
+function extractExplicitReasoningEfforts(modelInfo?: LiteLLMModelInfo): SupportedReasoningEffort[] | undefined {
     if (!modelInfo) {
-        return [];
+        return undefined;
     }
 
     const efforts = new Set<SupportedReasoningEffort>();
+    let hasAnyExplicitField = false;
     for (const [key, effortValue] of Object.entries(LITELLM_REASONING_EFFORT_MAPPING)) {
-        // Use safe property access - any null values treated as undefined
         const value = modelInfo[key as keyof LiteLLMModelInfo];
         if (value === true) {
             efforts.add(effortValue);
         }
+        if (value !== undefined && value !== null) {
+            hasAnyExplicitField = true;
+        }
+    }
+
+    if (!hasAnyExplicitField) {
+        return undefined;
     }
 
     // Sort efforts in standard order: none, minimal, low, medium, high, xhigh, max

--- a/src/utils/reasoningEffortFallback.ts
+++ b/src/utils/reasoningEffortFallback.ts
@@ -2,7 +2,15 @@ import type { SupportedReasoningEffort } from "../types";
 import { Logger } from "./logger";
 
 // Reasoning effort ladder from most to least capable. `undefined` means omit the parameter entirely.
-const EFFORT_LADDER: readonly SupportedReasoningEffort[] = ["xhigh", "high", "medium", "low", "minimal", "none"];
+const EFFORT_LADDER: readonly SupportedReasoningEffort[] = [
+    "max",
+    "xhigh",
+    "high",
+    "medium",
+    "low",
+    "minimal",
+    "none",
+];
 
 function nextLowerEffort(effort: SupportedReasoningEffort): SupportedReasoningEffort | undefined {
     const index = EFFORT_LADDER.indexOf(effort);

--- a/src/utils/test/modelCapabilities.test.ts
+++ b/src/utils/test/modelCapabilities.test.ts
@@ -362,9 +362,9 @@ suite("modelCapabilities", () => {
     });
 
     suite("getSupportedReasoningEfforts", () => {
-        const canonicalGpt5Efforts: SupportedReasoningEffort[] = ["none", "low", "medium", "high"];
-        const claudeEfforts: SupportedReasoningEffort[] = ["none", "low", "medium", "high"];
-        const canonicalCatchAllEfforts: SupportedReasoningEffort[] = ["none", "low", "medium", "high"];
+        const canonicalGpt5Efforts: SupportedReasoningEffort[] = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+        const claudeEfforts: SupportedReasoningEffort[] = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+        const canonicalCatchAllEfforts: SupportedReasoningEffort[] = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
 
         test("returns empty array when supports_reasoning is true but reasoning_effort not in supported_openai_params", () => {
             const modelInfo: LiteLLMModelInfo = {
@@ -424,8 +424,8 @@ suite("modelCapabilities", () => {
 
             const result = getSupportedReasoningEfforts(modelInfo, "gpt-5.4-mini");
 
-            // Canonical ladder is now limited to none/low/medium/high.
-            assert.deepStrictEqual(result, ["none", "low", "medium", "high"]);
+            // Only xhigh is explicitly supported; explicit fields take precedence over the default ladder.
+            assert.deepStrictEqual(result, ["xhigh"]);
         });
 
         test("returns Claude ladder for claude-haiku-4-5", () => {


### PR DESCRIPTION
This pull request expands and refines the handling of "reasoning effort" levels across the codebase, aligning more closely with LiteLLM's explicit effort fields and improving how these are surfaced and respected in both configuration and API requests. The changes ensure that all possible reasoning effort levels are recognized, that explicit model fields are prioritized (including explicit "none"), and that the correct values are sent through to providers and reflected in tests.

**Reasoning Effort Levels Expansion and Canonicalization**
- Expanded the set of supported reasoning effort levels to include `"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, and `"max"` throughout the codebase, updating constants and test expectations accordingly. [[1]](diffhunk://#diff-d9e81129580a2578ae7fd41157bc6b259b0b14594e98c116d6664ed849f4bf0aL23-R32) [[2]](diffhunk://#diff-262f5ff137fa3c41fe0be43a89abb90c08cfaa581a2c5b3ac902c24041e79ecdL187-R196) [[3]](diffhunk://#diff-8b423f68fa356137fe433e1b0728670f986de5cbb3b3e3a621bcf597f21b982bL15-R15) [[4]](diffhunk://#diff-310b00b9b05ea12fe7261357f6c260cd1f788185f799c8fe6ab07ac4edffdfadL365-R367) [[5]](diffhunk://#diff-28f65f17bc38c6e7b4f69c6b07a3fd1c43a6e817c00e2e961171d26b4abe1008L5-R13)

**Explicit Effort Field Detection and Precedence**
- Refactored logic to detect explicit effort fields in model info: now returns `undefined` only if no explicit fields are present, and an array (possibly empty) if at least one field is present, ensuring explicit `false` values are respected and take precedence over defaults. [[1]](diffhunk://#diff-d9e81129580a2578ae7fd41157bc6b259b0b14594e98c116d6664ed849f4bf0aR188-R198) [[2]](diffhunk://#diff-d9e81129580a2578ae7fd41157bc6b259b0b14594e98c116d6664ed849f4bf0aR232-R237) [[3]](diffhunk://#diff-d9e81129580a2578ae7fd41157bc6b259b0b14594e98c116d6664ed849f4bf0aR260-R267) [[4]](diffhunk://#diff-262f5ff137fa3c41fe0be43a89abb90c08cfaa581a2c5b3ac902c24041e79ecdL274-R283) [[5]](diffhunk://#diff-262f5ff137fa3c41fe0be43a89abb90c08cfaa581a2c5b3ac902c24041e79ecdL288-R297) [[6]](diffhunk://#diff-262f5ff137fa3c41fe0be43a89abb90c08cfaa581a2c5b3ac902c24041e79ecdL300-R311) [[7]](diffhunk://#diff-262f5ff137fa3c41fe0be43a89abb90c08cfaa581a2c5b3ac902c24041e79ecdR333-R357)

**API Request Handling and Provider Logic**
- Changed provider/request builder logic so that `"none"` is now sent as a real `reasoning_effort` value in API requests (rather than omitting the field), and updated related tests to reflect this behavior. [[1]](diffhunk://#diff-edbdcd3b6d51561b270cc0aed65648556ed2c4a6abbcb5ed41422b521e0285a3L78-R78) [[2]](diffhunk://#diff-edbdcd3b6d51561b270cc0aed65648556ed2c4a6abbcb5ed41422b521e0285a3L165-R164) [[3]](diffhunk://#diff-2465bc4b6601f0c48504ec66acb57d947350527a271af8726b274024306bf183L463-L476) [[4]](diffhunk://#diff-2465bc4b6601f0c48504ec66acb57d947350527a271af8726b274024306bf183L702-R695) [[5]](diffhunk://#diff-b907da3eb8cef293bf07b8572cdf6c7bc0f65123fad24d17792cf29a9506ce49L200-R207) [[6]](diffhunk://#diff-b907da3eb8cef293bf07b8572cdf6c7bc0f65123fad24d17792cf29a9506ce49L289-R288) [[7]](diffhunk://#diff-b907da3eb8cef293bf07b8572cdf6c7bc0f65123fad24d17792cf29a9506ce49L306-R305)

**Model Info and Mapping Synchronization**
- Added support for the `supports_none_reasoning_effort` field in `LiteLLMModelInfo` and its mapping, ensuring that models can explicitly declare support for the `"none"` effort. [[1]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL250-R250) [[2]](diffhunk://#diff-d9e81129580a2578ae7fd41157bc6b259b0b14594e98c116d6664ed849f4bf0aR14) [[3]](diffhunk://#diff-262f5ff137fa3c41fe0be43a89abb90c08cfaa581a2c5b3ac902c24041e79ecdR173)

**Test and Documentation Updates**
- Updated tests and inline documentation to match the new effort ladder and explicit field handling, ensuring correctness and clarity. [[1]](diffhunk://#diff-8b423f68fa356137fe433e1b0728670f986de5cbb3b3e3a621bcf597f21b982bL168-R169) [[2]](diffhunk://#diff-8b423f68fa356137fe433e1b0728670f986de5cbb3b3e3a621bcf597f21b982bL205-R205) [[3]](diffhunk://#diff-310b00b9b05ea12fe7261357f6c260cd1f788185f799c8fe6ab07ac4edffdfadL427-R428)

These changes make reasoning effort handling more robust, explicit, and aligned with LiteLLM's evolving capabilities.