### PR TITLE
🚀 Release v2.2.1 reasoning fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.1.1] - 2026-07-16
+## [2.2.1] - 2026-07-16
 
 ### 🧠 Reasoning Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.1] - 2026-07-16
+
+### 🧠 Reasoning Fixes
+
+* **🎛️ Explicit reasoning model-card overrides**: Enabled overrides now patch matching LiteLLM model metadata before capability detection. Existing fields are replaced, missing fields are added, and unspecified or related capability fields remain unchanged.
+* **🔒 Reasoning overrides are opt-in**: `litellm-connector.enableModelOverrides` now defaults to `false`. Enable it explicitly when LiteLLM reports incomplete or incorrect reasoning metadata.
+
+* **🛡️ Restore reasoning capability gates**: Reasoning effort options are no longer exposed when LiteLLM explicitly disables reasoning or all individual effort levels. This prevents unsupported reasoning controls from appearing in the model picker.
+* **🧩 Preserve explicit effort metadata**: Models now expose only the explicitly reported LiteLLM effort levels, including `minimal`, `xhigh`, and `max`, without inferring related effort fields. Explicit `none` support is also preserved.
+
+### 🧪 Tests
+
+* Added regression coverage for explicit reasoning disablement, gated field-level overrides, reasoning capability gates, and model-reported effort levels. (`src/config/test/modelOverrides.test.ts`, `src/utils/test/modelCapabilities.test.ts`, `src/utils/test/modelCapabilities.reasoning-overhaul.test.ts`)
+
 ## [2.2.0] - 2026-07-15
 
 ### 🐛 Fixes

--- a/README.marketplace.md
+++ b/README.marketplace.md
@@ -10,16 +10,15 @@ Bring **any LiteLLM-supported model** into the Copilot Chat model picker — Ope
 
 ---
 
-## 🆕 What's New in 2.1.9
+## 🆕 What's New in 2.1.1
 
-- 🛠️ **Capability-aware tool choice** — Omits `tool_choice` when LiteLLM model metadata explicitly says the parameter is unsupported, while preserving compatibility for models without explicit capability metadata.
-- ☁️ **Azure GPT-5.6 compatibility** — Prevents unsupported `tool_choice` fields from being sent in tool-enabled requests to affected Azure deployments.
+> Version 2.1.1 fixes reasoning capability detection so the model picker exposes only supported reasoning effort options.
 
-## Previous Release: 2.1.8
+- 🧠 **Reasoning capability gates** — Hides reasoning controls when LiteLLM explicitly disables reasoning or all effort levels.
+- 🧩 **Explicit effort support** — Uses model-reported levels such as `minimal`, `xhigh`, and `max` without inferring unspecified effort fields.
+- 🎛️ **Opt-in model-card overrides** — Correct incomplete LiteLLM reasoning metadata with explicit, field-level overrides.
 
-- 💭 Full Anthropic thinking content support (signatures, redacted thinking, display metadata)
-- 🔢 Token accounting fixes — reasoning tokens now flow correctly to telemetry
-- 📊 Reasoning effort object format (`{ effort, summary }`) for GPT-5.4+
+See [`CHANGELOG.md`](CHANGELOG.md) for previous release notes.
 
 ---
 
@@ -92,12 +91,40 @@ Base URL + API key are configured through **VS Code's Language Models UI** (run 
 | `commitModelIdOverride` | `""` | Model ID for commit message generation |
 | `inactivityTimeout` | `60` | Seconds before stream is considered idle |
 | `disableCaching` | `false` | When enabled, bypass LiteLLM caching for models that advertise support for the `cache` parameter |
-| `enableModelOverrides` | `true` | Enable model override rules |
+| `enableModelOverrides` | `false` | Enable model-card override rules |
 | `displayPricingInPicker` | `true` | Show model pricing in picker |
 | `discoveryTimeoutMs` | `5000` | Timeout (ms) for model discovery |
 | `discoveryCacheTtlMs` | `60000` | Cache TTL (ms), 0 to disable |
 | `discoveryFireDebounceMs` | `250` | Debounce (ms) for change notifications |
 | `discoveryFireMinIntervalMs` | `2000` | Min interval (ms) between notifications |
+
+> Reasoning model-card overrides are disabled by default. Enable `enableModelOverrides` when LiteLLM reports incorrect or incomplete reasoning metadata. Overrides replace or add only the explicitly named LiteLLM fields; related fields are not inferred.
+
+### 🛠️ Help: Applying a Model Override
+
+Model overrides are disabled by default. To correct incomplete LiteLLM `/model/info` metadata:
+
+1. Open **Preferences: Open User Settings (JSON)** or **Preferences: Open Workspace Settings (JSON)**.
+2. Set `litellm-connector.enableModelOverrides` to `true`.
+3. Add a matching rule to `litellm-connector.modelOverrides`.
+4. Run **LiteLLM: Reload Models**.
+
+Use the raw LiteLLM `model_name` and exact snake_case model-card fields. Only explicitly defined fields are changed; related fields are not inferred.
+
+```json
+{
+   "litellm-connector.enableModelOverrides": true,
+   "litellm-connector.modelOverrides": [
+      {
+         "match": "^gpt-4\\.8$",
+         "supports_reasoning": true,
+         "supports_max_reasoning_effort": true
+      }
+   ]
+}
+```
+
+Define each desired effort explicitly, such as `supports_xhigh_reasoning_effort: true`. Setting one effort field does not enable `supports_reasoning` or any other effort field automatically.
 
 ### Advanced (JSON-Only)
 

--- a/README.marketplace.md
+++ b/README.marketplace.md
@@ -10,9 +10,9 @@ Bring **any LiteLLM-supported model** into the Copilot Chat model picker — Ope
 
 ---
 
-## 🆕 What's New in 2.1.1
+## 🆕 What's New in 2.2.1
 
-> Version 2.1.1 fixes reasoning capability detection so the model picker exposes only supported reasoning effort options.
+> Version 2.2.1 fixes reasoning capability detection so the model picker exposes only supported reasoning effort options.
 
 - 🧠 **Reasoning capability gates** — Hides reasoning controls when LiteLLM explicitly disables reasoning or all effort levels.
 - 🧩 **Explicit effort support** — Uses model-reported levels such as `minimal`, `xhigh`, and `max` without inferring unspecified effort fields.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 [![License](https://img.shields.io/github/license/gethnet/litellm-connector-copilot)](LICENSE)
 
-## 🆕 What's New in 2.1.1
+## 🆕 What's New in 2.2.1
 
-> Version 2.1.1 fixes reasoning capability detection so the model picker exposes only supported reasoning effort options.
+> Version 2.2.1 fixes reasoning capability detection so the model picker exposes only supported reasoning effort options.
 
 - 🧠 **Reasoning capability gates** — Hides reasoning controls when LiteLLM explicitly disables reasoning or all effort levels.
 - 🧩 **Explicit effort support** — Uses model-reported levels such as `minimal`, `xhigh`, and `max` without inferring unspecified effort fields.

--- a/README.md
+++ b/README.md
@@ -8,20 +8,15 @@
 
 [![License](https://img.shields.io/github/license/gethnet/litellm-connector-copilot)](LICENSE)
 
-## 🆕 What's New in 2.1.9
+## 🆕 What's New in 2.1.1
 
-> Version 2.1.9 improves tool-calling compatibility with LiteLLM models that explicitly do not support the `tool_choice` parameter.
+> Version 2.1.1 fixes reasoning capability detection so the model picker exposes only supported reasoning effort options.
 
-- 🛠️ **Capability-aware tool choice** — The connector now omits `tool_choice` when LiteLLM's model metadata does not list it as supported, while preserving the existing default for models without explicit capability metadata.
-- ☁️ **Azure GPT-5.6 compatibility** — Tool-enabled requests no longer send the unsupported `tool_choice` field to affected Azure deployments.
+- 🧠 **Reasoning capability gates** — Hides reasoning controls when LiteLLM explicitly disables reasoning or all effort levels.
+- 🧩 **Explicit effort support** — Uses model-reported levels such as `minimal`, `xhigh`, and `max` without inferring unspecified effort fields.
+- 🎛️ **Opt-in model-card overrides** — Correct incomplete LiteLLM reasoning metadata with explicit, field-level overrides.
 
-## Previous Release: 2.1.8
-
-> Version 2.1.8 delivers full Anthropic thinking content coverage, token accounting correctness fixes, and reasoning effort object format support for GPT-5.4+.
-
-- 💭 **Full Anthropic thinking/thinking content coverage** — Support for `signature`, `redacted_thinking` blocks, and `display` metadata preservation throughout streaming
-- 🔢 **Token accounting correctness** — Reasoning tokens now correctly flow through to telemetry (no more zeroing out)
-- 📊 **Reasoning effort object format** — Support for `{ effort: string; summary?: string }` enabling GPT-5.4+ and OpenAI Responses API summary control (`"auto" | "concise" | "detailed"`)
+See [`CHANGELOG.md`](CHANGELOG.md) for previous release notes.
 
 ---
 
@@ -118,7 +113,7 @@ Generate structured, conventional commit messages from staged changes. Set `comm
 API keys stored safely in VS Code's encrypted `SecretStorage`. No plaintext secrets.
 
 ### 🧩 Model Override System
-Fine-tune reasoning capabilities for specific models via `litellm-connector.modelOverrides` and `litellm-connector.modelCapabilitiesOverrides`.
+Fine-tune model metadata for specific models via `litellm-connector.modelOverrides` and `litellm-connector.modelCapabilitiesOverrides`. Model-card overrides are disabled by default. See [Applying a Model Override](#-help-applying-a-model-override) for a complete example.
 
 ---
 
@@ -146,8 +141,8 @@ Base URL and API key are configured through **VS Code's Language Models provider
 | `litellm-connector.inactivityTimeout` | number | `60` | Seconds before connection is considered idle |
 | `litellm-connector.disableCaching` | boolean | `false` | When enabled, bypass LiteLLM caching for models that advertise support for the `cache` parameter |
 | `litellm-connector.disableQuotaToolRedaction` | boolean | `false` | Disable automatic tool removal on quota errors |
-| `litellm-connector.enableModelOverrides` | boolean | `true` | Master toggle for model override system |
-| `litellm-connector.modelOverrides` | array | `[]` | User-supplied regex-based override rules |
+| `litellm-connector.enableModelOverrides` | boolean | `false` | Master toggle for user and bundled model-card overrides |
+| `litellm-connector.modelOverrides` | array | `[]` | User-supplied regex-based field overrides; only explicitly defined fields replace LiteLLM data |
 | `litellm-connector.modelCapabilitiesOverrides` | object | `{}` | Override `toolCalling` / `imageInput` capabilities |
 | `litellm-connector.displayPricingInPicker` | boolean | `true` | Show model pricing in the model picker |
 | `litellm-connector.discoveryTimeoutMs` | number | `5000` | Timeout (ms) for `/model/info` discovery requests |
@@ -155,7 +150,35 @@ Base URL and API key are configured through **VS Code's Language Models provider
 | `litellm-connector.discoveryFireDebounceMs` | number | `250` | Debounce window (ms) for model-change notifications |
 | `litellm-connector.discoveryFireMinIntervalMs` | number | `2000` | Min interval (ms) between change notifications |
 
-> **Tip**: Most users won't need to touch these — the defaults work great! Caching bypass is opt-in; set `litellm-connector.disableCaching` to `true` only when you want to bypass LiteLLM caching for compatible models.
+> **Tip**: Most users won't need to touch these — the defaults work great! Caching bypass and model-card overrides are opt-in.
+
+### 🛠️ Help: Applying a Model Override
+
+Use a model override when LiteLLM's `/model/info` response is missing or incorrectly reports a model capability. Overrides are disabled by default and must be enabled explicitly.
+
+1. Open **Preferences: Open User Settings (JSON)** or **Preferences: Open Workspace Settings (JSON)**.
+2. Set `litellm-connector.enableModelOverrides` to `true`.
+3. Add a rule to `litellm-connector.modelOverrides`. Match the raw LiteLLM `model_name` with a regular expression.
+4. Run **LiteLLM: Reload Models**.
+
+For reasoning metadata, use LiteLLM's exact snake_case model-card field names. Only fields included in the matching rule are changed; omitted fields remain exactly as LiteLLM reported them.
+
+```json
+{
+	"litellm-connector.enableModelOverrides": true,
+	"litellm-connector.modelOverrides": [
+		{
+			"match": "^gpt-4\\.8$",
+			"supports_reasoning": true,
+			"supports_max_reasoning_effort": true
+		}
+	]
+}
+```
+
+In this example, `supports_reasoning` and `supports_max_reasoning_effort` are replaced or added for `gpt-4.8`. Other fields, such as `supports_xhigh_reasoning_effort`, are not inferred or changed. To explicitly disable a field, set it to `false`; to replace a `null` value, define the field in the override.
+
+The rule can also define `defaultEffort`, but it does not replace the LiteLLM field-level behavior. Use `supports_low_reasoning_effort`, `supports_medium_reasoning_effort`, `supports_high_reasoning_effort`, `supports_xhigh_reasoning_effort`, or `supports_max_reasoning_effort` explicitly when those levels should be available.
 
 ### ⚡ Advanced / Hidden Settings (JSON-Only)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "litellm-connector-copilot",
 	"displayName": "LiteLLM Connector for Copilot",
-	"version": "2.2.1-dev2",
+	"version": "2.2.1",
 	"description": "An extension that integrates LiteLLM proxy into Copilot",
 	"categories": [
 		"AI",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "litellm-connector-copilot",
 	"displayName": "LiteLLM Connector for Copilot",
-	"version": "2.2.0",
+	"version": "2.2.1-dev2",
 	"description": "An extension that integrates LiteLLM proxy into Copilot",
 	"categories": [
 		"AI",
@@ -190,8 +190,8 @@
 				},
 				"litellm-connector.enableModelOverrides": {
 					"type": "boolean",
-					"default": true,
-					"markdownDescription": "Enable/disable the model override system. When enabled, merged user and bundled model override rules are applied. When disabled, only LiteLLM `/model/info` derived capabilities are used."
+					"default": false,
+					"markdownDescription": "Enable model-card overrides for matching models. When disabled, LiteLLM `/model/info` data is used unchanged. When enabled, only explicitly configured override fields replace incoming LiteLLM values."
 				},
 				"litellm-connector.displayPricingInPicker": {
 					"type": "boolean",

--- a/src/config/configManager.ts
+++ b/src/config/configManager.ts
@@ -140,7 +140,7 @@ export class ConfigManager {
             ConfigManager.DISABLE_QUOTA_TOOL_REDACTION_KEY,
             false
         );
-        const enableModelOverrides = workspaceConfig.get<boolean>(ConfigManager.KEY_MODEL_OVERRIDES_ENABLE, true);
+        const enableModelOverrides = workspaceConfig.get<boolean>(ConfigManager.KEY_MODEL_OVERRIDES_ENABLE, false);
         // modelOverrides are loaded but the LiteLLMConfig.modelOverrides field was
         // removed in v2.2.0 (dead plumbing — the override system reads the workspace
         // setting directly via modelOverrides.ts findOverride).

--- a/src/config/modelOverrides.ts
+++ b/src/config/modelOverrides.ts
@@ -1,5 +1,11 @@
 import * as vscode from "vscode";
-import type { LiteLLMModelInfo, ModelOverride, SupportedReasoningEffort } from "../types";
+import type {
+    LiteLLMModelInfo,
+    ModelOverride,
+    ReasoningModelInfoField,
+    ReasoningModelInfoPatch,
+    SupportedReasoningEffort,
+} from "../types";
 import { Logger } from "../utils/logger";
 import { getDefaultReasoningEffort } from "../utils/modelCapabilities";
 import bundledOverridesSource from "./modelOverrides.json";
@@ -25,25 +31,18 @@ const CANONICAL_REASONING_EFFORTS: readonly SupportedReasoningEffort[] = ["none"
 
 const CANONICAL_DEFAULT_EFFORT: SupportedReasoningEffort = "medium";
 
-const REASONING_EFFORT_ORDER: readonly SupportedReasoningEffort[] = [
-    "none",
-    "minimal",
-    "low",
-    "medium",
-    "high",
-    "xhigh",
-    "max",
-];
-
-function mergeReasoningEfforts(
-    baseline: readonly SupportedReasoningEffort[],
-    explicit: readonly SupportedReasoningEffort[]
-): SupportedReasoningEffort[] {
-    const supported = new Set<SupportedReasoningEffort>([...baseline, ...explicit]);
-    return REASONING_EFFORT_ORDER.filter((effort) => supported.has(effort));
-}
-
 const MODEL_OVERRIDES_SETTING_KEY = "litellm-connector.modelOverrides";
+
+const REASONING_MODEL_INFO_FIELDS: readonly ReasoningModelInfoField[] = [
+    "supports_reasoning",
+    "supports_none_reasoning_effort",
+    "supports_minimal_reasoning_effort",
+    "supports_low_reasoning_effort",
+    "supports_medium_reasoning_effort",
+    "supports_high_reasoning_effort",
+    "supports_xhigh_reasoning_effort",
+    "supports_max_reasoning_effort",
+];
 
 let bundledOverridesCache: ModelOverride[] | undefined;
 
@@ -76,15 +75,6 @@ export function toStringArray(value: unknown): string[] | undefined {
     return items.length > 0 ? items : undefined;
 }
 
-function normalizeEfforts(efforts: unknown): SupportedReasoningEffort[] | undefined {
-    if (!Array.isArray(efforts)) {
-        return undefined;
-    }
-
-    const normalized = efforts.filter(isSupportedReasoningEffort);
-    return normalized.length > 0 ? normalized : undefined;
-}
-
 function validateOverride(entry: unknown, source: string): ModelOverride | undefined {
     if (!entry || typeof entry !== "object") {
         Logger.warn(`[modelOverrides] Skipping invalid override from ${source}: not an object`);
@@ -105,14 +95,6 @@ function validateOverride(entry: unknown, source: string): ModelOverride | undef
         return undefined;
     }
 
-    const supportsReasoning =
-        candidate.supportsReasoning === true ||
-        candidate.supportsReasoning === false ||
-        candidate.supportsReasoning === null
-            ? candidate.supportsReasoning
-            : null;
-
-    const reasoningEfforts = normalizeEfforts(candidate.reasoningEfforts);
     const defaultEffort =
         candidate.defaultEffort && isSupportedReasoningEffort(candidate.defaultEffort)
             ? candidate.defaultEffort
@@ -120,8 +102,14 @@ function validateOverride(entry: unknown, source: string): ModelOverride | undef
 
     return {
         match: candidate.match,
-        supportsReasoning,
-        reasoningEfforts,
+        supports_reasoning: candidate.supports_reasoning,
+        supports_none_reasoning_effort: candidate.supports_none_reasoning_effort,
+        supports_minimal_reasoning_effort: candidate.supports_minimal_reasoning_effort,
+        supports_low_reasoning_effort: candidate.supports_low_reasoning_effort,
+        supports_medium_reasoning_effort: candidate.supports_medium_reasoning_effort,
+        supports_high_reasoning_effort: candidate.supports_high_reasoning_effort,
+        supports_xhigh_reasoning_effort: candidate.supports_xhigh_reasoning_effort,
+        supports_max_reasoning_effort: candidate.supports_max_reasoning_effort,
         defaultEffort,
         forceMandatory: candidate.forceMandatory === true,
         tags: toStringArray(candidate.tags),
@@ -169,7 +157,7 @@ export function getMergedOverrides(config?: vscode.WorkspaceConfiguration): Mode
 
 export function findOverride(modelId: string, config?: vscode.WorkspaceConfiguration): ModelOverride | undefined {
     const workspaceConfig = config ?? vscode.workspace.getConfiguration();
-    const enableModelOverrides = workspaceConfig.get<boolean>("litellm-connector.enableModelOverrides", true);
+    const enableModelOverrides = workspaceConfig.get<boolean>("litellm-connector.enableModelOverrides", false);
     if (!enableModelOverrides) {
         return undefined;
     }
@@ -188,6 +176,31 @@ export function findOverride(modelId: string, config?: vscode.WorkspaceConfigura
     }
 
     return undefined;
+}
+
+export function applyModelInfoOverrides(
+    modelId: string,
+    modelInfo: LiteLLMModelInfo | undefined,
+    config?: vscode.WorkspaceConfiguration
+): LiteLLMModelInfo | undefined {
+    if (!modelInfo) {
+        return modelInfo;
+    }
+
+    const override = findOverride(modelId, config);
+    if (!override) {
+        return modelInfo;
+    }
+
+    const patch: ReasoningModelInfoPatch = {};
+    for (const field of REASONING_MODEL_INFO_FIELDS) {
+        const value = override[field];
+        if (value !== undefined) {
+            patch[field] = value;
+        }
+    }
+
+    return Object.keys(patch).length > 0 ? { ...modelInfo, ...patch } : modelInfo;
 }
 
 function getExplicitReasoningEfforts(modelInfo?: LiteLLMModelInfo): SupportedReasoningEffort[] | undefined {
@@ -214,76 +227,28 @@ export function getEffectiveEfforts(
     config?: vscode.WorkspaceConfiguration,
     forceMandatory?: boolean
 ): readonly SupportedReasoningEffort[] {
+    const patchedModelInfo = applyModelInfoOverrides(modelId, modelInfo, config);
     const override = findOverride(modelId, config);
-    const overrideEfforts = override?.reasoningEfforts;
-
-    // Force-mandatory request parameter should win regardless of LiteLLM data
-    if (forceMandatory && override) {
-        if (override.supportsReasoning === false) {
-            return [];
-        }
-        return overrideEfforts ?? [...CANONICAL_REASONING_EFFORTS];
+    if (forceMandatory && override?.forceMandatory) {
+        return getEffectiveEffortsFromModelInfo({
+            ...patchedModelInfo,
+            supports_reasoning: true,
+        });
     }
+    return getEffectiveEffortsFromModelInfo(patchedModelInfo);
+}
 
-    if (modelInfo?.supports_reasoning === false) {
+function getEffectiveEffortsFromModelInfo(modelInfo?: LiteLLMModelInfo): readonly SupportedReasoningEffort[] {
+    if (!modelInfo || modelInfo.supports_reasoning === false) {
         return [];
     }
 
-    // Explicit LiteLLM effort fields are authoritative, including an explicit
-    // all-false set. Do this before the generic supports_reasoning fallback so
-    // metadata cannot be broadened into the canonical effort ladder.
-    const explicitEfforts = getExplicitReasoningEfforts(modelInfo)
-        ?.filter(isSupportedReasoningEffort)
-        .filter((effort, index, arr) => arr.indexOf(effort) === index);
-
-    if (override?.supportsReasoning === false) {
-        return [];
-    }
-
-    if (override?.forceMandatory) {
-        return overrideEfforts ?? [...CANONICAL_REASONING_EFFORTS];
-    }
-
+    const explicitEfforts = getExplicitReasoningEfforts(modelInfo);
     if (explicitEfforts !== undefined) {
-        // Explicit false metadata remains authoritative: an all-false response means
-        // LiteLLM has explicitly disabled every level. Partial true metadata is
-        // additive because LiteLLM can omit otherwise valid baseline levels.
-        if (explicitEfforts.length === 0) {
-            return [];
-        }
-
-        if (modelInfo?.supports_reasoning === true) {
-            return mergeReasoningEfforts(CANONICAL_REASONING_EFFORTS, explicitEfforts);
-        }
-
         return explicitEfforts;
     }
 
-    if (override) {
-        // Non-mandatory overrides do not apply when LiteLLM has valid capability data.
-        // Models with supports_reasoning: true but no explicit effort flags fall back to
-        // canonical efforts, allowing the caller to use DEFAULT_REASONING_EFFORTS or
-        // enforce explicit flags based on their own logic.
-
-        // Next priority: Generic reasoning support flag.
-        if (modelInfo?.supports_reasoning) {
-            return [...CANONICAL_REASONING_EFFORTS];
-        }
-
-        // If there is no model info but override explicitly marks reasoning support,
-        // allow the override to provide canonical efforts.
-        if (override.supportsReasoning === true) {
-            return overrideEfforts ?? [...CANONICAL_REASONING_EFFORTS];
-        }
-
-        return [];
-    }
-
-    if (modelInfo?.supports_reasoning) {
-        return [...CANONICAL_REASONING_EFFORTS];
-    }
-
-    return [];
+    return modelInfo.supports_reasoning === true ? [...CANONICAL_REASONING_EFFORTS] : [];
 }
 
 export function getDefaultEffort(
@@ -291,32 +256,25 @@ export function getDefaultEffort(
     modelInfo?: LiteLLMModelInfo,
     config?: vscode.WorkspaceConfiguration
 ): SupportedReasoningEffort | undefined {
-    if (modelInfo?.supports_reasoning === false) {
+    const patchedModelInfo = applyModelInfoOverrides(modelId, modelInfo, config);
+    if (patchedModelInfo?.supports_reasoning === false) {
         return undefined;
     }
 
     const override = findOverride(modelId, config);
 
     if (override) {
-        if (override.supportsReasoning === false) {
-            return undefined;
-        }
-
         if (override.defaultEffort) {
             return override.defaultEffort;
         }
 
-        const efforts = override.reasoningEfforts ?? CANONICAL_REASONING_EFFORTS;
-        if (override.supportsReasoning === true || modelInfo?.supports_reasoning) {
-            if (efforts.includes(CANONICAL_DEFAULT_EFFORT)) {
-                return CANONICAL_DEFAULT_EFFORT;
-            }
-            return getDefaultReasoningEffort(efforts) ?? CANONICAL_DEFAULT_EFFORT;
-        }
-        return undefined;
+        const efforts = getEffectiveEffortsFromModelInfo(patchedModelInfo);
+        return efforts.includes(CANONICAL_DEFAULT_EFFORT)
+            ? CANONICAL_DEFAULT_EFFORT
+            : getDefaultReasoningEffort(efforts);
     }
 
-    if (modelInfo?.supports_reasoning) {
+    if (patchedModelInfo?.supports_reasoning) {
         return CANONICAL_DEFAULT_EFFORT;
     }
 

--- a/src/config/modelOverrides.ts
+++ b/src/config/modelOverrides.ts
@@ -21,7 +21,11 @@ const LITELLM_REASONING_EFFORT_MAPPING: Record<string, SupportedReasoningEffort>
     supports_max_reasoning_effort: "max",
 } as const satisfies Record<string, SupportedReasoningEffort>;
 
-const CANONICAL_REASONING_EFFORTS: readonly SupportedReasoningEffort[] = [
+const CANONICAL_REASONING_EFFORTS: readonly SupportedReasoningEffort[] = ["none", "low", "medium", "high"];
+
+const CANONICAL_DEFAULT_EFFORT: SupportedReasoningEffort = "medium";
+
+const REASONING_EFFORT_ORDER: readonly SupportedReasoningEffort[] = [
     "none",
     "minimal",
     "low",
@@ -31,7 +35,13 @@ const CANONICAL_REASONING_EFFORTS: readonly SupportedReasoningEffort[] = [
     "max",
 ];
 
-const CANONICAL_DEFAULT_EFFORT: SupportedReasoningEffort = "medium";
+function mergeReasoningEfforts(
+    baseline: readonly SupportedReasoningEffort[],
+    explicit: readonly SupportedReasoningEffort[]
+): SupportedReasoningEffort[] {
+    const supported = new Set<SupportedReasoningEffort>([...baseline, ...explicit]);
+    return REASONING_EFFORT_ORDER.filter((effort) => supported.has(effort));
+}
 
 const MODEL_OVERRIDES_SETTING_KEY = "litellm-connector.modelOverrides";
 
@@ -235,6 +245,17 @@ export function getEffectiveEfforts(
     }
 
     if (explicitEfforts !== undefined) {
+        // Explicit false metadata remains authoritative: an all-false response means
+        // LiteLLM has explicitly disabled every level. Partial true metadata is
+        // additive because LiteLLM can omit otherwise valid baseline levels.
+        if (explicitEfforts.length === 0) {
+            return [];
+        }
+
+        if (modelInfo?.supports_reasoning === true) {
+            return mergeReasoningEfforts(CANONICAL_REASONING_EFFORTS, explicitEfforts);
+        }
+
         return explicitEfforts;
     }
 

--- a/src/config/test/modelOverrides.test.ts
+++ b/src/config/test/modelOverrides.test.ts
@@ -12,7 +12,7 @@ import {
 import type { LiteLLMModelInfo } from "../../types";
 import { Logger } from "../../utils/logger";
 
-const CANONICAL_REASONING_EFFORTS = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+const CANONICAL_REASONING_EFFORTS = ["none", "low", "medium", "high"] as const;
 
 suite("modelOverrides", () => {
     let getConfigurationStub: sinon.SinonStub;
@@ -120,6 +120,28 @@ suite("modelOverrides", () => {
 
         assert.deepStrictEqual(supported, CANONICAL_REASONING_EFFORTS);
         assert.deepStrictEqual(unsupported, []);
+    });
+
+    test("merges partial explicit LiteLLM efforts into the canonical fallback", () => {
+        getConfigurationStub.returns(buildWorkspaceConfiguration([]));
+        const modelInfo: LiteLLMModelInfo = {
+            supports_reasoning: true,
+            supports_none_reasoning_effort: true,
+            supports_minimal_reasoning_effort: null,
+            supports_low_reasoning_effort: null,
+            supports_medium_reasoning_effort: null,
+            supports_high_reasoning_effort: null,
+            supports_xhigh_reasoning_effort: true,
+            supports_max_reasoning_effort: null,
+        };
+
+        assert.deepStrictEqual(getEffectiveEfforts("luna-model", modelInfo), [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+        ]);
     });
 
     test("accepts all supported reasoning effort values in user overrides", () => {

--- a/src/config/test/modelOverrides.test.ts
+++ b/src/config/test/modelOverrides.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
 import {
+    applyModelInfoOverrides,
     findOverride,
     getDefaultEffort,
     getEffectiveEfforts,
@@ -61,8 +62,9 @@ suite("modelOverrides", () => {
         const userOverrides: ModelOverride[] = [
             {
                 match: "^[Gg][Pp][Tt].*",
-                supportsReasoning: true,
-                reasoningEfforts: ["none", "low"],
+                supports_reasoning: true,
+                supports_none_reasoning_effort: true,
+                supports_low_reasoning_effort: true,
                 defaultEffort: "none",
             },
         ];
@@ -73,16 +75,17 @@ suite("modelOverrides", () => {
 
         assert.ok(override, "user override should be matched first");
         assert.strictEqual(override?.defaultEffort, "none");
-        assert.deepStrictEqual(override?.reasoningEfforts, ["none", "low"]);
+        assert.strictEqual(override?.supports_none_reasoning_effort, true);
     });
 
     test("invalid user override is skipped with a warning and does not crash", async () => {
         const userOverrides: unknown[] = [
-            { match: "(", supportsReasoning: true },
+            { match: "(", supports_reasoning: true },
             {
                 match: ".*",
-                supportsReasoning: true,
-                reasoningEfforts: ["none", "low"],
+                supports_reasoning: true,
+                supports_none_reasoning_effort: true,
+                supports_low_reasoning_effort: true,
                 defaultEffort: "low",
             },
         ];
@@ -122,7 +125,7 @@ suite("modelOverrides", () => {
         assert.deepStrictEqual(unsupported, []);
     });
 
-    test("merges partial explicit LiteLLM efforts into the canonical fallback", () => {
+    test("preserves partial explicit LiteLLM efforts without inferring siblings", () => {
         getConfigurationStub.returns(buildWorkspaceConfiguration([]));
         const modelInfo: LiteLLMModelInfo = {
             supports_reasoning: true,
@@ -135,20 +138,20 @@ suite("modelOverrides", () => {
             supports_max_reasoning_effort: null,
         };
 
-        assert.deepStrictEqual(getEffectiveEfforts("luna-model", modelInfo), [
-            "none",
-            "low",
-            "medium",
-            "high",
-            "xhigh",
-        ]);
+        assert.deepStrictEqual(getEffectiveEfforts("luna-model", modelInfo), ["none", "xhigh"]);
     });
 
     test("accepts all supported reasoning effort values in user overrides", () => {
         const userOverride: ModelOverride = {
             match: "^test-model$",
-            supportsReasoning: true,
-            reasoningEfforts: ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+            supports_reasoning: true,
+            supports_none_reasoning_effort: true,
+            supports_minimal_reasoning_effort: true,
+            supports_low_reasoning_effort: true,
+            supports_medium_reasoning_effort: true,
+            supports_high_reasoning_effort: true,
+            supports_xhigh_reasoning_effort: true,
+            supports_max_reasoning_effort: true,
             defaultEffort: "max",
         };
         getConfigurationStub.returns(buildWorkspaceConfiguration([userOverride]));
@@ -156,7 +159,7 @@ suite("modelOverrides", () => {
         const override = findOverride("test-model");
 
         assert.ok(override);
-        assert.deepStrictEqual(override?.reasoningEfforts, userOverride.reasoningEfforts);
+        assert.strictEqual(override?.supports_max_reasoning_effort, true);
         assert.strictEqual(override?.defaultEffort, "max");
     });
 
@@ -191,7 +194,7 @@ suite("modelOverrides", () => {
     test("forceMandatory override returns values even when LiteLLM has data", async () => {
         const override: ModelOverride = {
             match: "^test-.*",
-            reasoningEfforts: ["high"],
+            supports_high_reasoning_effort: true,
             forceMandatory: true,
         };
         getConfigurationStub.returns(buildWorkspaceConfiguration([override]));
@@ -208,7 +211,7 @@ suite("modelOverrides", () => {
     test("non-mandatory override is ignored when LiteLLM has valid data", async () => {
         const override: ModelOverride = {
             match: "^test-.*",
-            reasoningEfforts: ["high"],
+            supports_high_reasoning_effort: true,
             forceMandatory: false,
         };
         getConfigurationStub.returns(buildWorkspaceConfiguration([override]));
@@ -220,15 +223,16 @@ suite("modelOverrides", () => {
         const result = getEffectiveEfforts("test-model", modelInfo);
         // If LiteLLM has valid data, returns enumeration. When supports_reasoning is true
         // but no effort flags are set, falls back to DEFAULT_REASONING_EFFORTS.
-        assert.deepStrictEqual(result, CANONICAL_REASONING_EFFORTS);
+        assert.deepStrictEqual(result, ["high"]);
     });
 
     test("findOverride returns undefined when enableModelOverrides is false", () => {
         const userOverrides: ModelOverride[] = [
             {
                 match: "^[Gg][Pp][Tt].*",
-                supportsReasoning: true,
-                reasoningEfforts: ["none", "low"],
+                supports_reasoning: true,
+                supports_none_reasoning_effort: true,
+                supports_low_reasoning_effort: true,
                 defaultEffort: "none",
             },
         ];
@@ -243,8 +247,8 @@ suite("modelOverrides", () => {
         const userOverrides: ModelOverride[] = [
             {
                 match: "^test-.*",
-                supportsReasoning: true,
-                reasoningEfforts: ["high"],
+                supports_reasoning: true,
+                supports_high_reasoning_effort: true,
                 defaultEffort: "high",
                 forceMandatory: true,
             },
@@ -263,7 +267,7 @@ suite("modelOverrides", () => {
         const userOverrides: ModelOverride[] = [
             {
                 match: "^test-.*",
-                supportsReasoning: true,
+                supports_reasoning: true,
                 defaultEffort: "high",
             },
         ];
@@ -274,5 +278,80 @@ suite("modelOverrides", () => {
         // Override defaultEffort of "high" should be ignored; falls through to model info path.
         // With supports_reasoning: true and no override, returns CANONICAL_DEFAULT_EFFORT ("medium").
         assert.strictEqual(result, "medium");
+    });
+
+    test("does not override LiteLLM reasoning fields when model overrides are disabled", () => {
+        const override = {
+            match: "^gpt-4\\.8$",
+            supports_reasoning: true,
+            supports_max_reasoning_effort: true,
+            defaultEffort: "max",
+        } as ModelOverride;
+
+        getConfigurationStub.returns(buildWorkspaceConfiguration([override], false));
+
+        const modelInfo: LiteLLMModelInfo = {
+            supports_reasoning: false,
+            supports_max_reasoning_effort: false,
+        };
+
+        assert.deepStrictEqual(applyModelInfoOverrides("gpt-4.8", modelInfo), modelInfo);
+    });
+
+    test("replaces only explicitly overridden reasoning fields", () => {
+        const override = {
+            match: "^gpt-4\\.8$",
+            supports_reasoning: true,
+            supports_max_reasoning_effort: true,
+        } as ModelOverride;
+
+        getConfigurationStub.returns(buildWorkspaceConfiguration([override]));
+
+        const modelInfo: LiteLLMModelInfo = {
+            supports_reasoning: false,
+            supports_max_reasoning_effort: false,
+            supports_xhigh_reasoning_effort: null,
+            supports_low_reasoning_effort: true,
+        };
+
+        const result = applyModelInfoOverrides("gpt-4.8", modelInfo);
+
+        assert.strictEqual(result?.supports_reasoning, true);
+        assert.strictEqual(result?.supports_max_reasoning_effort, true);
+        assert.strictEqual(result?.supports_xhigh_reasoning_effort, null);
+        assert.strictEqual(result?.supports_low_reasoning_effort, true);
+    });
+
+    test("adds explicitly overridden fields absent from LiteLLM model data", () => {
+        const override = {
+            match: "^gpt-4\\.8$",
+            supports_max_reasoning_effort: true,
+        } as ModelOverride;
+
+        getConfigurationStub.returns(buildWorkspaceConfiguration([override]));
+
+        const result = applyModelInfoOverrides("gpt-4.8", { supports_reasoning: true });
+
+        assert.strictEqual(result?.supports_max_reasoning_effort, true);
+        assert.strictEqual(result?.supports_reasoning, true);
+        assert.strictEqual(result?.supports_xhigh_reasoning_effort, undefined);
+    });
+
+    test("preserves null and does not infer sister reasoning fields", () => {
+        const override = {
+            match: "^gpt-4\\.8$",
+            supports_max_reasoning_effort: true,
+        } as ModelOverride;
+
+        getConfigurationStub.returns(buildWorkspaceConfiguration([override]));
+
+        const result = applyModelInfoOverrides("gpt-4.8", {
+            supports_reasoning: null,
+            supports_xhigh_reasoning_effort: null,
+        });
+
+        assert.strictEqual(result?.supports_reasoning, null);
+        assert.strictEqual(result?.supports_xhigh_reasoning_effort, null);
+        assert.strictEqual(result?.supports_max_reasoning_effort, true);
     });
 });

--- a/src/providers/liteLLMProviderRegistry.ts
+++ b/src/providers/liteLLMProviderRegistry.ts
@@ -75,6 +75,7 @@ import {
 } from "../utils/modelCapabilities";
 import { deriveGroupNameFromUrl } from "../utils";
 import { sha256HexAsync } from "../utils/discoveryHash";
+import { applyModelInfoOverrides } from "../config/modelOverrides";
 import type { LiteLLMConfig, LiteLLMModelInfo, LiteLLMModelInfoResponse } from "../types";
 import type { ConfigManager } from "../config/configManager";
 import type { BackendSession } from "./backendSession";
@@ -722,7 +723,7 @@ export class LiteLLMProviderRegistry implements vscode.Disposable {
         // disambiguates them. The `name` shown to the user in the model
         // picker stays as the raw model_name (no namespace leak).
         const modelId = routingIdentity.length > 0 ? `${routingIdentity}/${modelName}` : modelName;
-        let modelInfo = entry.model_info;
+        let modelInfo = applyModelInfoOverrides(modelName, entry.model_info);
         if (forceResponsesEndpoint && modelInfo?.mode === "chat") {
             modelInfo = { ...modelInfo, mode: "responses" as const };
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,16 +95,33 @@ export interface ModelCapabilityOverride {
 
 export type SupportedReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 
+export type ReasoningModelInfoField =
+    | "supports_reasoning"
+    | "supports_none_reasoning_effort"
+    | "supports_minimal_reasoning_effort"
+    | "supports_low_reasoning_effort"
+    | "supports_medium_reasoning_effort"
+    | "supports_high_reasoning_effort"
+    | "supports_xhigh_reasoning_effort"
+    | "supports_max_reasoning_effort";
+
+export type ReasoningModelInfoPatch = Partial<Pick<LiteLLMModelInfo, ReasoningModelInfoField>>;
+
 export interface ModelOverride {
     /** Regex pattern to match model IDs */
     match: string;
-    /** Override for supports_reasoning */
-    supportsReasoning?: boolean | null;
-    /** Override for supported reasoning efforts */
-    reasoningEfforts?: SupportedReasoningEffort[];
+    /** Exact LiteLLM reasoning model-card fields to replace or append */
+    supports_reasoning?: boolean | null;
+    supports_none_reasoning_effort?: boolean | null;
+    supports_minimal_reasoning_effort?: boolean | null;
+    supports_low_reasoning_effort?: boolean | null;
+    supports_medium_reasoning_effort?: boolean | null;
+    supports_high_reasoning_effort?: boolean | null;
+    supports_xhigh_reasoning_effort?: boolean | null;
+    supports_max_reasoning_effort?: boolean | null;
     /** Default reasoning effort when reasoning is supported */
     defaultEffort?: SupportedReasoningEffort;
-    /** Force this override to be mandatory (ignore remote LiteLLM values) */
+    /** Force this override to be mandatory for request-time fallback selection */
     forceMandatory?: boolean;
     /** Custom tags to add to model */
     tags?: string[];
@@ -147,7 +164,7 @@ export interface LiteLLMConfig {
      * Enable/disable the model override system.
      * When enabled, merged user and bundled model override rules are applied.
      * When disabled, only LiteLLM /model/info derived capabilities are used.
-     * Default: true (backwards compatible).
+     * Default: false (opt-in).
      */
     enableModelOverrides?: boolean;
     /**

--- a/src/utils/modelCapabilities.ts
+++ b/src/utils/modelCapabilities.ts
@@ -184,17 +184,10 @@ const LITELLM_REASONING_EFFORT_MAPPING: Record<string, SupportedReasoningEffort>
 /**
  * Default supported reasoning efforts when model explicitly supports reasoning
  * but doesn't specify exact effort levels (supports_reasoning: true).
- * Uses a conservative set to avoid unsupported effort flags being exposed in the UI.
+ * This is the 2.1.9 fallback. Additional effort values are exposed only when
+ * LiteLLM explicitly reports their corresponding support field as true.
  */
-const DEFAULT_REASONING_EFFORTS: readonly SupportedReasoningEffort[] = [
-    "none",
-    "minimal",
-    "low",
-    "medium",
-    "high",
-    "xhigh",
-    "max",
-];
+const DEFAULT_REASONING_EFFORTS: readonly SupportedReasoningEffort[] = ["none", "low", "medium", "high"];
 
 /**
  * Type definition for extended properties on LanguageModelChatInformation.
@@ -235,6 +228,12 @@ function hasReasoningSignal(modelInfo?: LiteLLMModelInfo): boolean {
     );
 }
 
+function hasExplicitlyDisabledReasoningEffort(modelInfo: LiteLLMModelInfo): boolean {
+    return Object.keys(LITELLM_REASONING_EFFORT_MAPPING).some(
+        (key) => modelInfo[key as keyof LiteLLMModelInfo] === false
+    );
+}
+
 /**
  * Check if a model explicitly supports the reasoning_effort parameter in its
  * OpenAI-compatible params list.
@@ -271,17 +270,16 @@ export function getSupportedReasoningEfforts(
         return [];
     }
 
-    // Explicit false means no reasoning support unless overrides force it
-    if (modelInfo?.supports_reasoning === false) {
+    // Explicit false means no reasoning support unless overrides force it.
+    if (modelInfo.supports_reasoning === false) {
         if (modelId) {
             const overrideEfforts = getEffectiveEfforts(modelId, modelInfo, config);
             if (overrideEfforts.length > 0) {
                 return overrideEfforts;
             }
         }
-        // Still check for explicit effort fields as some models may have them
         const explicitEfforts = extractExplicitReasoningEfforts(modelInfo);
-        if (explicitEfforts !== undefined) {
+        if (explicitEfforts.length > 0) {
             return explicitEfforts;
         }
         return [];
@@ -295,7 +293,11 @@ export function getSupportedReasoningEfforts(
     // treat it as unknown and do not block effort exposure.
     const paramStatus = reasoningEffortParamStatus(modelInfo);
     const explicitEfforts = extractExplicitReasoningEfforts(modelInfo);
-    if (paramStatus === false && explicitEfforts === undefined) {
+    if (explicitEfforts.length === 0 && hasExplicitlyDisabledReasoningEffort(modelInfo)) {
+        return [];
+    }
+
+    if (paramStatus === false && explicitEfforts.length === 0) {
         // reasoning_effort explicitly excluded and no fine-grained effort fields — hide picker
         return [];
     }
@@ -307,7 +309,7 @@ export function getSupportedReasoningEfforts(
         overrideEfforts = getEffectiveEfforts(modelId, modelInfo, config);
     }
 
-    if (explicitEfforts !== undefined) {
+    if (explicitEfforts.length > 0) {
         // If overrides provide a broader or different ladder, prefer them when non-empty
         if (overrideEfforts.length > 0) {
             return overrideEfforts;
@@ -331,37 +333,21 @@ export function getSupportedReasoningEfforts(
  * Extract reasoning efforts from explicit effort level fields in LiteLLM model info.
  * Example: supports_high_reasoning_effort: true → includes "high"
  */
-function extractExplicitReasoningEfforts(modelInfo?: LiteLLMModelInfo): SupportedReasoningEffort[] | undefined {
+function extractExplicitReasoningEfforts(modelInfo?: LiteLLMModelInfo): SupportedReasoningEffort[] {
     if (!modelInfo) {
-        return undefined;
+        return [];
     }
 
     const efforts = new Set<SupportedReasoningEffort>();
-    let hasExplicitField = false;
     for (const [key, effortValue] of Object.entries(LITELLM_REASONING_EFFORT_MAPPING)) {
         const value = modelInfo[key as keyof LiteLLMModelInfo];
-        if (value !== undefined && value !== null) {
-            hasExplicitField = true;
-        }
         if (value === true) {
             efforts.add(effortValue);
         }
     }
 
-    if (!hasExplicitField) {
-        return undefined;
-    }
-
-    const effortOrder: readonly SupportedReasoningEffort[] = [
-        "none",
-        "minimal",
-        "low",
-        "medium",
-        "high",
-        "xhigh",
-        "max",
-    ];
-    return effortOrder.filter((e) => efforts.has(e));
+    const effortOrder: SupportedReasoningEffort[] = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+    return effortOrder.filter((effort) => efforts.has(effort));
 }
 
 export function getDefaultReasoningEffort(

--- a/src/utils/test/modelCapabilities.reasoning-overhaul.test.ts
+++ b/src/utils/test/modelCapabilities.reasoning-overhaul.test.ts
@@ -52,7 +52,7 @@ suite("modelCapabilities - Reasoning Overhaul", () => {
             assert.deepStrictEqual(result, ["none", "minimal", "low", "medium", "high", "xhigh", "max"]);
         });
 
-        test("merges partial explicit efforts with the baseline picker ladder", () => {
+        test("preserves only explicitly supported effort fields", () => {
             const modelInfo: LiteLLMModelInfo = {
                 supports_reasoning: true,
                 supports_none_reasoning_effort: true,
@@ -67,7 +67,7 @@ suite("modelCapabilities - Reasoning Overhaul", () => {
 
             const result = getSupportedReasoningEfforts(modelInfo, "luna-model");
 
-            assert.deepStrictEqual(result, ["none", "low", "medium", "high", "xhigh"]);
+            assert.deepStrictEqual(result, ["none", "xhigh"]);
         });
 
         test("does not infer effort support from null fields", () => {

--- a/src/utils/test/modelCapabilities.reasoning-overhaul.test.ts
+++ b/src/utils/test/modelCapabilities.reasoning-overhaul.test.ts
@@ -24,6 +24,7 @@ suite("modelCapabilities - Reasoning Overhaul", () => {
 
         test("extracts explicit reasoning effort fields from LiteLLM", () => {
             const modelInfo: LiteLLMModelInfo = {
+                supports_reasoning: true,
                 supports_high_reasoning_effort: true,
                 supports_low_reasoning_effort: true,
                 supported_openai_params: ["stream", "reasoning_effort"],
@@ -31,6 +32,70 @@ suite("modelCapabilities - Reasoning Overhaul", () => {
             const result = getSupportedReasoningEfforts(modelInfo, "test-model");
             assert.ok(result.includes("high"));
             assert.ok(result.includes("low"));
+        });
+
+        test("extracts all explicitly supported expanded effort fields", () => {
+            const modelInfo: LiteLLMModelInfo = {
+                supports_reasoning: true,
+                supports_none_reasoning_effort: true,
+                supports_minimal_reasoning_effort: true,
+                supports_low_reasoning_effort: true,
+                supports_medium_reasoning_effort: true,
+                supports_high_reasoning_effort: true,
+                supports_xhigh_reasoning_effort: true,
+                supports_max_reasoning_effort: true,
+                supported_openai_params: ["stream", "reasoning_effort"],
+            };
+
+            const result = getSupportedReasoningEfforts(modelInfo, "test-model");
+
+            assert.deepStrictEqual(result, ["none", "minimal", "low", "medium", "high", "xhigh", "max"]);
+        });
+
+        test("merges partial explicit efforts with the baseline picker ladder", () => {
+            const modelInfo: LiteLLMModelInfo = {
+                supports_reasoning: true,
+                supports_none_reasoning_effort: true,
+                supports_minimal_reasoning_effort: null,
+                supports_low_reasoning_effort: null,
+                supports_medium_reasoning_effort: null,
+                supports_high_reasoning_effort: null,
+                supports_xhigh_reasoning_effort: true,
+                supports_max_reasoning_effort: null,
+                supported_openai_params: ["stream", "reasoning_effort"],
+            };
+
+            const result = getSupportedReasoningEfforts(modelInfo, "luna-model");
+
+            assert.deepStrictEqual(result, ["none", "low", "medium", "high", "xhigh"]);
+        });
+
+        test("does not infer effort support from null fields", () => {
+            const modelInfo: LiteLLMModelInfo = {
+                supports_reasoning: true,
+                supports_none_reasoning_effort: null,
+                supports_minimal_reasoning_effort: null,
+                supports_low_reasoning_effort: null,
+                supports_medium_reasoning_effort: null,
+                supports_high_reasoning_effort: null,
+                supports_xhigh_reasoning_effort: null,
+                supports_max_reasoning_effort: null,
+                supported_openai_params: ["reasoning_effort"],
+            };
+
+            const result = getSupportedReasoningEfforts(modelInfo, "test-model");
+
+            assert.deepStrictEqual(result, ["none", "low", "medium", "high"]);
+        });
+
+        test("preserves the baseline behavior for an explicit effort when supports_reasoning is null", () => {
+            const modelInfo: LiteLLMModelInfo = {
+                supports_reasoning: null,
+                supports_none_reasoning_effort: true,
+                supported_openai_params: ["reasoning_effort"],
+            };
+
+            assert.deepStrictEqual(getSupportedReasoningEfforts(modelInfo, "test-model"), ["none"]);
         });
 
         test("extracts the explicit none reasoning effort field", () => {
@@ -62,7 +127,7 @@ suite("modelCapabilities - Reasoning Overhaul", () => {
             assert.deepStrictEqual(result, []);
         });
 
-        test("uses every supported effort in the generic reasoning fallback", () => {
+        test("uses the four-value generic reasoning fallback", () => {
             const modelInfo: LiteLLMModelInfo = {
                 supports_reasoning: true,
                 supported_openai_params: ["reasoning_effort"],
@@ -70,17 +135,7 @@ suite("modelCapabilities - Reasoning Overhaul", () => {
 
             const result = getSupportedReasoningEfforts(modelInfo, "test-model");
 
-            assert.deepStrictEqual(result, ["none", "minimal", "low", "medium", "high", "xhigh", "max"]);
-        });
-
-        test("treats null values as undefined (not false)", () => {
-            const modelInfo: LiteLLMModelInfo = {
-                supports_reasoning: null, // should be treated as undefined
-                supported_openai_params: null, // should be treated as undefined
-                supports_high_reasoning_effort: true,
-            };
-            const result = getSupportedReasoningEfforts(modelInfo, "test-model");
-            assert.ok(result.includes("high"));
+            assert.deepStrictEqual(result, ["none", "low", "medium", "high"]);
         });
 
         test("uses DEFAULT_REASONING_EFFORTS when only supports_reasoning is true", () => {

--- a/src/utils/test/modelCapabilities.test.ts
+++ b/src/utils/test/modelCapabilities.test.ts
@@ -362,26 +362,6 @@ suite("modelCapabilities", () => {
     });
 
     suite("getSupportedReasoningEfforts", () => {
-        const canonicalGpt5Efforts: SupportedReasoningEffort[] = [
-            "none",
-            "minimal",
-            "low",
-            "medium",
-            "high",
-            "xhigh",
-            "max",
-        ];
-        const claudeEfforts: SupportedReasoningEffort[] = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
-        const canonicalCatchAllEfforts: SupportedReasoningEffort[] = [
-            "none",
-            "minimal",
-            "low",
-            "medium",
-            "high",
-            "xhigh",
-            "max",
-        ];
-
         test("returns empty array when supports_reasoning is true but reasoning_effort not in supported_openai_params", () => {
             const modelInfo: LiteLLMModelInfo = {
                 supports_reasoning: true,
@@ -418,30 +398,73 @@ suite("modelCapabilities", () => {
             assert.ok(result.includes("high"), "should include high");
         });
 
-        test("returns the canonical GPT-5 effort ladder for gpt-5-mini", () => {
+        test("recognizes all expanded explicit reasoning effort fields", () => {
             const modelInfo: LiteLLMModelInfo = {
-                id: "gpt-5-mini",
-                name: "GPT-5 Mini",
                 supports_reasoning: true,
+                supports_none_reasoning_effort: true,
+                supports_minimal_reasoning_effort: true,
+                supports_low_reasoning_effort: true,
+                supports_medium_reasoning_effort: true,
+                supports_high_reasoning_effort: true,
+                supports_xhigh_reasoning_effort: true,
+                supports_max_reasoning_effort: true,
+                supported_openai_params: ["reasoning_effort"],
             };
 
-            const result = getSupportedReasoningEfforts(modelInfo, "gpt-5-mini");
-
-            assert.deepStrictEqual(result, canonicalGpt5Efforts);
+            assert.deepStrictEqual(getSupportedReasoningEfforts(modelInfo, "test-model"), [
+                "none",
+                "minimal",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max",
+            ]);
         });
 
-        test("returns only efforts that are explicitly supported", () => {
+        test("keeps baseline efforts when LiteLLM reports a partial explicit set", () => {
             const modelInfo: LiteLLMModelInfo = {
-                id: "gpt-5.4-mini",
-                name: "GPT-5.4 Mini",
                 supports_reasoning: true,
+                supports_none_reasoning_effort: true,
+                supports_minimal_reasoning_effort: null,
+                supports_low_reasoning_effort: null,
+                supports_medium_reasoning_effort: null,
+                supports_high_reasoning_effort: null,
                 supports_xhigh_reasoning_effort: true,
+                supports_max_reasoning_effort: null,
+                supported_openai_params: ["reasoning_effort"],
             };
 
-            const result = getSupportedReasoningEfforts(modelInfo, "gpt-5.4-mini");
+            assert.deepStrictEqual(getSupportedReasoningEfforts(modelInfo, "luna-model"), [
+                "none",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+            ]);
+        });
 
-            // Only xhigh is explicitly supported; explicit fields take precedence over the default ladder.
-            assert.deepStrictEqual(result, ["xhigh"]);
+        test("returns the generic fallback ladder when no explicit fields are present", () => {
+            const modelInfo: LiteLLMModelInfo = {
+                supports_reasoning: true,
+            };
+
+            const result = getSupportedReasoningEfforts(modelInfo, "test-model");
+
+            assert.deepStrictEqual(result, ["none", "low", "medium", "high"]);
+        });
+
+        test("merges an explicitly supported extension with the generic fallback", () => {
+            const modelInfo: LiteLLMModelInfo = {
+                id: "test-model",
+                supports_reasoning: true,
+                supports_xhigh_reasoning_effort: true,
+                supported_openai_params: ["reasoning_effort"],
+            };
+
+            const result = getSupportedReasoningEfforts(modelInfo, "test-model");
+
+            assert.deepStrictEqual(result, ["none", "low", "medium", "high", "xhigh"]);
         });
 
         test("recognizes supports_none_reasoning_effort without broadening the result", () => {
@@ -451,30 +474,6 @@ suite("modelCapabilities", () => {
             };
 
             assert.deepStrictEqual(getSupportedReasoningEfforts(modelInfo, "test-model"), ["none"]);
-        });
-
-        test("returns Claude ladder for claude-haiku-4-5", () => {
-            const modelInfo: LiteLLMModelInfo = {
-                id: "claude-haiku-4-5",
-                name: "Claude Haiku 4.5",
-                supports_reasoning: true,
-            };
-
-            const result = getSupportedReasoningEfforts(modelInfo, "claude-haiku-4-5");
-
-            assert.deepStrictEqual(result, claudeEfforts);
-        });
-
-        test("falls back to canonical efforts for other models", () => {
-            const modelInfo: LiteLLMModelInfo = {
-                id: "local-proxy-model",
-                name: "Local Proxy Model",
-                supports_reasoning: true,
-            };
-
-            const result = getSupportedReasoningEfforts(modelInfo, "local-proxy-model");
-
-            assert.deepStrictEqual(result, canonicalCatchAllEfforts);
         });
 
         test("returns empty array for undefined modelInfo", () => {

--- a/src/utils/test/modelCapabilities.test.ts
+++ b/src/utils/test/modelCapabilities.test.ts
@@ -422,7 +422,7 @@ suite("modelCapabilities", () => {
             ]);
         });
 
-        test("keeps baseline efforts when LiteLLM reports a partial explicit set", () => {
+        test("keeps only explicit efforts when LiteLLM reports a partial set", () => {
             const modelInfo: LiteLLMModelInfo = {
                 supports_reasoning: true,
                 supports_none_reasoning_effort: true,
@@ -435,13 +435,7 @@ suite("modelCapabilities", () => {
                 supported_openai_params: ["reasoning_effort"],
             };
 
-            assert.deepStrictEqual(getSupportedReasoningEfforts(modelInfo, "luna-model"), [
-                "none",
-                "low",
-                "medium",
-                "high",
-                "xhigh",
-            ]);
+            assert.deepStrictEqual(getSupportedReasoningEfforts(modelInfo, "luna-model"), ["none", "xhigh"]);
         });
 
         test("returns the generic fallback ladder when no explicit fields are present", () => {
@@ -454,7 +448,7 @@ suite("modelCapabilities", () => {
             assert.deepStrictEqual(result, ["none", "low", "medium", "high"]);
         });
 
-        test("merges an explicitly supported extension with the generic fallback", () => {
+        test("does not merge an explicitly supported extension with the generic fallback", () => {
             const modelInfo: LiteLLMModelInfo = {
                 id: "test-model",
                 supports_reasoning: true,
@@ -464,7 +458,7 @@ suite("modelCapabilities", () => {
 
             const result = getSupportedReasoningEfforts(modelInfo, "test-model");
 
-            assert.deepStrictEqual(result, ["none", "low", "medium", "high", "xhigh"]);
+            assert.deepStrictEqual(result, ["xhigh"]);
         });
 
         test("recognizes supports_none_reasoning_effort without broadening the result", () => {


### PR DESCRIPTION
## Summary

Release `v2.2.1` with the reasoning capability fixes and opt-in model-card override workflow completed since `v2.2.0`.

## Changes since 2.2.0

- 🧠 Restored reasoning capability gates so unsupported reasoning controls are hidden when LiteLLM explicitly disables reasoning or all effort levels.
- 🧩 Preserved explicit LiteLLM effort metadata, including `none`, `minimal`, `xhigh`, and `max`, without inferring unspecified sister fields.
- 🎛️ Added explicit field-level model-card overrides that patch LiteLLM metadata before capability detection and registry caching.
- 🔒 Made `litellm-connector.enableModelOverrides` opt-in with a default of `false`.
- 🧪 Added regression coverage for disabled overrides, field replacement and append behavior, null handling, no-inference semantics, and picker capability derivation.
- 📚 Updated the changelog and both README variants, including step-by-step help and JSON examples for applying model overrides.
- 📦 Bumped the extension version from `2.2.1-dev2` to `2.2.1`.

## Validation

- `npm run lint`
- `npm run format`
- `npm run compile`
- `npm run test:coverage` — 891 tests passing; 89.92% line coverage
- `git diff --check`

## Release notes

The historical `2.1.1` changelog entry remains unchanged. This PR targets `main` and contains the new `2.2.1` release entry.