### PR TITLE
🚀 Release v2.2.3 — Idle review prompt, session-scoped deferral & provider refactor

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -6,7 +6,9 @@ import { defineConfig } from '@vscode/test-cli';
 // would skip our extension entirely. Switch back to "stable" once 1.120.0 ships.
 export default defineConfig({
   version: 'insiders',
-  files: 'out/**/*.test.js',
+  // The memory profile is a self-executing benchmark with its own npm script.
+  // Running it concurrently with Mocha mutates global fetch and makes retry tests flaky.
+  files: 'out/**/!(memoryProfile).test.js',
   mocha: {
     ui: 'tdd',
     timeout: 20000,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,6 +342,17 @@ The ingress pipeline is agnostic to endpoint choice:
 
 > ⚠️ **DO NOT use `npm run test`**, `npm run check`, or any other npm scripts — they may cause issues. Only run the commands listed above.
 
+### Dev-only commands (`-devN` builds)
+The extension surfaces a small set of developer-only commands when the installed package version ends with a `-devN` suffix (e.g. `2.2.3-dev1`). This is the only reliable dev-build signal because users install pre-compiled incremental updates rather than attaching a debugger.
+
+- Visibility is controlled by a `litellm-connector.isDevBuild` context key set during activation via `setDevBuildContextKey()` in `src/commands/devTools.ts`. The `commandPalette` menu `when` clause in `package.json` hides the commands on production builds.
+- The command handler always re-checks the live extension version at invocation time as a defense-in-depth guard against stale context keys after a hot-swap update.
+- `registerDevResetReviewPromptCommand()` always registers the handler; palette visibility is the `when` clause's responsibility, not conditional registration.
+
+| Command | Title | Purpose |
+| --- | --- | --- |
+| `litellm-connector.dev.resetReviewPrompt` | LiteLLM (Dev): Dev Reset Review Prompt | Clears `installDate`, `successfulTurns`, and `doNotAskAgain` `globalState` keys for the review prompt so the eligibility cycle can be re-tested without waiting for 10 successful turns + 5 minutes idle. |
+
 ### When to run what
 - Before implementing non-trivial logic: add or update the relevant tests first.
 - Before/after non-trivial edits: run `npm run compile` and `npm run test:coverage`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ This repository is a **VS Code extension**. Agents must follow these rules when 
 
 - **VS Code API**: Always target the `vscode` namespace.
 - **Proposed APIs**: Use `@vscode/dts` and keep `src/vscode.d.ts` current when relying on proposed types.
-- **Engine target**: `package.json` `engines.vscode` is `^1.120.0`. All provider code must assume the VS Code 1.120 Language Model API surface.
+- **Engine target**: `package.json` `engines.vscode` should be at or newer than `^1.125.0`. All provider code must assume the VS Code 1.120 or newer Language Model API surface.
 - **Configuration & Secrets (v1.120+, per-group configuration)**:
   - Language model provider configuration (base URL, API key, and any per-backend settings) is declared via the `languageModelChatProviders` contribution point in `package.json`
   - VS Code 1.120 supports **per-group configuration**: each configured provider group passes its own `options.configuration` into `provideLanguageModelChatInformation` and request methods. The provider must read configuration from `options.configuration` for every call rather than caching globally.
@@ -151,7 +151,7 @@ The extension uses a **shared orchestration + specialized protocol handlers** pa
 
 - **Chat Provider** (single, unified): `src/providers/liteLLMChatProvider.ts`
   - There is **one** chat provider class named `LiteLLMChatProvider`. Do **not** introduce or reintroduce version-suffixed siblings (`LiteLLMChatProviderV2`, `LiteLLMChatProviderV3`, etc.). The previous V1/V2/V3 split has been collapsed into this single implementation.
-  - Implements `vscode.LanguageModelChatProvider` against the VS Code 1.120 surface
+  - Implements `vscode.LanguageModelChatProvider` against the VS Code 1.120 or newer surface
   - Extends `LiteLLMProviderBase` and adds chat-protocol behavior only
   - Handles chat-specific streaming, tool call buffering, response part emission (text / thinking / data / tool calls), and message parsing
   - Reads per-group configuration from `options.configuration` on each call (no global config caching)
@@ -321,7 +321,7 @@ The ingress pipeline is agnostic to endpoint choice:
 ### External dependencies
 - **LiteLLM**: expects a compatible OpenAI-like proxy with `/chat/completions`, `/completions`, and/or `/responses` endpoints
 - **GitHub Copilot Chat**: this extension is a *provider* for the official Copilot Chat extension (chat provider)
-- **VS Code 1.120+** (declared in `package.json` `engines.vscode` as `^1.120.0`): required for:
+- **VS Code 1.125+** (declared in `package.json` `engines.vscode` as `^1.125.0`): required for:
   - `languageModelChatProviders` contribution point with **per-group configuration** schema
   - Stable `LanguageModelChatProvider` API used by the unified `LiteLLMChatProvider`
   - `LanguageModelTextCompletionProvider` proposed API (completions provider)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.2.3] - 2026-07-31
+
 ### 🚀 Features
 
 * **💬 Idle-time review prompt for engaged users**: After 10 successful chat turns and 5 minutes of idle time, the extension now offers a non-modal notification to leave a Marketplace review. Users can defer, permanently opt out, or accept to open the extension page. All state is stored in `globalState` (no remote flags or user-identifying telemetry). Telemetry events `review_prompt_eligible` and `review_prompt_choice` are emitted through the existing consent-aware adapter. (`src/engagement/reviewPromptService.ts`)
 * **🛠️ Dev-only review prompt reset command**: A new `litellm-connector.dev.resetReviewPrompt` command (visible in the Command Palette as **LiteLLM (Dev): Dev Reset Review Prompt**) clears all durable review-prompt state (`installDate`, `successfulTurns`, `doNotAskAgain`) for local testing. The command is gated on a `litellm-connector.isDevBuild` context key that is `true` only when the installed extension reports a `-devN` version suffix; production builds never surface the command and the handler re-checks the live version at invocation time as a defense-in-depth guard. (`src/commands/devTools.ts`, `package.json`)
+* **🔕 Session-scoped "Maybe Later" suppression**: Clicking "Maybe Later" or dismissing the review notification now suppresses further prompts for the remainder of the active VS Code session only. The deferral is tracked in memory via `vscode.env.sessionId` and is never persisted to durable `globalState`, so a restart treats the user as if they had never deferred and the eligibility cycle restarts. (`src/engagement/reviewPromptService.ts`)
+
+### 🐛 Fixes
+
+* **🛡️ Stop re-prompting after "Maybe Later" when a chat starts while the notification is displayed**: `showPromptIfEligible()` now re-checks session deferral at the display boundary as defense-in-depth. Previously, a 5-minute idle timer armed while the notification was already on screen (e.g. a chat started during the `await showInformationMessage()` window) could fire after the user deferred and re-prompt despite the "Maybe Later" choice. (`src/engagement/reviewPromptService.ts`)
 
 ### 🔧 Tweaks
 
@@ -16,6 +23,7 @@ All notable changes to this project will be documented in this file.
 ### 🧪 Tests
 
 * Added comprehensive TDD suite for review prompt service covering eligibility thresholds, idle timer cancellation, prompt choices (Leave a Review / Don't Ask Again / Maybe Later), persistent state, and disposal. (`src/engagement/test/reviewPromptService.test.ts`)
+* Added regression coverage for session-scoped suppression, dismissal behavior, re-prompting after a session change, and the "Maybe Later" race when a chat starts while the notification is displayed. (`src/engagement/test/reviewPromptService.test.ts`)
 * Added tests for review prompt telemetry event shapes and automatic enrichment in `TelemetryService`. (`src/telemetry/test/telemetryService.test.ts`)
 * Added PostHog adapter test verifying review prompt telemetry is suppressed when telemetry is disabled. (`src/telemetry/test/posthogAdapter.test.ts`)
 * Added chat provider test proving start and success hooks are called exactly once for a successful chat response. (`src/providers/test/chatProvider.test.ts`)
@@ -33,9 +41,9 @@ All notable changes to this project will be documented in this file.
 
 * **📦 New module: `src/engagement/`**: Dedicated directory for product engagement services, keeping review prompt logic outside providers and telemetry layers.
 * **📦 New module: `src/commands/devTools.ts`**: Houses dev-only command registration and the `litellm-connector.isDevBuild` context-key helper, separated from user-facing commands so the dev surface stays isolated.
-* **🧪 CI test isolation**: Memory profiler test is excluded from CI execution to prevent flaky test interactions with concurrent Mocha runs. (`.vscode-test.mjs`, commit `76e7298`)
-* **📦 Dependency update (pending merge)**: `@types/sinon` bumped from 21.0.1 to 22.0.0 (major) on the `dependabot/npm_and_yarn/types/sinon-22.0.0` branch. (`package.json`)
-* **🔧 Version bump**: `package.json` version updated to `2.2.3-dev3`.
+* **📦 Split provider base into focused helper modules**: Extracted call-time config resolution (`src/providers/base/callConfig.ts`), parameter filtering (`src/providers/base/parameterFiltering.ts`), and quota redaction (`src/providers/base/quotaRedaction.ts`) out of the monolithic `LiteLLMProviderBase` to keep the orchestrator thinner and easier to test.
+* **🧪 CI test isolation**: Memory profiler test is excluded from CI execution to prevent flaky test interactions with concurrent Mocha runs. (`.vscode-test.mjs`)
+* **🔧 Version bump**: `package.json` version updated to `2.2.3`.
 
 ## [2.2.2] - 2026-07-17
 
@@ -684,7 +692,7 @@ There have been a tremendous amount of backend work done with this update to mak
 
 ---
 
-[Unreleased]: https://github.com/gethnet/litellm-connector-copilot/compare/rel/v1.6.0...HEAD
+[Unreleased]: https://github.com/gethnet/litellm-connector-copilot/compare/rel/v2.2.3...HEAD
 [1.6.0]: https://github.com/gethnet/litellm-connector-copilot/releases/tag/rel/v1.6.0
 [1.5.0]: https://github.com/gethnet/litellm-connector-copilot/releases/tag/rel/v1.5.0
 [1.4.6]: https://github.com/gethnet/litellm-connector-copilot/releases/tag/rel/v1.4.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 🚀 Features
+
+* **💬 Idle-time review prompt for engaged users**: After 10 successful chat turns and 5 minutes of idle time, the extension now offers a non-modal notification to leave a Marketplace review. Users can defer, permanently opt out, or accept to open the extension page. All state is stored in `globalState` (no remote flags or user-identifying telemetry). Telemetry events `review_prompt_eligible` and `review_prompt_choice` are emitted through the existing consent-aware adapter. (`src/engagement/reviewPromptService.ts`)
+* **🛠️ Dev-only review prompt reset command**: A new `litellm-connector.dev.resetReviewPrompt` command (visible in the Command Palette as **LiteLLM (Dev): Dev Reset Review Prompt**) clears all durable review-prompt state (`installDate`, `successfulTurns`, `doNotAskAgain`) for local testing. The command is gated on a `litellm-connector.isDevBuild` context key that is `true` only when the installed extension reports a `-devN` version suffix; production builds never surface the command and the handler re-checks the live version at invocation time as a defense-in-depth guard. (`src/commands/devTools.ts`, `package.json`)
+
+### 🔧 Tweaks
+
+* **🔗 Marketplace review deep-link**: The "Leave a Review" action now opens `https://marketplace.visualstudio.com/items?itemName=GethNet.litellm-connector-copilot&ssr=false#review-details` so users land directly on the rating and review form instead of the generic extension page. (`src/engagement/reviewPromptService.ts`)
+
+### 🧪 Tests
+
+* Added comprehensive TDD suite for review prompt service covering eligibility thresholds, idle timer cancellation, prompt choices (Leave a Review / Don't Ask Again / Maybe Later), persistent state, and disposal. (`src/engagement/test/reviewPromptService.test.ts`)
+* Added tests for review prompt telemetry event shapes and automatic enrichment in `TelemetryService`. (`src/telemetry/test/telemetryService.test.ts`)
+* Added PostHog adapter test verifying review prompt telemetry is suppressed when telemetry is disabled. (`src/telemetry/test/posthogAdapter.test.ts`)
+* Added chat provider test proving start and success hooks are called exactly once for a successful chat response. (`src/providers/test/chatProvider.test.ts`)
+* Added activation test verifying the review prompt service is initialized and injected without requiring global state. (`src/test/integration/extension.test.ts`)
+* Added `devTools` test suite covering `isDevVersion` version-suffix matching, `setDevBuildContextKey` context-key setting (dev, production, and lookup-throws paths), always-register behavior, state reset on dev builds, and the handler's defense-in-depth no-op when a production build replaces a dev registration. (`src/commands/test/devTools.test.ts`)
+
+### 🧠 Provider & Telemetry
+
+* **Typed telemetry capture methods**: Added `captureReviewPromptEligible` and `captureReviewPromptChoice` to `TelemetryService` with snake_case event properties (`install_date`, `successful_turn_count`, `choice`). Properties route through the existing consent-aware PostHog adapter. (`src/telemetry/telemetryService.ts`)
+* **Base provider injection point**: `LiteLLMProviderBase` now exposes `setReviewPromptService()` for optional dependency injection. (`src/providers/liteLLMProviderBase.ts`)
+* **Chat provider lifecycle hooks**: `LiteLLMChatProvider` calls `recordChatRequestStarted()` on request start and `recordSuccessfulChatTurn()` after success metric reporting. Failed, cancelled, and commit-generation paths are excluded. (`src/providers/liteLLMChatProvider.ts`)
+* **Extension activation wiring**: `ReviewPromptService` is instantiated, pushed to subscriptions, and injected into the chat provider during activation. (`src/extension.ts`)
+
+### 🧹 Chores
+
+* **📦 New module: `src/engagement/`**: Dedicated directory for product engagement services, keeping review prompt logic outside providers and telemetry layers.
+* **📦 New module: `src/commands/devTools.ts`**: Houses dev-only command registration and the `litellm-connector.isDevBuild` context-key helper, separated from user-facing commands so the dev surface stays isolated.
+* **🧪 CI test isolation**: Memory profiler test is excluded from CI execution to prevent flaky test interactions with concurrent Mocha runs. (`.vscode-test.mjs`, commit `76e7298`)
+* **📦 Dependency update (pending merge)**: `@types/sinon` bumped from 21.0.1 to 22.0.0 (major) on the `dependabot/npm_and_yarn/types/sinon-22.0.0` branch. (`package.json`)
+* **🔧 Version bump**: `package.json` version updated to `2.2.3-dev3`.
+
 ## [2.2.2] - 2026-07-17
 
 ### 🧠 Reasoning Fixes

--- a/README.marketplace.md
+++ b/README.marketplace.md
@@ -10,13 +10,12 @@ Bring **any LiteLLM-supported model** into the Copilot Chat model picker — Ope
 
 ---
 
-## 🆕 What's New in 2.2.2
+## 🆕 What's New in 2.2.3
 
-> Version 2.2.2 corrects per-effort reasoning metadata handling so the model picker preserves defaults and applies explicit LiteLLM effort states correctly.
+> Version 2.2.3 adds an idle-time Marketplace review prompt for engaged users and fixes a re-prompt race after "Maybe Later".
 
-- 🧠 **Per-effort reasoning states** — Baseline `null` or absent fields retain the default effort, `false` removes only that effort, and `true` retains it.
-- 🧩 **Extended effort support** — Explicitly supported `minimal`, `xhigh`, and `max` values are added without replacing the baseline effort list.
-- 🎛️ **Field-specific model-card overrides** — Overrides continue to change only the exact LiteLLM fields they define.
+- 💬 **Idle-time review prompt** — After 10 successful chat turns and 5 minutes of idle time, the extension offers a non-modal notification to leave a Marketplace review. Choose **Leave a Review**, **Maybe Later** (suppresses for the rest of the session), or **Don't Ask Again** (permanently opts out). All state is local; no user-identifying telemetry is sent.
+- 🔕 **Smarter "Maybe Later"** — Deferring the prompt now suppresses it for the remainder of the active VS Code session only (tracked in memory via `sessionId`), and a race that could re-prompt after "Maybe Later" when a chat started while the notification was displayed is now fixed.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for previous release notes.
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,12 @@
 
 [![License](https://img.shields.io/github/license/gethnet/litellm-connector-copilot)](LICENSE)
 
-## 🆕 What's New in 2.2.2
+## 🆕 What's New in 2.2.3
 
-> Version 2.2.2 corrects per-effort reasoning metadata handling so the model picker preserves defaults and applies explicit LiteLLM effort states correctly.
+> Version 2.2.3 adds an idle-time Marketplace review prompt for engaged users and fixes a re-prompt race after "Maybe Later".
 
-- 🧠 **Per-effort reasoning states** — Baseline `null` or absent fields retain the default effort, `false` removes only that effort, and `true` retains it.
-- 🧩 **Extended effort support** — Explicitly supported `minimal`, `xhigh`, and `max` values are added without replacing the baseline effort list.
-- 🎛️ **Field-specific model-card overrides** — Overrides continue to change only the exact LiteLLM fields they define.
+- 💬 **Idle-time review prompt** — After 10 successful chat turns and 5 minutes of idle time, the extension offers a non-modal notification to leave a Marketplace review. Choose **Leave a Review**, **Maybe Later** (suppresses for the rest of the session), or **Don't Ask Again** (permanently opts out). All state is local; no user-identifying telemetry is sent.
+- 🔕 **Smarter "Maybe Later"** — Deferring the prompt now suppresses it for the remainder of the active VS Code session only (tracked in memory via `sessionId`), and a race that could re-prompt after "Maybe Later" when a chat started while the notification was displayed is now fixed.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for previous release notes.
 

--- a/package.json
+++ b/package.json
@@ -1,354 +1,354 @@
 {
-	"name": "litellm-connector-copilot",
-	"displayName": "LiteLLM Connector for Copilot",
-	"version": "2.2.3-dev3",
-	"description": "An extension that integrates LiteLLM proxy into Copilot",
-	"categories": [
-		"AI",
-		"Chat",
-		"Machine Learning",
-		"Other"
-	],
-	"keywords": [
-		"litellm",
-		"llm",
-		"copilot",
-		"ai-connector",
-		"openai",
-		"anthropic",
-		"local-llm",
-		"language model provider",
-		"language model",
-		"connector",
-		"copilot connector"
-	],
-	"homepage": "https://github.com/gethnet/litellm-connector-copilot",
-	"bugs": {
-		"url": "https://github.com/gethnet/litellm-connector-copilot/issues"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/gethnet/litellm-connector-copilot"
-	},
-	"license": "Apache-2.0",
-	"maintainers": [
-		"amwdrizz"
-	],
-	"contributors": [
-		"amwdrizz"
-	],
-	"publisher": "GethNet",
-	"main": "./dist/extension.js",
-	"browser": "./dist/web/extension.js",
-	"scripts": {
-		"bump-version": "node scripts/bump-version.js",
-		"check": "npm run lint; npm run format; npm run test:coverage;",
-		"clean": "find ./dist ./out ./coverage ./test-results -delete || true",
-		"clean:build": "find ./dist ./out -delete || true",
-		"clean:tests": "find ./coverage ./test-results -delete || true",
-		"precompile": "npm run clean",
-		"compile": "tsc -p ./",
-		"coverage:serve": "npx serve coverage -p 8080",
-		"download-api": "yes | dts main && mv vscode.d.ts src/ && yes | dts dev && mv vscode.proposed.*.d.ts src/",
-		"format": "prettier --check .",
-		"format:fix": "prettier --write .",
-		"postinstall": "npm run download-api",
-		"lint": "eslint",
-		"lint:fix": "eslint --fix",
-		"memory-profile": "npm run compile && node scripts/run-memory-profile.mjs",
-		"package:marketplace": "node scripts/package-marketplace.mjs",
-		"pretest": "npm run compile",
-		"test": "xvfb-run vscode-test --args=\"--no-sandbox\"",
-		"pretest:coverage": "npm run compile",
-		"test:coverage": "node scripts/test-coverage.mjs",
-		"test:report": "npm run pretest && export VSCODE_TEST_RESULTS_DIR=$PWD/test-results && mkdir -p $VSCODE_TEST_RESULTS_DIR && npm run test",
-		"vscode:pack": "npm run clean:build && tsc --noEmit && node esbuild.js --production && npx vsce package",
-		"vscode:pack:dev": "npm run clean:build && tsc --noEmit && node esbuild.js && npx vsce package",
-		"watch": "tsc -watch -p ./"
-	},
-	"contributes": {
-		"commands": [
-			{
-				"command": "litellm-connector.showModels",
-				"title": "LiteLLM: Show Available Models"
-			},
-			{
-				"command": "litellm-connector.reloadModels",
-				"title": "LiteLLM: Reload Models"
-			},
-			{
-				"command": "litellm-connector.manage",
-				"title": "LiteLLM: Manage Configuration"
-			},
-			{
-				"command": "litellm-connector.resetConfiguration",
-				"title": "LiteLLM: Reset All Configuration"
-			},
-			{
-				"command": "litellm-connector.generateCommitMessage",
-				"title": "Generate Commit Message",
-				"icon": "$(sparkle)"
-			},
-			{
-				"command": "litellm-connector.setLogLevel",
-				"title": "LiteLLM: Set Log Level"
-			},
-			{
-				"command": "litellm-connector.dev.resetReviewPrompt",
-				"title": "LiteLLM: Dev Reset Review Prompt",
-				"enablement": "litellm-connector.isDevBuild",
-				"category": "LiteLLM (Dev)"
-			}
-		],
-		"configuration": {
-			"title": "LiteLLM Connector",
-			"properties": {
-				"litellm-connector.modelIdOverride": {
-					"type": "string",
-					"default": "",
-					"description": "(Deprecated) Optional: force a specific LiteLLM model id for legacy workflows."
-				},
-				"litellm-connector.commitModelIdOverride": {
-					"type": "string",
-					"default": "",
-					"description": "Override the model ID for git commit message generation. If empty, the feature is disabled.",
-					"markdownDescription": "Override the model ID for git commit message generation. If empty, the feature is disabled."
-				},
-				"litellm-connector.disableQuotaToolRedaction": {
-					"type": "boolean",
-					"default": false,
-					"description": "Disable per-turn tool redaction when a quota error is detected in chat history. Leave off to keep redaction enabled."
-				},
-				"litellm-connector.modelOverrides": {
-					"type": "array",
-					"default": [],
-					"description": "User-supplied model overrides for reasoning capabilities. Merged on top of bundled overrides (user entries take precedence on regex match). Each entry: { match: string (regex), supportsReasoning?: boolean|null, reasoningEfforts?: string[], defaultEffort?: string, notes?: string }.",
-					"items": {
-						"type": "object",
-						"properties": {
-							"match": {
-								"type": "string",
-								"description": "Regex pattern matched against the model id."
-							},
-							"supportsReasoning": {
-								"type": [
-									"boolean",
-									"null"
-								],
-								"description": "Override reasoning support. null = inherit from proxy."
-							},
-							"reasoningEfforts": {
-								"type": "array",
-								"items": {
-									"type": "string",
-									"enum": [
-										"none",
-										"minimal",
-										"low",
-										"medium",
-										"high",
-										"xhigh",
-										"max"
-									]
-								}
-							},
-							"defaultEffort": {
-								"type": "string",
-								"enum": [
-									"none",
-									"minimal",
-									"low",
-									"medium",
-									"high",
-									"xhigh",
-									"max"
-								]
-							},
-							"notes": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"match"
-						]
-					}
-				},
-				"litellm-connector.modelCapabilitiesOverrides": {
-					"type": "object",
-					"default": {},
-					"description": "Override model capabilities (toolCalling, imageInput) reported to VS Code. Key is the Model ID (e.g. 'gpt-4o'), value is a comma-separated list of capabilities to ENABLE (e.g. 'toolCalling,imageInput').",
-					"additionalProperties": {
-						"type": "string"
-					}
-				},
-				"litellm-connector.inactivityTimeout": {
-					"type": "number",
-					"default": 60,
-					"description": "Timeout in seconds of inactivity before the LiteLLM proxy connection is considered idle."
-				},
-				"litellm-connector.disableCaching": {
-					"type": "boolean",
-					"default": false,
-					"description": "When enabled, bypass LiteLLM caching only for models whose supported OpenAI parameters include cache.",
-					"tags": [
-						"experimental"
-					]
-				},
-				"litellm-connector.enableModelOverrides": {
-					"type": "boolean",
-					"default": false,
-					"markdownDescription": "Enable model-card overrides for matching models. When disabled, LiteLLM `/model/info` data is used unchanged. When enabled, only explicitly configured override fields replace incoming LiteLLM values."
-				},
-				"litellm-connector.displayPricingInPicker": {
-					"type": "boolean",
-					"default": true,
-					"description": "Show model pricing in the model picker when available."
-				},
-				"litellm-connector.discoveryTimeoutMs": {
-					"type": "number",
-					"default": 5000,
-					"minimum": 500,
-					"maximum": 60000,
-					"tags": [
-						"advanced"
-					],
-					"description": "Timeout in milliseconds for /model/info discovery requests. Default: 5000."
-				},
-				"litellm-connector.discoveryCacheTtlMs": {
-					"type": "number",
-					"default": 60000,
-					"minimum": 0,
-					"maximum": 300000,
-					"tags": [
-						"advanced"
-					],
-					"description": "TTL in milliseconds for cached /model/info discovery responses. Set to 0 to disable caching. Default: 60000."
-				},
-				"litellm-connector.discoveryFireDebounceMs": {
-					"type": "number",
-					"default": 250,
-					"minimum": 0,
-					"maximum": 5000,
-					"tags": [
-						"advanced"
-					],
-					"description": "Trailing-edge debounce window in milliseconds for outward model-discovery change notifications. Set to 0 to disable debouncing. Default: 250."
-				},
-				"litellm-connector.discoveryFireMinIntervalMs": {
-					"type": "number",
-					"default": 2000,
-					"minimum": 0,
-					"maximum": 30000,
-					"tags": [
-						"advanced"
-					],
-					"description": "Minimum interval in milliseconds between outward model-discovery change notifications. Set to 0 to disable rate limiting. Default: 2000."
-				}
-			}
-		},
-		"keybindings": [],
-		"languageModelChatProviders": [
-			{
-				"vendor": "litellm-connector",
-				"displayName": "LiteLLM",
-				"configuration": {
-					"type": "object",
-					"properties": {
-						"baseUrl": {
-							"type": "string",
-							"title": "Server URL",
-							"description": "Base URL for the LiteLLM proxy server (must start with http:// or https://).",
-							"pattern": "^https?:\\/\\/.+",
-							"group": "navigation"
-						},
-						"apiKey": {
-							"type": "string",
-							"title": "API Key",
-							"description": "API key used to authenticate with the LiteLLM proxy.",
-							"secret": true,
-							"minLength": 1
-						}
-					},
-					"required": [
-						"baseUrl",
-						"apiKey"
-					]
-				}
-			}
-		],
-		"menus": {
-			"scm/title": [
-				{
-					"command": "litellm-connector.generateCommitMessage",
-					"group": "navigation",
-					"when": "config.litellm-connector.commitModelIdOverride != ''"
-				}
-			],
-			"commandPalette": [
-				{
-					"command": "litellm-connector.dev.resetReviewPrompt",
-					"when": "litellm-connector.isDevBuild"
-				}
-			]
-		}
-	},
-	"activationEvents": [
-		"onLanguageModelChatProvider:litellm-connector",
-		"onStartupFinished"
-	],
-	"devDependencies": {
-		"@eslint/js": "^10.0.0",
-		"@stylistic/eslint-plugin": "^5.7.1",
-		"@types/mocha": "^10.0.10",
-		"@types/node": "^26.1.1",
-		"@types/sinon": "^22.0.0",
-		"@types/vscode": "^1.125.0",
-		"@vscode/dts": "^0.4.1",
-		"@vscode/test-cli": "^0.0.15",
-		"@vscode/test-electron": "^3.0.0",
-		"@vscode/vsce": "^3.7.0",
-		"esbuild": "^0.28.0",
-		"eslint": "^10.7.0",
-		"mocha-junit-reporter": "^2.2.1",
-		"mocha-multi-reporters": "^1.5.0",
-		"ovsx": "^1.0.2",
-		"posthog-js": "^1.404.0",
-		"posthog-node": "^5.45.2",
-		"prettier": "^3.8.4",
-		"rimraf": "^6.0.1",
-		"serve": "^14.2.6",
-		"sinon": "^22.0.0",
-		"typescript": "^6.0.3",
-		"typescript-eslint": "^8.64.0",
-		"zx": "^8.8.5"
-	},
-	"engines": {
-		"vscode": "^1.125.0"
-	},
-	"icon": "assets/logo.png",
-	"badges": [
-		{
-			"description": "Star litellm-connector-copilot on Github",
-			"url": "https://img.shields.io/github/stars/gethnet/litellm-connector-copilot?style=social",
-			"href": "https://github.com/gethnet/litellm-connector-copilot"
-		}
-	],
-	"galleryBanner": {
-		"color": "#100f11",
-		"theme": "dark"
-	},
-	"preview": true,
-	"enabledApiProposals": [
-		"chatProvider",
-		"languageModelCapabilities",
-		"languageModelPricing",
-		"languageModelProxy",
-		"languageModelSystem",
-		"languageModelThinkingPart",
-		"languageModelToolResultAudience",
-		"languageModelToolSupportsModel"
-	],
-	"sponsor": {
-		"url": "https://buymeacoffee.com/amwdrizz"
-	}
+  "name": "litellm-connector-copilot",
+  "displayName": "LiteLLM Connector for Copilot",
+  "version": "2.2.3",
+  "description": "An extension that integrates LiteLLM proxy into Copilot",
+  "categories": [
+    "AI",
+    "Chat",
+    "Machine Learning",
+    "Other"
+  ],
+  "keywords": [
+    "litellm",
+    "llm",
+    "copilot",
+    "ai-connector",
+    "openai",
+    "anthropic",
+    "local-llm",
+    "language model provider",
+    "language model",
+    "connector",
+    "copilot connector"
+  ],
+  "homepage": "https://github.com/gethnet/litellm-connector-copilot",
+  "bugs": {
+    "url": "https://github.com/gethnet/litellm-connector-copilot/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gethnet/litellm-connector-copilot"
+  },
+  "license": "Apache-2.0",
+  "maintainers": [
+    "amwdrizz"
+  ],
+  "contributors": [
+    "amwdrizz"
+  ],
+  "publisher": "GethNet",
+  "main": "./dist/extension.js",
+  "browser": "./dist/web/extension.js",
+  "scripts": {
+    "bump-version": "node scripts/bump-version.js",
+    "check": "npm run lint; npm run format; npm run test:coverage;",
+    "clean": "find ./dist ./out ./coverage ./test-results -delete || true",
+    "clean:build": "find ./dist ./out -delete || true",
+    "clean:tests": "find ./coverage ./test-results -delete || true",
+    "precompile": "npm run clean",
+    "compile": "tsc -p ./",
+    "coverage:serve": "npx serve coverage -p 8080",
+    "download-api": "yes | dts main && mv vscode.d.ts src/ && yes | dts dev && mv vscode.proposed.*.d.ts src/",
+    "format": "prettier --check .",
+    "format:fix": "prettier --write .",
+    "postinstall": "npm run download-api",
+    "lint": "eslint",
+    "lint:fix": "eslint --fix",
+    "memory-profile": "npm run compile && node scripts/run-memory-profile.mjs",
+    "package:marketplace": "node scripts/package-marketplace.mjs",
+    "pretest": "npm run compile",
+    "test": "xvfb-run vscode-test --args=\"--no-sandbox\"",
+    "pretest:coverage": "npm run compile",
+    "test:coverage": "node scripts/test-coverage.mjs",
+    "test:report": "npm run pretest && export VSCODE_TEST_RESULTS_DIR=$PWD/test-results && mkdir -p $VSCODE_TEST_RESULTS_DIR && npm run test",
+    "vscode:pack": "npm run clean:build && tsc --noEmit && node esbuild.js --production && npx vsce package",
+    "vscode:pack:dev": "npm run clean:build && tsc --noEmit && node esbuild.js && npx vsce package",
+    "watch": "tsc -watch -p ./"
+  },
+  "contributes": {
+    "commands": [
+      {
+        "command": "litellm-connector.showModels",
+        "title": "LiteLLM: Show Available Models"
+      },
+      {
+        "command": "litellm-connector.reloadModels",
+        "title": "LiteLLM: Reload Models"
+      },
+      {
+        "command": "litellm-connector.manage",
+        "title": "LiteLLM: Manage Configuration"
+      },
+      {
+        "command": "litellm-connector.resetConfiguration",
+        "title": "LiteLLM: Reset All Configuration"
+      },
+      {
+        "command": "litellm-connector.generateCommitMessage",
+        "title": "Generate Commit Message",
+        "icon": "$(sparkle)"
+      },
+      {
+        "command": "litellm-connector.setLogLevel",
+        "title": "LiteLLM: Set Log Level"
+      },
+      {
+        "command": "litellm-connector.dev.resetReviewPrompt",
+        "title": "LiteLLM: Dev Reset Review Prompt",
+        "enablement": "litellm-connector.isDevBuild",
+        "category": "LiteLLM (Dev)"
+      }
+    ],
+    "configuration": {
+      "title": "LiteLLM Connector",
+      "properties": {
+        "litellm-connector.modelIdOverride": {
+          "type": "string",
+          "default": "",
+          "description": "(Deprecated) Optional: force a specific LiteLLM model id for legacy workflows."
+        },
+        "litellm-connector.commitModelIdOverride": {
+          "type": "string",
+          "default": "",
+          "description": "Override the model ID for git commit message generation. If empty, the feature is disabled.",
+          "markdownDescription": "Override the model ID for git commit message generation. If empty, the feature is disabled."
+        },
+        "litellm-connector.disableQuotaToolRedaction": {
+          "type": "boolean",
+          "default": false,
+          "description": "Disable per-turn tool redaction when a quota error is detected in chat history. Leave off to keep redaction enabled."
+        },
+        "litellm-connector.modelOverrides": {
+          "type": "array",
+          "default": [],
+          "description": "User-supplied model overrides for reasoning capabilities. Merged on top of bundled overrides (user entries take precedence on regex match). Each entry: { match: string (regex), supportsReasoning?: boolean|null, reasoningEfforts?: string[], defaultEffort?: string, notes?: string }.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "match": {
+                "type": "string",
+                "description": "Regex pattern matched against the model id."
+              },
+              "supportsReasoning": {
+                "type": [
+                  "boolean",
+                  "null"
+                ],
+                "description": "Override reasoning support. null = inherit from proxy."
+              },
+              "reasoningEfforts": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "none",
+                    "minimal",
+                    "low",
+                    "medium",
+                    "high",
+                    "xhigh",
+                    "max"
+                  ]
+                }
+              },
+              "defaultEffort": {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ]
+              },
+              "notes": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "match"
+            ]
+          }
+        },
+        "litellm-connector.modelCapabilitiesOverrides": {
+          "type": "object",
+          "default": {},
+          "description": "Override model capabilities (toolCalling, imageInput) reported to VS Code. Key is the Model ID (e.g. 'gpt-4o'), value is a comma-separated list of capabilities to ENABLE (e.g. 'toolCalling,imageInput').",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "litellm-connector.inactivityTimeout": {
+          "type": "number",
+          "default": 60,
+          "description": "Timeout in seconds of inactivity before the LiteLLM proxy connection is considered idle."
+        },
+        "litellm-connector.disableCaching": {
+          "type": "boolean",
+          "default": false,
+          "description": "When enabled, bypass LiteLLM caching only for models whose supported OpenAI parameters include cache.",
+          "tags": [
+            "experimental"
+          ]
+        },
+        "litellm-connector.enableModelOverrides": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable model-card overrides for matching models. When disabled, LiteLLM `/model/info` data is used unchanged. When enabled, only explicitly configured override fields replace incoming LiteLLM values."
+        },
+        "litellm-connector.displayPricingInPicker": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show model pricing in the model picker when available."
+        },
+        "litellm-connector.discoveryTimeoutMs": {
+          "type": "number",
+          "default": 5000,
+          "minimum": 500,
+          "maximum": 60000,
+          "tags": [
+            "advanced"
+          ],
+          "description": "Timeout in milliseconds for /model/info discovery requests. Default: 5000."
+        },
+        "litellm-connector.discoveryCacheTtlMs": {
+          "type": "number",
+          "default": 60000,
+          "minimum": 0,
+          "maximum": 300000,
+          "tags": [
+            "advanced"
+          ],
+          "description": "TTL in milliseconds for cached /model/info discovery responses. Set to 0 to disable caching. Default: 60000."
+        },
+        "litellm-connector.discoveryFireDebounceMs": {
+          "type": "number",
+          "default": 250,
+          "minimum": 0,
+          "maximum": 5000,
+          "tags": [
+            "advanced"
+          ],
+          "description": "Trailing-edge debounce window in milliseconds for outward model-discovery change notifications. Set to 0 to disable debouncing. Default: 250."
+        },
+        "litellm-connector.discoveryFireMinIntervalMs": {
+          "type": "number",
+          "default": 2000,
+          "minimum": 0,
+          "maximum": 30000,
+          "tags": [
+            "advanced"
+          ],
+          "description": "Minimum interval in milliseconds between outward model-discovery change notifications. Set to 0 to disable rate limiting. Default: 2000."
+        }
+      }
+    },
+    "keybindings": [],
+    "languageModelChatProviders": [
+      {
+        "vendor": "litellm-connector",
+        "displayName": "LiteLLM",
+        "configuration": {
+          "type": "object",
+          "properties": {
+            "baseUrl": {
+              "type": "string",
+              "title": "Server URL",
+              "description": "Base URL for the LiteLLM proxy server (must start with http:// or https://).",
+              "pattern": "^https?:\\/\\/.+",
+              "group": "navigation"
+            },
+            "apiKey": {
+              "type": "string",
+              "title": "API Key",
+              "description": "API key used to authenticate with the LiteLLM proxy.",
+              "secret": true,
+              "minLength": 1
+            }
+          },
+          "required": [
+            "baseUrl",
+            "apiKey"
+          ]
+        }
+      }
+    ],
+    "menus": {
+      "scm/title": [
+        {
+          "command": "litellm-connector.generateCommitMessage",
+          "group": "navigation",
+          "when": "config.litellm-connector.commitModelIdOverride != ''"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "litellm-connector.dev.resetReviewPrompt",
+          "when": "litellm-connector.isDevBuild"
+        }
+      ]
+    }
+  },
+  "activationEvents": [
+    "onLanguageModelChatProvider:litellm-connector",
+    "onStartupFinished"
+  ],
+  "devDependencies": {
+    "@eslint/js": "^10.0.0",
+    "@stylistic/eslint-plugin": "^5.7.1",
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^26.1.1",
+    "@types/sinon": "^22.0.0",
+    "@types/vscode": "^1.125.0",
+    "@vscode/dts": "^0.4.1",
+    "@vscode/test-cli": "^0.0.15",
+    "@vscode/test-electron": "^3.0.0",
+    "@vscode/vsce": "^3.7.0",
+    "esbuild": "^0.28.0",
+    "eslint": "^10.7.0",
+    "mocha-junit-reporter": "^2.2.1",
+    "mocha-multi-reporters": "^1.5.0",
+    "ovsx": "^1.0.2",
+    "posthog-js": "^1.409.0",
+    "posthog-node": "^5.47.0",
+    "prettier": "^3.8.4",
+    "rimraf": "^6.0.1",
+    "serve": "^14.2.6",
+    "sinon": "^22.0.0",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.64.0",
+    "zx": "^8.8.5"
+  },
+  "engines": {
+    "vscode": "^1.125.0"
+  },
+  "icon": "assets/logo.png",
+  "badges": [
+    {
+      "description": "Star litellm-connector-copilot on Github",
+      "url": "https://img.shields.io/github/stars/gethnet/litellm-connector-copilot?style=social",
+      "href": "https://github.com/gethnet/litellm-connector-copilot"
+    }
+  ],
+  "galleryBanner": {
+    "color": "#100f11",
+    "theme": "dark"
+  },
+  "preview": true,
+  "enabledApiProposals": [
+    "chatProvider",
+    "languageModelCapabilities",
+    "languageModelPricing",
+    "languageModelProxy",
+    "languageModelSystem",
+    "languageModelThinkingPart",
+    "languageModelToolResultAudience",
+    "languageModelToolSupportsModel"
+  ],
+  "sponsor": {
+    "url": "https://buymeacoffee.com/amwdrizz"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "litellm-connector-copilot",
 	"displayName": "LiteLLM Connector for Copilot",
-	"version": "2.2.3",
+	"version": "2.2.3-dev3",
 	"description": "An extension that integrates LiteLLM proxy into Copilot",
 	"categories": [
 		"AI",
@@ -92,6 +92,12 @@
 			{
 				"command": "litellm-connector.setLogLevel",
 				"title": "LiteLLM: Set Log Level"
+			},
+			{
+				"command": "litellm-connector.dev.resetReviewPrompt",
+				"title": "LiteLLM: Dev Reset Review Prompt",
+				"enablement": "litellm-connector.isDevBuild",
+				"category": "LiteLLM (Dev)"
 			}
 		],
 		"configuration": {
@@ -276,6 +282,12 @@
 					"command": "litellm-connector.generateCommitMessage",
 					"group": "navigation",
 					"when": "config.litellm-connector.commitModelIdOverride != ''"
+				}
+			],
+			"commandPalette": [
+				{
+					"command": "litellm-connector.dev.resetReviewPrompt",
+					"when": "litellm-connector.isDevBuild"
 				}
 			]
 		}

--- a/src/commands/devTools.ts
+++ b/src/commands/devTools.ts
@@ -1,0 +1,118 @@
+import * as vscode from "vscode";
+import type { ReviewPromptService } from "../engagement/reviewPromptService";
+import { StructuredLogger } from "../observability";
+
+const DEV_VERSION_PATTERN = /-dev\d*$/;
+
+/**
+ * Context key that controls visibility of dev-only commands in the Command
+ * Palette. Set to `true` during activation when the running extension reports
+ * a `-devN` version suffix; remains absent (falsy) on production builds so the
+ * `commandPalette` menu `when` clause hides the entries.
+ */
+export const DEV_BUILD_CONTEXT_KEY = "litellm-connector.isDevBuild";
+
+/**
+ * Module-level reference to the activation context. Stored once during
+ * activation so command handlers can re-check the live extension version at
+ * invocation time without being re-passed the context on every call.
+ */
+let activationContext: vscode.ExtensionContext | undefined;
+
+/**
+ * Returns true when the installed extension reports a `-devN` version suffix.
+ * Dev builds are produced by `npm run bump-version dev`; the trailing marker is
+ * the only reliable signal for "incremental install" since users run a
+ * pre-compiled extension rather than attaching a debugger.
+ */
+export function isDevVersion(version: string | undefined): boolean {
+    return typeof version === "string" && DEV_VERSION_PATTERN.test(version);
+}
+
+/**
+ * Reads the installed extension's package version from the VS Code extension
+ * host. Falls back to `undefined` when the lookup fails so callers can treat
+ * missing metadata as "not a dev build" without throwing. `context.extension`
+ * may be missing on partial test stubs, so guard the read with `?.`.
+ */
+function readInstalledExtensionVersion(context: vscode.ExtensionContext): string | undefined {
+    const id = context.extension?.id;
+    const ext = id ? vscode.extensions.getExtension(id) : undefined;
+    const pkg: unknown = ext?.packageJSON;
+    if (typeof pkg !== "object" || pkg === null) {
+        return undefined;
+    }
+    const version = (pkg as Record<string, unknown>).version;
+    return typeof version === "string" ? version : undefined;
+}
+
+/** Internal helper: read version without propagating exceptions. */
+function safeReadVersion(context: vscode.ExtensionContext): string | undefined {
+    try {
+        return readInstalledExtensionVersion(context);
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Sets the `litellm-connector.isDevBuild` context key so the `commandPalette`
+ * menu `when` clause shows/hides dev-only commands. Also stores the context for
+ * the command handler's defense-in-depth version re-check. Safe to call from
+ * synchronous `activate()`; never throws.
+ *
+ * @returns `true` when the running build is a `-devN` version, else `false`.
+ */
+export async function setDevBuildContextKey(context: vscode.ExtensionContext): Promise<boolean> {
+    activationContext = context;
+    const version = safeReadVersion(context);
+    const isDev = isDevVersion(version);
+    StructuredLogger.info("dev_tools.set_context", { context: DEV_BUILD_CONTEXT_KEY, isDev, version });
+    try {
+        await vscode.commands.executeCommand("setContext", DEV_BUILD_CONTEXT_KEY, isDev);
+    } catch (setCtxErr) {
+        // setContext must be available on the extension host; guard anyway so a
+        // rare API failure never breaks activation.
+        StructuredLogger.info("dev_tools.set_context_failed", {
+            context: DEV_BUILD_CONTEXT_KEY,
+            error: setCtxErr instanceof Error ? setCtxErr.message : String(setCtxErr),
+        });
+    }
+    return isDev;
+}
+
+/**
+ * Registers the `litellm-connector.dev.resetReviewPrompt` command. The command
+ * is always registered so VS Code can execute it once the `commandPalette`
+ * `when` clause surfaces it. The handler re-checks the live extension version
+ * at invocation time as a defense-in-depth guard against stale context keys
+ * (e.g. a user updating from a dev build to a production build without
+ * reloading, which would leave `litellm-connector.isDevBuild` true until the
+ * next activation).
+ *
+ * @returns A disposable for the registered command.
+ */
+export function registerDevResetReviewPromptCommand(reviewPromptService: ReviewPromptService): vscode.Disposable {
+    return vscode.commands.registerCommand("litellm-connector.dev.resetReviewPrompt", async () => {
+        // Re-check at invocation time: setContext is only refreshed on activation,
+        // so a stale key could still surface the command after a hot-swap update.
+        const liveVersion = activationContext ? safeReadVersion(activationContext) : undefined;
+        if (!isDevVersion(liveVersion)) {
+            StructuredLogger.info("dev_tools.handler_blocked_in_production", {
+                command: "dev.resetReviewPrompt",
+                version: liveVersion,
+            });
+            vscode.window.showWarningMessage(
+                "LiteLLM: dev-only commands are disabled in this build. " +
+                    "Install a -devN version to use reset tools."
+            );
+            return;
+        }
+
+        await reviewPromptService.clearReviewPromptState();
+        StructuredLogger.info("dev_tools.review_prompt_state_reset", { version: liveVersion });
+        vscode.window.showInformationMessage(
+            "LiteLLM: review-prompt state cleared. " + "Next successful chat turn will start a fresh eligibility cycle."
+        );
+    });
+}

--- a/src/commands/test/devTools.test.ts
+++ b/src/commands/test/devTools.test.ts
@@ -1,0 +1,239 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import {
+    DEV_BUILD_CONTEXT_KEY,
+    isDevVersion,
+    registerDevResetReviewPromptCommand,
+    setDevBuildContextKey,
+} from "../devTools";
+import { ReviewPromptService } from "../../engagement/reviewPromptService";
+import type { TelemetryService } from "../../telemetry/telemetryService";
+import { StructuredLogger } from "../../observability/structuredLogger";
+import { createMockMemento } from "../../test/utils/testMocks";
+
+interface Stubs {
+    sandbox: sinon.SinonSandbox;
+    showInformationMessage: sinon.SinonStub;
+    showWarningMessage: sinon.SinonStub;
+    getExtensionStub: sinon.SinonStub;
+    executeCommandSpy: sinon.SinonSpy;
+}
+
+function installStubs(): Stubs {
+    const sandbox = sinon.createSandbox();
+    sandbox.stub(StructuredLogger, "info");
+    return {
+        sandbox,
+        showInformationMessage: sandbox.stub(vscode.window, "showInformationMessage").resolves(undefined),
+        showWarningMessage: sandbox.stub(vscode.window, "showWarningMessage").resolves(undefined),
+        getExtensionStub: sandbox.stub(vscode.extensions, "getExtension"),
+        // Use a spy (not a stub) so setContext is really forwarded to VS Code and
+        // executeCommand("litellm-connector.dev.resetReviewPrompt") dispatches to
+        // the registered handler instead of silently resolving undefined.
+        executeCommandSpy: sandbox.spy(vscode.commands, "executeCommand"),
+    };
+}
+
+function buildContext(stubs: Stubs, version: string | undefined): vscode.ExtensionContext {
+    const id = "test.litellm-connector";
+    stubs.getExtensionStub.withArgs(id).returns({ id, packageJSON: { version } } as vscode.Extension<unknown>);
+
+    return {
+        extension: { id, packageJSON: { version } },
+        subscriptions: [],
+    } as unknown as vscode.ExtensionContext;
+}
+
+function buildService(): ReviewPromptService {
+    const globalState = createMockMemento({
+        "litellm-connector.reviewPrompt.installDate.v1": Date.now(),
+        "litellm-connector.reviewPrompt.successfulTurns.v1": 12,
+        "litellm-connector.reviewPrompt.doNotAskAgain.v1": true,
+    });
+    const telemetry: Pick<TelemetryService, "captureReviewPromptEligible" | "captureReviewPromptChoice"> = {
+        captureReviewPromptEligible: () => undefined,
+        captureReviewPromptChoice: () => undefined,
+    };
+    return new ReviewPromptService(globalState, telemetry as unknown as TelemetryService);
+}
+
+/**
+ * Reads the (command, key, value) triple from a setContext executeCommand spy
+ * call with explicit typing so ESLint's no-unsafe-* rules are satisfied.
+ */
+function readSetContextCall(
+    spy: sinon.SinonSpy,
+    callIndex = 0
+): {
+    command: string;
+    key: string;
+    value: unknown;
+} {
+    const args = spy.getCall(callIndex).args as unknown[];
+    return {
+        command: args[0] as string,
+        key: args[1] as string,
+        value: args[2],
+    };
+}
+
+suite("isDevVersion", () => {
+    test("accepts -dev, -dev1, and -dev99 suffixes", () => {
+        assert.strictEqual(isDevVersion("2.2.3-dev"), true);
+        assert.strictEqual(isDevVersion("2.2.3-dev1"), true);
+        assert.strictEqual(isDevVersion("0.0.1-dev99"), true);
+    });
+
+    test("rejects production-style versions and undefined", () => {
+        assert.strictEqual(isDevVersion("2.2.3"), false);
+        assert.strictEqual(isDevVersion("2.2.3-rc1"), false);
+        assert.strictEqual(isDevVersion(""), false);
+        assert.strictEqual(isDevVersion(undefined), false);
+    });
+});
+
+suite("setDevBuildContextKey", () => {
+    let stubs: Stubs;
+
+    setup(() => {
+        stubs = installStubs();
+    });
+
+    teardown(() => {
+        stubs.sandbox.restore();
+    });
+
+    test("returns true and sets context true on -devN builds", async () => {
+        const context = buildContext(stubs, "2.2.3-dev1");
+
+        const isDev = await setDevBuildContextKey(context);
+
+        assert.strictEqual(isDev, true);
+        assert.strictEqual(stubs.executeCommandSpy.called, true);
+        const call = readSetContextCall(stubs.executeCommandSpy);
+        assert.strictEqual(call.command, "setContext");
+        assert.strictEqual(call.key, DEV_BUILD_CONTEXT_KEY);
+        assert.strictEqual(call.value, true);
+    });
+
+    test("returns false and sets context false on production builds", async () => {
+        const context = buildContext(stubs, "2.2.3");
+
+        const isDev = await setDevBuildContextKey(context);
+
+        assert.strictEqual(isDev, false);
+        const call = readSetContextCall(stubs.executeCommandSpy);
+        assert.strictEqual(call.key, DEV_BUILD_CONTEXT_KEY);
+        assert.strictEqual(call.value, false);
+    });
+
+    test("still sets context false when version lookup throws", async () => {
+        stubs.getExtensionStub.withArgs("test.litellm-connector").throws(new Error("boom"));
+        const context = {
+            extension: { id: "test.litellm-connector" },
+            subscriptions: [],
+        } as unknown as vscode.ExtensionContext;
+
+        const isDev = await setDevBuildContextKey(context);
+
+        assert.strictEqual(isDev, false);
+        const call = readSetContextCall(stubs.executeCommandSpy);
+        assert.strictEqual(call.key, DEV_BUILD_CONTEXT_KEY);
+        assert.strictEqual(call.value, false);
+    });
+});
+
+suite("registerDevResetReviewPromptCommand", () => {
+    let stubs: Stubs;
+    let disposables: vscode.Disposable[];
+
+    setup(() => {
+        stubs = installStubs();
+        disposables = [];
+    });
+
+    teardown(() => {
+        for (const d of disposables) {
+            d.dispose();
+        }
+        stubs.sandbox.restore();
+    });
+
+    test("always registers the command regardless of build", async () => {
+        // Production context: command must still be registered (palette hides it).
+        const prodContext = buildContext(stubs, "2.2.3");
+        await setDevBuildContextKey(prodContext);
+        const service = buildService();
+
+        const disposable = registerDevResetReviewPromptCommand(service);
+        assert.ok(disposable, "command must always be registered; palette visibility is via setContext");
+        disposables.push(disposable);
+
+        const commands = await vscode.commands.getCommands(true);
+        assert.strictEqual(
+            commands.includes("litellm-connector.dev.resetReviewPrompt"),
+            true,
+            "command must be in the command registry even on production builds"
+        );
+    });
+
+    test("resets state on dev builds when activated via setDevBuildContextKey", async () => {
+        const devContext = buildContext(stubs, "2.2.3-dev1");
+        await setDevBuildContextKey(devContext);
+        const service = buildService();
+
+        const disposable = registerDevResetReviewPromptCommand(service);
+        assert.ok(disposable);
+        disposables.push(disposable);
+
+        await vscode.commands.executeCommand("litellm-connector.dev.resetReviewPrompt");
+
+        const state = (service as unknown as { globalState: vscode.Memento }).globalState;
+        assert.strictEqual(
+            state.get("litellm-connector.reviewPrompt.installDate.v1"),
+            undefined,
+            "installDate must be cleared"
+        );
+        assert.strictEqual(
+            state.get("litellm-connector.reviewPrompt.successfulTurns.v1"),
+            undefined,
+            "successfulTurns must be cleared"
+        );
+        assert.strictEqual(
+            state.get("litellm-connector.reviewPrompt.doNotAskAgain.v1"),
+            undefined,
+            "doNotAskAgain must be cleared"
+        );
+        assert.strictEqual(stubs.showInformationMessage.calledOnce, true);
+        assert.strictEqual(stubs.showWarningMessage.called, false);
+    });
+
+    test("handler is a no-op when live extension is production even if context key was stale-true", async () => {
+        // Activate as dev (sets context true), then simulate a hot-swap update to
+        // a production build before invoking the command.
+        const devContext = buildContext(stubs, "2.2.3-dev1");
+        await setDevBuildContextKey(devContext);
+        const service = buildService();
+
+        const disposable = registerDevResetReviewPromptCommand(service);
+        disposables.push(disposable);
+
+        // Re-stub getExtension so the live lookup returns a production build.
+        stubs.getExtensionStub.withArgs("test.litellm-connector").returns({
+            id: "test.litellm-connector",
+            packageJSON: { version: "2.2.3" },
+        } as vscode.Extension<unknown>);
+
+        await vscode.commands.executeCommand("litellm-connector.dev.resetReviewPrompt");
+
+        const state = (service as unknown as { globalState: vscode.Memento }).globalState;
+        assert.strictEqual(
+            state.get("litellm-connector.reviewPrompt.doNotAskAgain.v1"),
+            true,
+            "opt-out flag must be preserved when handler is gated off"
+        );
+        assert.strictEqual(stubs.showInformationMessage.called, false);
+        assert.strictEqual(stubs.showWarningMessage.calledOnce, true);
+    });
+});

--- a/src/engagement/reviewPromptService.ts
+++ b/src/engagement/reviewPromptService.ts
@@ -1,0 +1,174 @@
+import * as vscode from "vscode";
+import { StructuredLogger } from "../observability/structuredLogger";
+import type { TelemetryService } from "../telemetry/telemetryService";
+
+const INSTALL_DATE_KEY = "litellm-connector.reviewPrompt.installDate.v1";
+const SUCCESSFUL_TURNS_KEY = "litellm-connector.reviewPrompt.successfulTurns.v1";
+const DO_NOT_ASK_AGAIN_KEY = "litellm-connector.reviewPrompt.doNotAskAgain.v1";
+const IDLE_DELAY_MS = 5 * 60 * 1000;
+const MINIMUM_SUCCESSFUL_TURNS = 10;
+const MARKETPLACE_URL =
+    "https://marketplace.visualstudio.com/items?itemName=GethNet.litellm-connector-copilot&ssr=false#review-details";
+
+const LEAVE_A_REVIEW = "Leave a Review";
+const MAYBE_LATER = "Maybe Later";
+const DO_NOT_ASK_AGAIN = "Don't Ask Again";
+
+type ReviewPromptChoice = "review_or_rated" | "never_again" | "later";
+
+/**
+ * Owns local-only review prompt eligibility. The service intentionally records only
+ * coarse extension state in globalState and exposes no request content to telemetry or logs.
+ */
+export class ReviewPromptService implements vscode.Disposable {
+    private idleTimer: NodeJS.Timeout | undefined;
+    private initialized = false;
+
+    public constructor(
+        private readonly globalState: vscode.Memento | undefined,
+        private readonly telemetryService: TelemetryService
+    ) {}
+
+    /**
+     * Creates a durable install timestamp once. Existing valid timestamps are never replaced,
+     * allowing time-since-install telemetry to remain stable across extension activation cycles.
+     */
+    public async initialize(): Promise<void> {
+        if (!this.globalState) {
+            return;
+        }
+
+        const installDate = this.globalState.get<unknown>(INSTALL_DATE_KEY);
+        if (typeof installDate !== "number" || !Number.isFinite(installDate)) {
+            await this.globalState.update(INSTALL_DATE_KEY, Date.now());
+        }
+        this.initialized = true;
+    }
+
+    /** Clears the idle countdown immediately when a user begins a new chat request. */
+    public recordChatRequestStarted(): void {
+        this.clearIdleTimer();
+        // If the user is already eligible, restart the 5-minute idle timer from now
+        if (
+            this.initialized &&
+            !this.isPermanentlyDismissed() &&
+            this.getSuccessfulTurnCount() >= MINIMUM_SUCCESSFUL_TURNS
+        ) {
+            this.scheduleIdlePrompt();
+        }
+    }
+
+    /**
+     * Persists a successful chat turn, then starts an idle-only countdown once the engagement
+     * threshold is met. Failed/cancelled turns never call this method and cannot increase eligibility.
+     */
+    public async recordSuccessfulChatTurn(): Promise<void> {
+        if (!this.initialized || !this.globalState || this.isPermanentlyDismissed()) {
+            return;
+        }
+
+        const successfulTurnCount = this.getSuccessfulTurnCount() + 1;
+        await this.globalState.update(SUCCESSFUL_TURNS_KEY, successfulTurnCount);
+        if (successfulTurnCount >= MINIMUM_SUCCESSFUL_TURNS) {
+            this.scheduleIdlePrompt();
+        }
+    }
+
+    public dispose(): void {
+        this.clearIdleTimer();
+    }
+
+    /**
+     * Wipes all durable review-prompt state and cancels any pending idle timer.
+     * Intended for local development use only; production callers should prefer
+     * "Don't Ask Again" or "Maybe Later" so the user remains in control of their
+     * engagement cadence.
+     */
+    public async clearReviewPromptState(): Promise<void> {
+        this.clearIdleTimer();
+        this.initialized = false;
+        if (!this.globalState) {
+            return;
+        }
+
+        await this.globalState.update(INSTALL_DATE_KEY, undefined);
+        await this.globalState.update(SUCCESSFUL_TURNS_KEY, undefined);
+        await this.globalState.update(DO_NOT_ASK_AGAIN_KEY, undefined);
+    }
+
+    private getSuccessfulTurnCount(): number {
+        const storedCount = this.globalState?.get<unknown>(SUCCESSFUL_TURNS_KEY);
+        return typeof storedCount === "number" && Number.isFinite(storedCount) && storedCount >= 0 ? storedCount : 0;
+    }
+
+    private getInstallDate(): number {
+        const installDate = this.globalState?.get<unknown>(INSTALL_DATE_KEY);
+        return typeof installDate === "number" && Number.isFinite(installDate) ? installDate : Date.now();
+    }
+
+    private isPermanentlyDismissed(): boolean {
+        return this.globalState?.get<boolean>(DO_NOT_ASK_AGAIN_KEY, false) === true;
+    }
+
+    private scheduleIdlePrompt(): void {
+        this.clearIdleTimer();
+        this.idleTimer = setTimeout(() => {
+            this.idleTimer = undefined;
+            void this.showPromptIfEligible();
+        }, IDLE_DELAY_MS);
+    }
+
+    private clearIdleTimer(): void {
+        if (this.idleTimer) {
+            clearTimeout(this.idleTimer);
+            this.idleTimer = undefined;
+        }
+    }
+
+    private async showPromptIfEligible(): Promise<void> {
+        if (!this.globalState || this.isPermanentlyDismissed()) {
+            return;
+        }
+
+        const successfulTurnCount = this.getSuccessfulTurnCount();
+        if (successfulTurnCount < MINIMUM_SUCCESSFUL_TURNS) {
+            return;
+        }
+
+        const installDate = this.getInstallDate();
+        this.telemetryService.captureReviewPromptEligible({ installDate, successfulTurnCount });
+        StructuredLogger.info("review_prompt.eligible", { installDate, successfulTurnCount });
+
+        const selected = await vscode.window.showInformationMessage(
+            "Enjoying LiteLLM Connector? A Marketplace review helps other developers discover it.",
+            LEAVE_A_REVIEW,
+            MAYBE_LATER,
+            DO_NOT_ASK_AGAIN
+        );
+
+        if (selected === LEAVE_A_REVIEW) {
+            await this.globalState.update(DO_NOT_ASK_AGAIN_KEY, true);
+            this.recordChoice("review_or_rated", installDate, successfulTurnCount);
+            await vscode.env.openExternal(vscode.Uri.parse(MARKETPLACE_URL));
+            return;
+        }
+
+        if (selected === DO_NOT_ASK_AGAIN) {
+            await this.globalState.update(DO_NOT_ASK_AGAIN_KEY, true);
+            this.recordChoice("never_again", installDate, successfulTurnCount);
+            return;
+        }
+
+        this.recordChoice("later", installDate, successfulTurnCount);
+        this.scheduleIdlePrompt();
+    }
+
+    private recordChoice(choice: ReviewPromptChoice, installDate: number, successfulTurnCount: number): void {
+        this.telemetryService.captureReviewPromptChoice({ choice, installDate, successfulTurnCount });
+        StructuredLogger.info("review_prompt.choice_recorded", {
+            choice,
+            installDate,
+            successfulTurnCount,
+        });
+    }
+}

--- a/src/engagement/reviewPromptService.ts
+++ b/src/engagement/reviewPromptService.ts
@@ -153,7 +153,11 @@ export class ReviewPromptService implements vscode.Disposable {
     }
 
     private async showPromptIfEligible(): Promise<void> {
-        if (!this.globalState || this.isPermanentlyDismissed()) {
+        // Re-check session deferral at the display boundary as defense-in-depth. A timer armed
+        // before the user deferred (e.g. a chat started while the notification was already on
+        // screen) can fire after `deferredSessionId` is set; the scheduling guards cannot close
+        // that race because `idleTimer` is already `undefined` once the callback is executing.
+        if (!this.globalState || this.isPermanentlyDismissed() || this.isSessionDeferred()) {
             return;
         }
 

--- a/src/engagement/reviewPromptService.ts
+++ b/src/engagement/reviewPromptService.ts
@@ -19,10 +19,22 @@ type ReviewPromptChoice = "review_or_rated" | "never_again" | "later";
 /**
  * Owns local-only review prompt eligibility. The service intentionally records only
  * coarse extension state in globalState and exposes no request content to telemetry or logs.
+ *
+ * Session-scoped suppression: "Maybe Later" (or a dismissed notification) suppresses
+ * further prompts for the remainder of the current VS Code session only. The session
+ * marker is read from `vscode.env.sessionId` and kept entirely in memory — it is never
+ * persisted to durable `globalState`. When the session changes (VS Code restart), the
+ * user is treated as if they had never deferred, so the eligibility cycle restarts.
  */
 export class ReviewPromptService implements vscode.Disposable {
     private idleTimer: NodeJS.Timeout | undefined;
     private initialized = false;
+    /**
+     * In-memory-only record of the session that last deferred the prompt. Stored as a
+     * field (not in durable `globalState`) so it evaporates on extension deactivation.
+     * When `vscode.env.sessionId` differs from this value, the deferral is cleared.
+     */
+    private deferredSessionId: string | undefined;
 
     public constructor(
         private readonly globalState: vscode.Memento | undefined,
@@ -48,10 +60,11 @@ export class ReviewPromptService implements vscode.Disposable {
     /** Clears the idle countdown immediately when a user begins a new chat request. */
     public recordChatRequestStarted(): void {
         this.clearIdleTimer();
-        // If the user is already eligible, restart the 5-minute idle timer from now
+        // If the user is already eligible and has not deferred this session, restart the 5-minute idle timer.
         if (
             this.initialized &&
             !this.isPermanentlyDismissed() &&
+            !this.isSessionDeferred() &&
             this.getSuccessfulTurnCount() >= MINIMUM_SUCCESSFUL_TURNS
         ) {
             this.scheduleIdlePrompt();
@@ -69,7 +82,7 @@ export class ReviewPromptService implements vscode.Disposable {
 
         const successfulTurnCount = this.getSuccessfulTurnCount() + 1;
         await this.globalState.update(SUCCESSFUL_TURNS_KEY, successfulTurnCount);
-        if (successfulTurnCount >= MINIMUM_SUCCESSFUL_TURNS) {
+        if (successfulTurnCount >= MINIMUM_SUCCESSFUL_TURNS && !this.isSessionDeferred()) {
             this.scheduleIdlePrompt();
         }
     }
@@ -108,6 +121,20 @@ export class ReviewPromptService implements vscode.Disposable {
 
     private isPermanentlyDismissed(): boolean {
         return this.globalState?.get<boolean>(DO_NOT_ASK_AGAIN_KEY, false) === true;
+    }
+
+    /**
+     * Returns true when the current VS Code session has already deferred the prompt via
+     * "Maybe Later" or dismissal. The deferral is kept in memory only (never durable), so a
+     * new session — even one that reuses a stale `sessionId` after a restart — clears it
+     * because the field is reset on construction. The check compares the live
+     * `vscode.env.sessionId` against the stored deferral marker.
+     */
+    private isSessionDeferred(): boolean {
+        if (this.deferredSessionId === undefined) {
+            return false;
+        }
+        return vscode.env.sessionId === this.deferredSessionId;
     }
 
     private scheduleIdlePrompt(): void {
@@ -159,8 +186,12 @@ export class ReviewPromptService implements vscode.Disposable {
             return;
         }
 
+        // "Maybe Later" or a dismissed (undefined) notification: suppress for the remainder of
+        // this VS Code session only. The deferral is stored in memory keyed by the current
+        // sessionId; it is NOT persisted to durable globalState, so a session change (restart)
+        // treats the user as if they had never deferred.
+        this.deferredSessionId = vscode.env.sessionId;
         this.recordChoice("later", installDate, successfulTurnCount);
-        this.scheduleIdlePrompt();
     }
 
     private recordChoice(choice: ReviewPromptChoice, installDate: number, successfulTurnCount: number): void {

--- a/src/engagement/test/reviewPromptService.test.ts
+++ b/src/engagement/test/reviewPromptService.test.ts
@@ -178,6 +178,37 @@ suite("ReviewPromptService", () => {
         assert.strictEqual(showInformationMessage.calledTwice, true);
     });
 
+    test("does not re-prompt when a new request is started while the prompt is displayed and the user then clicks Maybe Later", async () => {
+        service = createService();
+
+        // Hold the notification open so we can inject behavior while it is displayed.
+        let resolvePrompt: (value: string | undefined) => void = () => {};
+        const promptDisplayed = new Promise<string | undefined>((resolve) => {
+            resolvePrompt = resolve;
+        });
+        showInformationMessage.callsFake(() => promptDisplayed);
+
+        await service.initialize();
+        await recordSuccessfulTurns(service, 10);
+
+        // Fire the idle timer so the prompt is now displayed and awaiting user input.
+        await clock.tickAsync(5 * 60 * 1000);
+        assert.strictEqual(showInformationMessage.calledOnce, true);
+
+        // While the notification is displayed, the user begins a new chat. The scheduling
+        // guards see no session deferral yet (the user has not clicked anything), so a new
+        // 5-minute timer is armed. The race window being closed is the point of this test.
+        service.recordChatRequestStarted();
+
+        // User clicks "Maybe Later", setting the in-memory session deferral.
+        resolvePrompt("Maybe Later");
+        await clock.tickAsync(0);
+
+        // The timer armed during the displayed notification must not re-prompt.
+        await clock.tickAsync(5 * 60 * 1000);
+        assert.strictEqual(showInformationMessage.calledOnce, true);
+    });
+
     test("does not initialize or schedule a prompt when global state is unavailable", async () => {
         createService();
         service = new ReviewPromptService(undefined, telemetryService as unknown as TelemetryService);

--- a/src/engagement/test/reviewPromptService.test.ts
+++ b/src/engagement/test/reviewPromptService.test.ts
@@ -1,0 +1,170 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import { ReviewPromptService } from "../reviewPromptService";
+import type { TelemetryService } from "../../telemetry/telemetryService";
+import { StructuredLogger } from "../../observability/structuredLogger";
+import { createMockMemento } from "../../test/utils/testMocks";
+
+suite("ReviewPromptService", () => {
+    let sandbox: sinon.SinonSandbox;
+    let clock: sinon.SinonFakeTimers;
+    let globalState: vscode.Memento;
+    let telemetryService: sinon.SinonStubbedInstance<TelemetryService>;
+    let showInformationMessage: sinon.SinonStub;
+    let openExternal: sinon.SinonStub;
+    let service: ReviewPromptService;
+
+    function createService(seed: Record<string, unknown> = {}): ReviewPromptService {
+        globalState = createMockMemento(seed);
+        telemetryService = {
+            captureReviewPromptEligible: sandbox.stub(),
+            captureReviewPromptChoice: sandbox.stub(),
+        } as unknown as sinon.SinonStubbedInstance<TelemetryService>;
+        showInformationMessage = sandbox.stub(vscode.window, "showInformationMessage").resolves(undefined);
+        openExternal = sandbox.stub(vscode.env, "openExternal").resolves(true);
+        return new ReviewPromptService(globalState, telemetryService as unknown as TelemetryService);
+    }
+
+    async function recordSuccessfulTurns(instance: ReviewPromptService, count: number): Promise<void> {
+        for (let index = 0; index < count; index += 1) {
+            await instance.recordSuccessfulChatTurn();
+        }
+    }
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        clock = sandbox.useFakeTimers({ now: new Date("2026-07-26T12:00:00.000Z") });
+        sandbox.stub(StructuredLogger, "info");
+    });
+
+    teardown(() => {
+        service?.dispose();
+        sandbox.restore();
+    });
+
+    test("records the install date once and does not prompt before ten successful turns", async () => {
+        service = createService();
+
+        await service.initialize();
+        await recordSuccessfulTurns(service, 9);
+        await clock.tickAsync(5 * 60 * 1000);
+
+        assert.strictEqual(typeof globalState.get<number>("litellm-connector.reviewPrompt.installDate.v1"), "number");
+        assert.strictEqual(showInformationMessage.called, false);
+        assert.strictEqual(telemetryService.captureReviewPromptEligible.called, false);
+    });
+
+    test("prompts after ten successful turns and five minutes without a new request", async () => {
+        service = createService();
+        await service.initialize();
+        await recordSuccessfulTurns(service, 10);
+
+        await clock.tickAsync(5 * 60 * 1000);
+
+        assert.strictEqual(showInformationMessage.calledOnce, true);
+        assert.strictEqual(telemetryService.captureReviewPromptEligible.calledOnce, true);
+        assert.deepStrictEqual(telemetryService.captureReviewPromptEligible.firstCall.args[0], {
+            installDate: new Date("2026-07-26T12:00:00.000Z").getTime(),
+            successfulTurnCount: 10,
+        });
+    });
+
+    test("restarts the five-minute countdown when a new request begins", async () => {
+        service = createService();
+        await service.initialize();
+        await recordSuccessfulTurns(service, 10);
+
+        await clock.tickAsync(4 * 60 * 1000);
+        service.recordChatRequestStarted();
+        await clock.tickAsync(60 * 1000);
+        assert.strictEqual(showInformationMessage.called, false);
+
+        await clock.tickAsync(4 * 60 * 1000);
+        assert.strictEqual(showInformationMessage.calledOnce, true);
+    });
+
+    test("opens the extension Marketplace page and permanently suppresses later prompts after Leave a Review", async () => {
+        service = createService();
+        showInformationMessage.resolves("Leave a Review");
+        await service.initialize();
+        await recordSuccessfulTurns(service, 10);
+
+        await clock.tickAsync(5 * 60 * 1000);
+
+        assert.strictEqual(globalState.get<boolean>("litellm-connector.reviewPrompt.doNotAskAgain.v1"), true);
+        assert.strictEqual(openExternal.calledOnce, true);
+        assert.strictEqual(
+            decodeURIComponent(openExternal.firstCall.args[0].toString()),
+            "https://marketplace.visualstudio.com/items?itemName=GethNet.litellm-connector-copilot&ssr=false#review-details"
+        );
+        assert.deepStrictEqual(telemetryService.captureReviewPromptChoice.firstCall.args[0], {
+            choice: "review_or_rated",
+            installDate: new Date("2026-07-26T12:00:00.000Z").getTime(),
+            successfulTurnCount: 10,
+        });
+
+        await service.recordSuccessfulChatTurn();
+        await clock.tickAsync(5 * 60 * 1000);
+        assert.strictEqual(showInformationMessage.calledOnce, true);
+    });
+
+    test("permanently suppresses later prompts after Don't Ask Again", async () => {
+        service = createService();
+        showInformationMessage.resolves("Don't Ask Again");
+        await service.initialize();
+        await recordSuccessfulTurns(service, 10);
+
+        await clock.tickAsync(5 * 60 * 1000);
+
+        assert.strictEqual(globalState.get<boolean>("litellm-connector.reviewPrompt.doNotAskAgain.v1"), true);
+        assert.strictEqual(openExternal.called, false);
+        assert.deepStrictEqual(telemetryService.captureReviewPromptChoice.firstCall.args[0], {
+            choice: "never_again",
+            installDate: new Date("2026-07-26T12:00:00.000Z").getTime(),
+            successfulTurnCount: 10,
+        });
+    });
+
+    test("records later for Maybe Later and a dismissed notification without setting terminal opt-out", async () => {
+        service = createService();
+        showInformationMessage.onFirstCall().resolves("Maybe Later");
+        showInformationMessage.onSecondCall().resolves(undefined);
+        await service.initialize();
+        await recordSuccessfulTurns(service, 10);
+
+        await clock.tickAsync(5 * 60 * 1000);
+        assert.strictEqual(globalState.get<boolean>("litellm-connector.reviewPrompt.doNotAskAgain.v1", false), false);
+        assert.deepStrictEqual(telemetryService.captureReviewPromptChoice.firstCall.args[0], {
+            choice: "later",
+            installDate: new Date("2026-07-26T12:00:00.000Z").getTime(),
+            successfulTurnCount: 10,
+        });
+
+        await clock.tickAsync(5 * 60 * 1000);
+        assert.strictEqual(showInformationMessage.calledTwice, true);
+        assert.strictEqual(telemetryService.captureReviewPromptChoice.secondCall.args[0].choice, "later");
+    });
+
+    test("does not initialize or schedule a prompt when global state is unavailable", async () => {
+        createService();
+        service = new ReviewPromptService(undefined, telemetryService as unknown as TelemetryService);
+
+        await service.initialize();
+        await service.recordSuccessfulChatTurn();
+        await clock.tickAsync(5 * 60 * 1000);
+
+        assert.strictEqual(showInformationMessage.called, false);
+        assert.strictEqual(telemetryService.captureReviewPromptEligible.called, false);
+    });
+
+    test("clears a pending idle timer when disposed", async () => {
+        service = createService();
+        await service.initialize();
+        await recordSuccessfulTurns(service, 10);
+        service.dispose();
+
+        await clock.tickAsync(5 * 60 * 1000);
+        assert.strictEqual(showInformationMessage.called, false);
+    });
+});

--- a/src/engagement/test/reviewPromptService.test.ts
+++ b/src/engagement/test/reviewPromptService.test.ts
@@ -13,6 +13,7 @@ suite("ReviewPromptService", () => {
     let telemetryService: sinon.SinonStubbedInstance<TelemetryService>;
     let showInformationMessage: sinon.SinonStub;
     let openExternal: sinon.SinonStub;
+    let sessionIdStub: sinon.SinonStub;
     let service: ReviewPromptService;
 
     function createService(seed: Record<string, unknown> = {}): ReviewPromptService {
@@ -23,6 +24,7 @@ suite("ReviewPromptService", () => {
         } as unknown as sinon.SinonStubbedInstance<TelemetryService>;
         showInformationMessage = sandbox.stub(vscode.window, "showInformationMessage").resolves(undefined);
         openExternal = sandbox.stub(vscode.env, "openExternal").resolves(true);
+        sessionIdStub = sandbox.stub(vscode.env, "sessionId").get(() => "test-session-id");
         return new ReviewPromptService(globalState, telemetryService as unknown as TelemetryService);
     }
 
@@ -126,10 +128,9 @@ suite("ReviewPromptService", () => {
         });
     });
 
-    test("records later for Maybe Later and a dismissed notification without setting terminal opt-out", async () => {
+    test("suppresses further prompts for the remainder of the active session after Maybe Later", async () => {
         service = createService();
-        showInformationMessage.onFirstCall().resolves("Maybe Later");
-        showInformationMessage.onSecondCall().resolves(undefined);
+        showInformationMessage.resolves("Maybe Later");
         await service.initialize();
         await recordSuccessfulTurns(service, 10);
 
@@ -141,9 +142,40 @@ suite("ReviewPromptService", () => {
             successfulTurnCount: 10,
         });
 
+        // Further idle periods and chat turns in the SAME session must not re-prompt.
+        await recordSuccessfulTurns(service, 5);
+        await clock.tickAsync(5 * 60 * 1000);
+        assert.strictEqual(showInformationMessage.calledOnce, true);
+    });
+
+    test("dismissed notification also suppresses further prompts for the active session", async () => {
+        service = createService();
+        showInformationMessage.resolves(undefined);
+        await service.initialize();
+        await recordSuccessfulTurns(service, 10);
+
+        await clock.tickAsync(5 * 60 * 1000);
+        assert.strictEqual(telemetryService.captureReviewPromptChoice.firstCall.args[0].choice, "later");
+
+        await recordSuccessfulTurns(service, 5);
+        await clock.tickAsync(5 * 60 * 1000);
+        assert.strictEqual(showInformationMessage.calledOnce, true);
+    });
+
+    test("re-prompts after a session change even if the user previously chose Maybe Later", async () => {
+        service = createService();
+        showInformationMessage.resolves("Maybe Later");
+        await service.initialize();
+        await recordSuccessfulTurns(service, 10);
+
+        await clock.tickAsync(5 * 60 * 1000);
+        assert.strictEqual(showInformationMessage.calledOnce, true);
+
+        // Simulate a new VS Code session with a different sessionId.
+        sessionIdStub.get(() => "new-session-id");
+        await recordSuccessfulTurns(service, 5);
         await clock.tickAsync(5 * 60 * 1000);
         assert.strictEqual(showInformationMessage.calledTwice, true);
-        assert.strictEqual(telemetryService.captureReviewPromptChoice.secondCall.args[0].choice, "later");
     });
 
     test("does not initialize or schedule a prompt when global state is unavailable", async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import {
 } from "./commands/manageConfig";
 import { registerGenerateCommitMessageCommand } from "./commands/generateCommitMessage";
 import { registerSetLogLevelCommand } from "./commands/setLogLevel";
+import { registerDevResetReviewPromptCommand, setDevBuildContextKey } from "./commands/devTools";
 import { LiteLLMCommitMessageProvider } from "./providers/liteLLMCommitProvider";
 import { Logger } from "./utils/logger";
 import { StructuredLogger } from "./observability";
@@ -18,6 +19,7 @@ import { LiteLLMTelemetry } from "./utils/telemetry";
 import { setTelemetryService as setTokenUtilsTelemetryService } from "./adapters/tokenUtils";
 import { EffortFallbackCache } from "./utils/reasoningEffortFallback";
 import { LegacyConfigMigration } from "./config/legacyConfigMigration";
+import { ReviewPromptService } from "./engagement/reviewPromptService";
 
 // Store the config manager for cleanup on deactivation
 let configManagerInstance: ConfigManager | undefined;
@@ -174,6 +176,12 @@ export function activate(context: vscode.ExtensionContext): void {
     activeChatProviderInstance = activeProvider; // Store for cleanup on deactivation
     activeProvider.setTelemetryService(telemetryService);
 
+    const reviewPromptService = new ReviewPromptService(context.globalState, telemetryService);
+    context.subscriptions.push(reviewPromptService);
+    void reviewPromptService.initialize();
+
+    activeProvider.setReviewPromptService(reviewPromptService);
+
     const isOnModernConfigAtStartup = getModernConfigSessionFlag();
     telemetryService.captureModernConfigStatus({
         is_on_modern_config: isOnModernConfigAtStartup,
@@ -294,6 +302,14 @@ export function activate(context: vscode.ExtensionContext): void {
         context.subscriptions.push(registerReloadModelsCommand(activeProvider, telemetryService));
         context.subscriptions.push(registerGenerateCommitMessageCommand(commitProvider, telemetryService));
         context.subscriptions.push(registerSetLogLevelCommand());
+
+        // Dev-only reset-review-prompt command. The command is always registered
+        // so VS Code can execute it once the `commandPalette` `when` clause
+        // surfaces it. Visibility is controlled by the `litellm-connector.isDevBuild`
+        // context key (set below); the handler also re-checks the live version as
+        // a defense-in-depth guard against stale context after hot-swap updates.
+        context.subscriptions.push(registerDevResetReviewPromptCommand(reviewPromptService));
+        void setDevBuildContextKey(context);
         Logger.info("Config command registered.");
     } catch (cmdErr) {
         Logger.error("Failed to register commands", cmdErr);

--- a/src/providers/base/callConfig.ts
+++ b/src/providers/base/callConfig.ts
@@ -1,0 +1,109 @@
+import * as vscode from "vscode";
+import { Logger } from "../../utils/logger";
+import type { ConfigManager } from "../../config/configManager";
+import type { LiteLLMProviderRegistry } from "../liteLLMProviderRegistry";
+
+/**
+ * Dependencies needed to resolve the per-group configuration for a
+ * response-time call. Extracted as an interface so the resolver is a pure
+ * function of (options, model, deps) and unit-testable in isolation.
+ */
+export interface CallConfigDeps {
+    configManager: ConfigManager;
+    registry: Pick<LiteLLMProviderRegistry, "lookup">;
+}
+
+/**
+ * Resolves the per-group configuration for a response-time call.
+ *
+ * Discovery-time call paths and the per-group config come from
+ * `options.configuration` (set by VS Code 1.120 at discovery time).
+ * Response-time paths in VS Code 1.120 do NOT pass the per-group config
+ * on `options.configuration` — the proposed-type definition for
+ * `ProvideLanguageModelChatResponseOptions` does not declare that field.
+ *
+ * As a fallback we consult the in-memory `LiteLLMProviderRegistry` keyed
+ * by the model id. The registry is populated by every successful
+ * discovery call, so a model that's been discovered in this session is
+ * routable. If neither channel has the model, the call is a
+ * configuration problem and the transport surfaces a visible error.
+ *
+ * IMPORTANT: VS Code may pass an EMPTY configuration object (truthy, but
+ * no `baseUrl` or `apiKey`) for some calls, particularly for models picked
+ * from a group other than the one currently being routed. We trust
+ * `options.configuration` ONLY when it has both a usable `baseUrl`
+ * (string, non-empty) and a usable `apiKey` (string, non-empty). Anything
+ * else falls through to the registry. Without this guard, the empty
+ * object previously short-circuited the registry fallback and produced a
+ * "No baseUrl provided" runtime error.
+ *
+ * Both resolution paths merge the workspace-config ergonomic toggles
+ * (`allowChatCompletionsFallback`, `disableCaching`) onto the returned
+ * configuration so the transport can read them without a second config
+ * fetch on the hot path.
+ */
+export async function resolveCallTimeConfiguration(
+    options: vscode.ProvideLanguageModelChatResponseOptions,
+    model: vscode.LanguageModelChatInformation,
+    deps: CallConfigDeps
+): Promise<Record<string, unknown> | undefined> {
+    const opt = options as vscode.ProvideLanguageModelChatResponseOptions & {
+        configuration?: Record<string, unknown>;
+    };
+    const optBaseUrl = typeof opt.configuration?.baseUrl === "string" ? opt.configuration.baseUrl.trim() : "";
+    const optApiKey = typeof opt.configuration?.apiKey === "string" ? opt.configuration.apiKey.trim() : "";
+
+    // Fetch workspace-config toggles once so both paths can merge them.
+    const cfg = await deps.configManager.getConfig();
+
+    if (opt.configuration && optBaseUrl.length > 0 && optApiKey.length > 0) {
+        Logger.trace(
+            `getCallTimeConfiguration: HIT via options.configuration modelId="${model.id}" baseUrl="${optBaseUrl}"`
+        );
+        // Merge workspace-config ergonomic toggles onto the per-group
+        // configuration so the transport can read allowChatCompletionsFallback
+        // and disableCaching without a separate config fetch on the hot path.
+        return {
+            ...opt.configuration,
+            allowChatCompletionsFallback: cfg.allowChatCompletionsFallback,
+            disableCaching: cfg.disableCaching,
+        };
+    }
+    if (opt.configuration) {
+        // Object is present but malformed (empty / missing fields).
+        // This is the case we need to escape from — VS Code passed an
+        // empty object and we must not trust it.
+        Logger.trace(
+            `getCallTimeConfiguration: options.configuration present but invalid (empty baseUrl or apiKey) modelId="${model.id}"; falling back to registry`
+        );
+    } else {
+        Logger.trace(
+            `getCallTimeConfiguration: options.configuration missing; falling back to registry lookup for modelId="${model.id}" modelName="${model.name}"`
+        );
+    }
+    // No options.configuration at response time (the common case in VS
+    // Code 1.120+). Fall back to the in-memory registry. The model id
+    // VS Code hands back is the namespaced `<routing>/<raw>` form
+    // produced by `LiteLLMProviderRegistry.toVSCodeInfo`; the registry
+    // maps that id back to the {baseUrl, apiKey} of the backend that
+    // produced it. The request builder extracts the raw model name
+    // from `model.id` for `request.model`; the transport only needs
+    // baseUrl + apiKey.
+    const entry = deps.registry.lookup(model.id);
+    if (entry) {
+        Logger.trace(`getCallTimeConfiguration: registry HIT modelId="${model.id}" -> baseUrl="${entry.baseUrl}"`);
+        // Same ergonomic-toggle merge as the options.configuration path above,
+        // so /responses fallback + disableCaching work regardless of which
+        // path resolved baseUrl/apiKey.
+        return {
+            baseUrl: entry.baseUrl,
+            apiKey: entry.apiKey,
+            allowChatCompletionsFallback: cfg.allowChatCompletionsFallback,
+            disableCaching: cfg.disableCaching,
+        };
+    }
+    Logger.warn(
+        `getCallTimeConfiguration: registry MISS modelId="${model.id}" modelName="${model.name}" — request will fail with configuration error`
+    );
+    return undefined;
+}

--- a/src/providers/base/parameterFiltering.ts
+++ b/src/providers/base/parameterFiltering.ts
@@ -1,0 +1,139 @@
+import type { LiteLLMModelInfo } from "../../types";
+
+/**
+ * Static fallback parameter limitations for known model families.
+ * Used as fallback when model info (supported_openai_params) is unavailable.
+ * These are prefix matches - if modelId includes the key, the limitation applies.
+ */
+export const KNOWN_PARAMETER_LIMITATIONS: Record<string, Set<string>> = {
+    "claude-3-5-sonnet": new Set(["temperature"]),
+    "claude-3-5-haiku": new Set(["temperature"]),
+    "claude-3-opus": new Set(["temperature"]),
+    "claude-3-sonnet": new Set(["temperature"]),
+    "claude-3-haiku": new Set(["temperature"]),
+    "claude-haiku-4-5": new Set(["temperature"]),
+    "gpt-5.1-codex": new Set(["temperature", "frequency_penalty", "presence_penalty"]),
+    "gpt-5.1-codex-mini": new Set(["temperature", "frequency_penalty", "presence_penalty"]),
+    "gpt-5.1-codex-max": new Set(["temperature", "frequency_penalty", "presence_penalty"]),
+    "codex-mini-latest": new Set(["temperature", "frequency_penalty", "presence_penalty"]),
+    "o1-": new Set(["temperature", "top_p", "presence_penalty", "frequency_penalty"]),
+    "gpt-5": new Set(["temperature", "top_p", "presence_penalty", "frequency_penalty"]),
+};
+
+/**
+ * Parameters the detector treats as "restrictable" — i.e. when a model's
+ * `supported_openai_params` is present but does NOT list one of these,
+ * we strip it. Non-restrictable parameters are left in place when absent
+ * from the supported list (preserves legacy lenient behavior).
+ */
+const RESTRICTABLE_PARAMS: ReadonlySet<string> = new Set([
+    "temperature",
+    "top_p",
+    "presence_penalty",
+    "frequency_penalty",
+    "stop",
+    "reasoning_effort",
+    "tool_choice",
+    "cache",
+]);
+
+/**
+ * Decides whether a given OpenAI parameter can be sent to a model.
+ *
+ * Source of truth: the `supported_openai_params` array on the model's
+ * `LiteLLMModelInfo` (delivered by the registry). There is no probe
+ * cache here — the registry's per-model capability data is authoritative
+ * and re-validated on every discovery call, so a stale cache layer
+ * would only ever shadow correct information and (as observed in
+ * production) cause a model to silently drop parameters it actually
+ * supports.
+ *
+ * Resolution order:
+ * 1. Exact-id `KNOWN_PARAMETER_LIMITATIONS` match → unsupported.
+ * 2. Prefix `KNOWN_PARAMETER_LIMITATIONS` match → unsupported.
+ * 3. `modelInfo.supported_openai_params` present:
+ *      - empty array → unsupported (model reports "supports nothing").
+ *      - param listed → supported.
+ *      - param absent and restrictable → unsupported.
+ *      - param absent and non-restrictable → supported (lenient).
+ * 4. No model info at all → supported (assume openai-compatible default).
+ */
+export function isParameterSupported(
+    param: string,
+    modelInfo: LiteLLMModelInfo | undefined,
+    modelId?: string
+): boolean {
+    if (modelId) {
+        if (KNOWN_PARAMETER_LIMITATIONS[modelId]?.has(param)) {
+            return false;
+        }
+        for (const [knownModel, limitations] of Object.entries(KNOWN_PARAMETER_LIMITATIONS)) {
+            if (modelId.includes(knownModel) && limitations.has(param)) {
+                return false;
+            }
+        }
+    }
+
+    if (modelInfo?.supported_openai_params) {
+        const supportedParams = modelInfo.supported_openai_params;
+        const normalizedParam = param.toLowerCase();
+        const isSupported = supportedParams.some((p) => p.toLowerCase() === normalizedParam);
+
+        if (supportedParams.length === 0) {
+            return false;
+        }
+
+        if (!isSupported) {
+            return !isRestrictableParam(param);
+        }
+        return true;
+    }
+
+    return true;
+}
+
+/** True when `param` is in the restrictable set (case-insensitive). */
+export function isRestrictableParam(param: string): boolean {
+    return RESTRICTABLE_PARAMS.has(param.toLowerCase());
+}
+
+/**
+ * Removes parameters the model does not support from an OpenAI-compatible
+ * request body, in place. Covers the standard scalar params plus LiteLLM's
+ * cache-bypass (`extra_body.cache`), which is retained only when the model
+ * explicitly supports the `cache` parameter.
+ */
+export function stripUnsupportedParametersFromRequest(
+    requestBody: Record<string, unknown>,
+    modelInfo: LiteLLMModelInfo | undefined,
+    modelId?: string
+): void {
+    const paramsToCheck = [
+        "temperature",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_p",
+        "no_cache",
+        "no-cache",
+        "tool_choice", // Added for GPT-5.6 Azure and similar models that don't support tool_choice
+    ];
+    for (const p of paramsToCheck) {
+        if (!isParameterSupported(p, modelInfo, modelId) && p in requestBody) {
+            delete requestBody[p];
+        }
+    }
+
+    // LiteLLM's cache bypass is carried only by extra_body.cache. It is
+    // retained when the model explicitly supports the cache parameter.
+    delete requestBody.cache;
+    if (requestBody.extra_body && typeof requestBody.extra_body === "object") {
+        const extraBody = requestBody.extra_body as Record<string, unknown>;
+        if (!isParameterSupported("cache", modelInfo, modelId)) {
+            delete extraBody.cache;
+        }
+        if (Object.keys(extraBody).length === 0) {
+            delete requestBody.extra_body;
+        }
+    }
+}

--- a/src/providers/base/quotaRedaction.ts
+++ b/src/providers/base/quotaRedaction.ts
@@ -1,0 +1,442 @@
+import * as vscode from "vscode";
+import type { LanguageModelChatRequestMessage } from "vscode";
+import type { OpenAIChatCompletionRequest } from "../../types";
+import type { LiteLLMModelInfo } from "../../types";
+import { Logger } from "../../utils/logger";
+import { LiteLLMTelemetry } from "../../utils/telemetry";
+
+/**
+ * Tools the detector knows how to redact. Kept narrow on purpose — the
+ * legacy detector only knew `insert_edit_into_file` and
+ * `replace_string_in_file`. Adding more here is a deliberate code change
+ * and must come with a test that exercises a real tool result for the new
+ * tool name (not just a substring match in prompt scaffolding).
+ */
+export const REDACTABLE_TOOL_NAMES: readonly string[] = ["insert_edit_into_file", "replace_string_in_file"] as const;
+
+export const QUOTA_PHRASE_REGEX =
+    /(\b429\b|rate\s*limit\s*exceeded|rate\s*limited|too\s*many\s*requests|insufficient\s*quota|quota\s*exceeded|exceeded\s*your\s*current\s*quota)/i;
+
+/**
+ * Dependencies the pure quota-redaction detector needs from its caller.
+ * Injecting these (instead of closing over `this`) keeps the module pure
+ * and testable in isolation; the base provider wires real implementations.
+ */
+export interface QuotaRedactionDeps {
+    /** Reports a quota-redaction telemetry metric. Defaults to `LiteLLMTelemetry.reportMetric`. */
+    reportMetric?: (metric: {
+        requestId: string;
+        model: string;
+        status: "success" | "failure" | "caching_bypassed";
+        error: string;
+        caller?: string;
+    }) => void;
+}
+
+/**
+ * Result of scanning message history for a quota error.
+ *
+ * - `high`   — a real provider 429 attached to a tool result for a redactable tool.
+ * - `low`    — a quota phrase in non-tool-result text (observability only, no redaction).
+ * - `none`   — no quota phrase found anywhere actionable.
+ */
+export type QuotaRedactionConfidence = "none" | "low" | "high";
+
+export interface QuotaRedactionResult {
+    tools: readonly vscode.LanguageModelChatTool[];
+    confidence: QuotaRedactionConfidence;
+}
+
+/**
+ * Decides whether the conversation history contains a real provider-side
+ * quota error attached to a tool call we know how to redact, and if so
+ * returns a filtered tools list with the offending tool removed for the
+ * current turn.
+ *
+ * High-confidence match: a `LanguageModelToolResultPart` whose text
+ * contains a quota phrase AND whose `callId` resolves to one of the
+ * `REDACTABLE_TOOL_NAMES` tools (verified by walking the messages in
+ * reverse to find the matching `LanguageModelToolCallPart`).
+ *
+ * Low-confidence match: a quota phrase appearing in any other text
+ * content. This is returned for observability (DEBUG log, telemetry
+ * counter) but does NOT trigger redaction.
+ *
+ * None: no quota phrase anywhere actionable.
+ */
+export function detectQuotaToolRedaction(
+    messages: readonly LanguageModelChatRequestMessage[],
+    tools: readonly vscode.LanguageModelChatTool[],
+    requestId: string,
+    modelId: string,
+    disableRedaction: boolean,
+    caller: string | undefined,
+    deps: QuotaRedactionDeps = {}
+): QuotaRedactionResult {
+    // Wrap the static call in an arrow function so `LiteLLMTelemetry` keeps its
+    // `this` binding. Taking a bare method reference (`LiteLLMTelemetry.reportMetric`)
+    // would detach it from the class and crash on `this._telemetryService`.
+    const reportMetric = deps.reportMetric ?? ((metric) => LiteLLMTelemetry.reportMetric(metric));
+
+    if (disableRedaction || !tools.length || !messages.length) {
+        return { tools, confidence: "none" };
+    }
+
+    const quotaMatch = findQuotaErrorInMessages(messages);
+    if (!quotaMatch) {
+        return { tools, confidence: "none" };
+    }
+
+    const { toolName, errorText, turnIndex, confidence } = quotaMatch;
+
+    // Low-confidence matches (e.g. a quota phrase mentioned in
+    // <reminderInstructions> or a user prompt about quotas) are logged
+    // at DEBUG and do NOT trigger redaction or telemetry. High-confidence
+    // matches (a real provider 429 in a tool result) keep the existing
+    // WARN + telemetry behavior.
+    if (confidence !== "high") {
+        // For low-confidence matches, only report as "low" if there's a
+        // redactable tool in the tools list. Otherwise, treat as "none"
+        // since there's nothing actionable.
+        const hasRedactableTool = tools.some((t) => REDACTABLE_TOOL_NAMES.includes(t.name));
+        const reportedConfidence = hasRedactableTool ? confidence : "none";
+        Logger.debug("Quota phrase detected in non-tool-result text; not redacting", {
+            toolName,
+            modelId,
+            requestId,
+            turnIndex,
+            confidence: reportedConfidence,
+        });
+        return { tools, confidence: reportedConfidence };
+    }
+
+    const toolNames = new Set(tools.map((tool) => tool.name));
+    if (!toolNames.has(toolName)) {
+        Logger.debug("Quota error detected, but tool not present", { toolName, requestId, modelId, turnIndex });
+        return { tools, confidence };
+    }
+
+    const filteredTools = tools.filter((tool) => tool.name !== toolName);
+    Logger.warn("Quota error detected; redacting tool for current turn", {
+        toolName,
+        errorText,
+        modelId,
+        requestId,
+        turnIndex,
+    });
+    reportMetric({
+        requestId,
+        model: modelId,
+        status: "failure",
+        error: `quota_exceeded:${toolName}`,
+        ...(caller && { caller }),
+    });
+
+    return { tools: filteredTools, confidence };
+}
+
+/**
+ * Detects whether the conversation history contains a real provider-side
+ * quota error attached to a tool call we know how to redact.
+ *
+ * High-confidence match: a `LanguageModelToolResultPart` whose text
+ * contains a quota phrase AND whose `callId` resolves to one of the
+ * `REDACTABLE_TOOL_NAMES` tools (verified by walking the messages in
+ * reverse to find the matching `LanguageModelToolCallPart`).
+ *
+ * Low-confidence match: a quota phrase appearing in any other text
+ * content. This is returned for observability (DEBUG log, telemetry
+ * counter) but does NOT trigger redaction.
+ *
+ * None: no quota phrase anywhere in the message text.
+ */
+export function findQuotaErrorInMessages(messages: readonly LanguageModelChatRequestMessage[]):
+    | {
+          toolName: string;
+          errorText: string;
+          turnIndex: number;
+          confidence: QuotaRedactionConfidence;
+      }
+    | undefined {
+    // 1. Walk messages in reverse to find a tool result that contains a
+    //    quota phrase. The result's `callId` anchors the match.
+    for (let i = messages.length - 1; i >= 0; i--) {
+        const message = messages[i];
+        const toolResultHit = findQuotaInToolResults(message);
+        if (toolResultHit) {
+            const owningToolName = lookupToolNameForCallId(messages, toolResultHit.callId);
+            if (owningToolName && REDACTABLE_TOOL_NAMES.includes(owningToolName)) {
+                return {
+                    toolName: owningToolName,
+                    errorText: sanitizeErrorTextForLogs(toolResultHit.text),
+                    turnIndex: i,
+                    confidence: "high",
+                };
+            }
+            // Tool result is for a tool we don't redact. Treat as
+            // low-confidence (observability only) and keep walking.
+            return {
+                toolName: owningToolName ?? toolResultHit.callId,
+                errorText: sanitizeErrorTextForLogs(toolResultHit.text),
+                turnIndex: i,
+                confidence: "low",
+            };
+        }
+    }
+
+    // 2. No qualifying tool result. Look for a quota phrase in any
+    //    OTHER text content. Strip Copilot wrappers first so we never
+    //    match the scaffolding. Only report as "low" if we find BOTH
+    //    a quota phrase AND a tool name in the text (mimicking original
+    //    behavior). If only quota is found without a tool name, treat
+    //    as "none" since there's nothing to redact.
+    const toolRegex = /(insert_edit_into_file|replace_string_in_file)/i;
+    for (let i = messages.length - 1; i >= 0; i--) {
+        const message = messages[i];
+        const text = collectMessageText(message);
+        if (!text) {
+            continue;
+        }
+        const stripped = stripCopilotWrappers(text);
+        if (!stripped) {
+            continue;
+        }
+        if (!QUOTA_PHRASE_REGEX.test(stripped)) {
+            continue;
+        }
+        // Check if there's also a tool name in the text
+        const toolMatch = stripped.match(toolRegex);
+        if (!toolMatch) {
+            // Quota phrase found but no tool name - not actionable
+            continue;
+        }
+        return {
+            toolName: "",
+            errorText: sanitizeErrorTextForLogs(text),
+            turnIndex: i,
+            confidence: "low",
+        };
+    }
+
+    return undefined;
+}
+
+/**
+ * Returns the first quota phrase match that lives inside a
+ * `LanguageModelToolResultPart` on this message, plus the `callId` of
+ * that tool result. Returns `undefined` if no tool result part contains
+ * a quota phrase.
+ */
+export function findQuotaInToolResults(
+    message: LanguageModelChatRequestMessage
+): { callId: string; text: string } | undefined {
+    const parts = message.content ?? [];
+    for (const part of parts) {
+        if (!(part instanceof vscode.LanguageModelToolResultPart)) {
+            continue;
+        }
+        const text = collectPartText(part.content);
+        if (!text) {
+            continue;
+        }
+        if (!QUOTA_PHRASE_REGEX.test(text)) {
+            continue;
+        }
+        return { callId: part.callId, text };
+    }
+    return undefined;
+}
+
+/**
+ * Walks messages in reverse to find the assistant turn that produced
+ * `callId` via a `LanguageModelToolCallPart` and returns the tool name
+ * declared there. Returns `undefined` if no matching tool call is found.
+ */
+export function lookupToolNameForCallId(
+    messages: readonly LanguageModelChatRequestMessage[],
+    callId: string
+): string | undefined {
+    for (let i = messages.length - 1; i >= 0; i--) {
+        const parts = messages[i].content ?? [];
+        for (const part of parts) {
+            if (part instanceof vscode.LanguageModelToolCallPart && part.callId === callId) {
+                return part.name;
+            }
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Text-only projection of a tool result's content array. Mirrors
+ * `collectMessageText` but operates on a single part's `content` field
+ * (which is itself an array of `LanguageModelTextPart`-shaped objects).
+ */
+export function collectPartText(content: readonly unknown[]): string {
+    let text = "";
+    for (const part of content) {
+        if (part instanceof vscode.LanguageModelTextPart) {
+            text += part.value;
+        } else if (typeof part === "string") {
+            text += part;
+        }
+    }
+    return text.trim();
+}
+
+/**
+ * Text-only projection of a chat message's content parts. Concatenates
+ * `LanguageModelTextPart` values and bare string parts into a single
+ * trimmed string. Returns the empty string when no text parts are present.
+ */
+export function collectMessageText(message: LanguageModelChatRequestMessage): string {
+    const parts = message.content ?? [];
+    let text = "";
+    for (const part of parts) {
+        if (part instanceof vscode.LanguageModelTextPart) {
+            text += part.value;
+        } else if (typeof part === "string") {
+            text += part;
+        }
+    }
+    return text.trim();
+}
+
+/**
+ * Strips Copilot-injected prompt scaffolding wrappers from `text` and
+ * returns the cleaned, trimmed result. Applied *before* the quota regex
+ * runs so the detector never matches on prompt scaffolding.
+ *
+ * Why this exists: Copilot Chat injects `<context>`, `<editorContext>`,
+ * `<reminderInstructions>`, and `<userRequest>` blocks into every user
+ * message. The `<reminderInstructions>` block routinely documents the
+ * exact tool-error handling rules that contain both the quota phrase
+ * and the `insert_edit_into_file` / `replace_string_in_file` tool names
+ * — a structural false positive for the legacy regex-pair detector.
+ *
+ * Invariant: this function is pure (no I/O, no side effects). The
+ * original `text` is not mutated.
+ */
+export function stripCopilotWrappers(text: string): string {
+    const trimmed = (text || "").trim();
+    if (!trimmed) {
+        return "";
+    }
+    return trimmed
+        .replace(/<context>[\s\S]*?<\/context>/gi, "")
+        .replace(/<editorContext>[\s\S]*?<\/editorContext>/gi, "")
+        .replace(/<reminderInstructions>[\s\S]*?<\/reminderInstructions>/gi, "")
+        .replace(/<userRequest>[\s\S]*?<\/userRequest>/gi, "")
+        .trim();
+}
+
+/**
+ * Sanitizes an error string for logging: collapses Copilot context
+ * wrappers to ellipsis placeholders and truncates the result to 500
+ * characters so logs never carry full prompt payloads.
+ */
+export function sanitizeErrorTextForLogs(text: string): string {
+    const trimmed = (text || "").trim();
+    if (!trimmed) {
+        return "";
+    }
+
+    const withoutCopilotContext = trimmed
+        .replace(/<context>[\s\S]*?<\/context>/gi, "<context>…</context>")
+        .replace(/<editorContext>[\s\S]*?<\/editorContext>/gi, "<editorContext>…</editorContext>")
+        .replace(
+            /<reminderInstructions>[\s\S]*?<\/reminderInstructions>/gi,
+            "<reminderInstructions>…</reminderInstructions>"
+        );
+
+    return withoutCopilotContext.length > 500 ? `${withoutCopilotContext.slice(0, 500)}…` : withoutCopilotContext;
+}
+
+/**
+ * Context passed to {@link logRequestPayloadOnFailure} describing where in
+ * the request lifecycle the failure occurred and which model/caller was
+ * involved.
+ */
+export interface RequestFailureLogContext {
+    stage: "sendRequestWithRetry" | "provideLanguageModelChatResponse";
+    modelId: string;
+    caller?: string;
+    modelInfoMode?: string;
+}
+
+/**
+ * Logs a sanitized summary of a failed request payload at `trace` level,
+ * pairing it with the sanitized error message. Used by the retry loop
+ * and the chat response handler so failure triage can reconstruct the
+ * request shape without exposing raw user content.
+ */
+export function logRequestPayloadOnFailure(
+    request: OpenAIChatCompletionRequest,
+    error: unknown,
+    context: RequestFailureLogContext
+): void {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const sanitizedError = sanitizeErrorTextForLogs(errorMessage);
+    const payloadSummary = summarizeRequestPayloadForLogs(request);
+
+    Logger.trace(
+        `[request-failure] stage=${context.stage} model=${context.modelId} caller=${context.caller ?? "unknown"} mode=${context.modelInfoMode ?? "unknown"} error=${sanitizedError}`,
+        payloadSummary
+    );
+}
+
+/**
+ * Builds a structured, log-safe summary of an OpenAI chat completion
+ * request: per-message content shape (not content), tool presence, and
+ * the scalar parameters that influence routing. Never includes raw
+ * message text or tool argument bodies.
+ */
+export function summarizeRequestPayloadForLogs(request: OpenAIChatCompletionRequest): Record<string, unknown> {
+    const summarizeMessages = (request.messages ?? []).map(
+        (message: { role?: string; content?: unknown; tool_calls?: unknown[]; tool_call_id?: string }) => {
+            const content = message.content;
+            const contentSummary =
+                typeof content === "string"
+                    ? `text(${content.length})`
+                    : Array.isArray(content)
+                      ? `parts(${content.length})`
+                      : typeof content;
+
+            return {
+                role: message.role,
+                content: contentSummary,
+                hasToolCalls: Array.isArray(message.tool_calls) && message.tool_calls.length > 0,
+                toolCallId: message.tool_call_id,
+            };
+        }
+    );
+
+    const summarizeTools = (request.tools ?? []).map((tool) => ({
+        type: tool.type,
+        name: tool.function?.name,
+        hasDescription: typeof tool.function?.description === "string" && tool.function.description.length > 0,
+    }));
+
+    return {
+        model: request.model,
+        stream: request.stream,
+        max_tokens: request.max_tokens,
+        temperature: request.temperature,
+        top_p: request.top_p,
+        frequency_penalty: request.frequency_penalty,
+        presence_penalty: request.presence_penalty,
+        stop: request.stop,
+        reasoning_effort: request.reasoning_effort,
+        stream_options: request.stream_options,
+        tool_choice: request.tool_choice,
+        messageCount: request.messages?.length ?? 0,
+        messages: summarizeMessages,
+        toolCount: request.tools?.length ?? 0,
+        tools: summarizeTools,
+        hasExtraBody: typeof request.extra_body === "object" && request.extra_body !== null,
+    };
+}
+
+// `LiteLLMModelInfo` is re-exported for callers that pair this module with
+// capability lookups; the redaction module itself does not consume it.
+export type { LiteLLMModelInfo };

--- a/src/providers/liteLLMChatProvider.ts
+++ b/src/providers/liteLLMChatProvider.ts
@@ -216,6 +216,7 @@ export class LiteLLMChatProvider extends LiteLLMProviderBase implements Language
         this.resetStreamingState();
         const startTime = LiteLLMTelemetry.startTimer();
         const requestId = Math.random().toString(36).substring(7);
+        this._reviewPromptService?.recordChatRequestStarted();
 
         // Check if vscode has thinking part API available.
         // Even if we are not the V2 provider, we can safely report thinking parts if the type exists.
@@ -557,6 +558,7 @@ export class LiteLLMChatProvider extends LiteLLMProviderBase implements Language
                         : undefined,
             };
             LiteLLMTelemetry.reportMetric(metric);
+            await this._reviewPromptService?.recordSuccessfulChatTurn();
             this.logFinalUsageEnvelope(requestId, modelToUse.id, caller, {
                 tokensIn: tokensInForTelemetry,
                 tokensOut,

--- a/src/providers/liteLLMProviderBase.ts
+++ b/src/providers/liteLLMProviderBase.ts
@@ -17,7 +17,6 @@ import {
 import { countTokensForV2Messages } from "../adapters/tokenUtils";
 import { ConfigManager } from "../config/configManager";
 import { Logger } from "../utils/logger";
-import { LiteLLMTelemetry } from "../utils/telemetry";
 import type { TelemetryService } from "../telemetry/telemetryService";
 import type { ReviewPromptService } from "../engagement/reviewPromptService";
 import { getSupportedReasoningEfforts } from "../utils/modelCapabilities";
@@ -34,28 +33,19 @@ import { RequestBuilder } from "./base/requestBuilder";
 import { Transport } from "./base/transport";
 import type { RequestBuilderDeps, TransportDeps } from "./base/types";
 import { LiteLLMProviderRegistry } from "./liteLLMProviderRegistry";
+import {
+    detectQuotaToolRedaction as detectQuotaToolRedactionImpl,
+    sanitizeErrorTextForLogs as sanitizeErrorTextForLogsImpl,
+    collectMessageText as collectMessageTextImpl,
+    logRequestPayloadOnFailure as logRequestPayloadOnFailureImpl,
+} from "./base/quotaRedaction";
+import {
+    isParameterSupported as isParameterSupportedImpl,
+    stripUnsupportedParametersFromRequest as stripUnsupportedParametersFromRequestImpl,
+} from "./base/parameterFiltering";
+import { resolveCallTimeConfiguration } from "./base/callConfig";
 import { LRUCache } from "../utils/lruCache";
 import { AuditTrail } from "../observability/auditTrail";
-
-/**
- * Static fallback parameter limitations for known model families.
- * Used as fallback when model info (supported_openai_params) is unavailable.
- * These are prefix matches - if modelId includes the key, the limitation applies.
- */
-const KNOWN_PARAMETER_LIMITATIONS: Record<string, Set<string>> = {
-    "claude-3-5-sonnet": new Set(["temperature"]),
-    "claude-3-5-haiku": new Set(["temperature"]),
-    "claude-3-opus": new Set(["temperature"]),
-    "claude-3-sonnet": new Set(["temperature"]),
-    "claude-3-haiku": new Set(["temperature"]),
-    "claude-haiku-4-5": new Set(["temperature"]),
-    "gpt-5.1-codex": new Set(["temperature", "frequency_penalty", "presence_penalty"]),
-    "gpt-5.1-codex-mini": new Set(["temperature", "frequency_penalty", "presence_penalty"]),
-    "gpt-5.1-codex-max": new Set(["temperature", "frequency_penalty", "presence_penalty"]),
-    "codex-mini-latest": new Set(["temperature", "frequency_penalty", "presence_penalty"]),
-    "o1-": new Set(["temperature", "top_p", "presence_penalty", "frequency_penalty"]),
-    "gpt-5": new Set(["temperature", "top_p", "presence_penalty", "frequency_penalty"]),
-};
 
 /**
  * Shared orchestration base for all LiteLLM-backed VS Code language model providers.
@@ -792,95 +782,24 @@ export abstract class LiteLLMProviderBase {
     /**
      * Resolves the per-group configuration for a response-time call.
      *
-     * Discovery-time call paths and the per-group config come from
-     * `options.configuration` (set by VS Code 1.120 at discovery time).
-     * Response-time paths in VS Code 1.120 do NOT pass the per-group config
-     * on `options.configuration` — the proposed-type definition for
-     * `ProvideLanguageModelChatResponseOptions` does not declare that field.
+     * Delegates to the pure {@link ../base/callConfig callConfig} module, which
+     * owns the `options.configuration` trust heuristic and the registry
+     * fallback. Kept as a private method (rather than called inline) so tests
+     * can exercise the resolution via the test-access seam.
      *
-     * As a fallback we consult the in-memory `LiteLLMProviderRegistry` keyed
-     * by the model id. The registry is populated by every successful
-     * discovery call, so a model that's been discovered in this session is
-     * routable. If neither channel has the model, the call is a
-     * configuration problem and the transport surfaces a visible error.
+     * See `resolveCallTimeConfiguration` for the full invariant documentation,
+     * including why an empty `options.configuration` object must NOT be
+     * trusted and how the workspace ergonomic toggles are merged onto both
+     * resolution paths.
      */
     private async getCallTimeConfiguration(
         options: vscode.ProvideLanguageModelChatResponseOptions,
         model: vscode.LanguageModelChatInformation
     ): Promise<Record<string, unknown> | undefined> {
-        const opt = options as vscode.ProvideLanguageModelChatResponseOptions & {
-            configuration?: Record<string, unknown>;
-        };
-        // The `options.configuration` field on the proposed-type
-        // `ProvideLanguageModelChatResponseOptions` is unreliable in VS Code
-        // 1.120+. Empirically: VS Code may pass an EMPTY configuration
-        // object (truthy, but no `baseUrl` or `apiKey`) for some calls,
-        // particularly for models that were picked from a group other
-        // than the one currently being routed. The wolfram group tends to
-        // not include `configuration` at all (so we fall back to the
-        // registry); the geth group tends to include an empty object
-        // (which previously short-circuited the registry fallback and
-        // produced a "No baseUrl provided" runtime error).
-        //
-        // We trust `options.configuration` ONLY when it has both a usable
-        // `baseUrl` (string, non-empty) and a usable `apiKey` (string,
-        // non-empty). Anything else falls through to the registry.
-        const optBaseUrl = typeof opt.configuration?.baseUrl === "string" ? opt.configuration.baseUrl.trim() : "";
-        const optApiKey = typeof opt.configuration?.apiKey === "string" ? opt.configuration.apiKey.trim() : "";
-
-        // Fetch workspace-config toggles once so both paths can merge them.
-        const cfg = await this._configManager.getConfig();
-
-        if (opt.configuration && optBaseUrl.length > 0 && optApiKey.length > 0) {
-            Logger.trace(
-                `getCallTimeConfiguration: HIT via options.configuration modelId="${model.id}" baseUrl="${optBaseUrl}"`
-            );
-            // Merge workspace-config ergonomic toggles onto the per-group
-            // configuration so the transport can read allowChatCompletionsFallback
-            // and disableCaching without a separate config fetch on the hot path.
-            return {
-                ...opt.configuration,
-                allowChatCompletionsFallback: cfg.allowChatCompletionsFallback,
-                disableCaching: cfg.disableCaching,
-            };
-        }
-        if (opt.configuration) {
-            // Object is present but malformed (empty / missing fields).
-            // This is the case we need to escape from — VS Code passed an
-            // empty object and we must not trust it.
-            Logger.trace(
-                `getCallTimeConfiguration: options.configuration present but invalid (empty baseUrl or apiKey) modelId="${model.id}"; falling back to registry`
-            );
-        } else {
-            Logger.trace(
-                `getCallTimeConfiguration: options.configuration missing; falling back to registry lookup for modelId="${model.id}" modelName="${model.name}"`
-            );
-        }
-        // No options.configuration at response time (the common case in VS
-        // Code 1.120+). Fall back to the in-memory registry. The model id
-        // VS Code hands back is the namespaced `<routing>/<raw>` form
-        // produced by `LiteLLMProviderRegistry.toVSCodeInfo`; the registry
-        // maps that id back to the {baseUrl, apiKey} of the backend that
-        // produced it. The request builder extracts the raw model name
-        // from `model.id` for `request.model`; the transport only needs
-        // baseUrl + apiKey.
-        const entry = this._registry.lookup(model.id);
-        if (entry) {
-            Logger.trace(`getCallTimeConfiguration: registry HIT modelId="${model.id}" -> baseUrl="${entry.baseUrl}"`);
-            // Same ergonomic-toggle merge as the options.configuration path above,
-            // so /responses fallback + disableCaching work regardless of which
-            // path resolved baseUrl/apiKey.
-            return {
-                baseUrl: entry.baseUrl,
-                apiKey: entry.apiKey,
-                allowChatCompletionsFallback: cfg.allowChatCompletionsFallback,
-                disableCaching: cfg.disableCaching,
-            };
-        }
-        Logger.warn(
-            `getCallTimeConfiguration: registry MISS modelId="${model.id}" modelName="${model.name}" — request will fail with configuration error`
-        );
-        return undefined;
+        return resolveCallTimeConfiguration(options, model, {
+            configManager: this._configManager,
+            registry: this._registry,
+        });
     }
 
     /**
@@ -907,56 +826,15 @@ export abstract class LiteLLMProviderBase {
     /**
      * Decides whether a given OpenAI parameter can be sent to a model.
      *
-     * Source of truth: the `supported_openai_params` array on the model's
-     * `LiteLLMModelInfo` (delivered by the registry). There is no probe
-     * cache here — the registry's per-model capability data is authoritative
-     * and re-validated on every discovery call, so a stale cache layer
-     * would only ever shadow correct information and (as observed in
-     * production) cause a model to silently drop parameters it actually
-     * supports.
+     * Delegates to the pure {@link ../base/parameterFiltering parameterFiltering}
+     * module. Source of truth: the `supported_openai_params` array on the
+     * model's `LiteLLMModelInfo` (delivered by the registry), with a static
+     * `KNOWN_PARAMETER_LIMITATIONS` fallback for known model families. There
+     * is no probe cache here — the registry's per-model capability data is
+     * authoritative and re-validated on every discovery call.
      */
     protected isParameterSupported(param: string, modelInfo: LiteLLMModelInfo | undefined, modelId?: string): boolean {
-        if (modelId) {
-            if (KNOWN_PARAMETER_LIMITATIONS[modelId]?.has(param)) {
-                return false;
-            }
-            for (const [knownModel, limitations] of Object.entries(KNOWN_PARAMETER_LIMITATIONS)) {
-                if (modelId.includes(knownModel) && limitations.has(param)) {
-                    return false;
-                }
-            }
-        }
-
-        if (modelInfo?.supported_openai_params) {
-            const supportedParams = modelInfo.supported_openai_params;
-            const normalizedParam = param.toLowerCase();
-            const isSupported = supportedParams.some((p) => p.toLowerCase() === normalizedParam);
-
-            if (supportedParams.length === 0) {
-                return false;
-            }
-
-            if (!isSupported) {
-                return !this.isRestrictableParam(param);
-            }
-            return true;
-        }
-
-        return true;
-    }
-
-    private isRestrictableParam(param: string): boolean {
-        const restrictableParams = new Set([
-            "temperature",
-            "top_p",
-            "presence_penalty",
-            "frequency_penalty",
-            "stop",
-            "reasoning_effort",
-            "tool_choice",
-            "cache",
-        ]);
-        return restrictableParams.has(param.toLowerCase());
+        return isParameterSupportedImpl(param, modelInfo, modelId);
     }
 
     protected stripUnsupportedParametersFromRequest(
@@ -964,34 +842,7 @@ export abstract class LiteLLMProviderBase {
         modelInfo: LiteLLMModelInfo | undefined,
         modelId?: string
     ): void {
-        const paramsToCheck = [
-            "temperature",
-            "stop",
-            "frequency_penalty",
-            "presence_penalty",
-            "top_p",
-            "no_cache",
-            "no-cache",
-            "tool_choice", // Added for GPT-5.6 Azure and similar models that don't support tool_choice
-        ];
-        for (const p of paramsToCheck) {
-            if (!this.isParameterSupported(p, modelInfo, modelId) && p in requestBody) {
-                delete requestBody[p];
-            }
-        }
-
-        // LiteLLM's cache bypass is carried only by extra_body.cache. It is
-        // retained when the model explicitly supports the cache parameter.
-        delete requestBody.cache;
-        if (requestBody.extra_body && typeof requestBody.extra_body === "object") {
-            const extraBody = requestBody.extra_body as Record<string, unknown>;
-            if (!this.isParameterSupported("cache", modelInfo, modelId)) {
-                delete extraBody.cache;
-            }
-            if (Object.keys(extraBody).length === 0) {
-                delete requestBody.extra_body;
-            }
-        }
+        stripUnsupportedParametersFromRequestImpl(requestBody, modelInfo, modelId);
     }
 
     protected detectQuotaToolRedaction(
@@ -1005,242 +856,19 @@ export abstract class LiteLLMProviderBase {
         tools: readonly vscode.LanguageModelChatTool[];
         confidence: "none" | "low" | "high";
     } {
-        if (disableRedaction || !tools.length || !messages.length) {
-            return { tools, confidence: "none" };
-        }
-
-        const quotaMatch = this.findQuotaErrorInMessages(messages);
-        if (!quotaMatch) {
-            return { tools, confidence: "none" };
-        }
-
-        const { toolName, errorText, turnIndex, confidence } = quotaMatch;
-
-        // Low-confidence matches (e.g. a quota phrase mentioned in
-        // <reminderInstructions> or a user prompt about quotas) are logged
-        // at DEBUG and do NOT trigger redaction or telemetry. High-confidence
-        // matches (a real provider 429 in a tool result) keep the existing
-        // WARN + telemetry behavior.
-        if (confidence !== "high") {
-            // For low-confidence matches, only report as "low" if there's a
-            // redactable tool in the tools list. Otherwise, treat as "none"
-            // since there's nothing actionable.
-            const hasRedactableTool = tools.some((t) => LiteLLMProviderBase.REDACTABLE_TOOL_NAMES.includes(t.name));
-            const reportedConfidence = hasRedactableTool ? confidence : "none";
-            Logger.debug("Quota phrase detected in non-tool-result text; not redacting", {
-                toolName,
-                modelId,
-                requestId,
-                turnIndex,
-                confidence: reportedConfidence,
-            });
-            return { tools, confidence: reportedConfidence };
-        }
-
-        const toolNames = new Set(tools.map((tool) => tool.name));
-        if (!toolNames.has(toolName)) {
-            Logger.debug("Quota error detected, but tool not present", { toolName, requestId, modelId, turnIndex });
-            return { tools, confidence };
-        }
-
-        const filteredTools = tools.filter((tool) => tool.name !== toolName);
-        Logger.warn("Quota error detected; redacting tool for current turn", {
-            toolName,
-            errorText,
-            modelId,
-            requestId,
-            turnIndex,
-        });
-        LiteLLMTelemetry.reportMetric({
-            requestId,
-            model: modelId,
-            status: "failure",
-            error: `quota_exceeded:${toolName}`,
-            ...(caller && { caller }),
-        });
-
-        return { tools: filteredTools, confidence };
+        // Delegates to the pure quota-redaction module. The module owns the
+        // detector, the regex/constants, the message-text projections, and the
+        // Copilot-wrapper stripping; this thin wrapper preserves the protected
+        // method name the request builder binds against and tests cast to.
+        return detectQuotaToolRedactionImpl(messages, tools, requestId, modelId, disableRedaction, caller);
     }
 
-    /**
-     * Tools the detector knows how to redact. Kept narrow on purpose — the
-     * legacy detector only knew `insert_edit_into_file` and
-     * `replace_string_in_file`. Adding more here is a deliberate code change
-     * and must come with a test that exercises a real tool result for the new
-     * tool name (not just a substring match in prompt scaffolding).
-     */
-    private static readonly REDACTABLE_TOOL_NAMES: readonly string[] = [
-        "insert_edit_into_file",
-        "replace_string_in_file",
-    ] as const;
-
-    private static readonly QUOTA_PHRASE_REGEX =
-        /(\b429\b|rate\s*limit\s*exceeded|rate\s*limited|too\s*many\s*requests|insufficient\s*quota|quota\s*exceeded|exceeded\s*your\s*current\s*quota)/i;
-
-    /**
-     * Detects whether the conversation history contains a real provider-side
-     * quota error attached to a tool call we know how to redact.
-     *
-     * High-confidence match: a `LanguageModelToolResultPart` whose text
-     * contains a quota phrase AND whose `callId` resolves to one of the
-     * `REDACTABLE_TOOL_NAMES` tools (verified by walking the messages in
-     * reverse to find the matching `LanguageModelToolCallPart`).
-     *
-     * Low-confidence match: a quota phrase appearing in any other text
-     * content. This is returned for observability (DEBUG log, telemetry
-     * counter) but does NOT trigger redaction.
-     *
-     * None: no quota phrase anywhere in the message text.
-     */
-    private findQuotaErrorInMessages(messages: readonly LanguageModelChatRequestMessage[]):
-        | {
-              toolName: string;
-              errorText: string;
-              turnIndex: number;
-              confidence: "none" | "low" | "high";
-          }
-        | undefined {
-        // 1. Walk messages in reverse to find a tool result that contains a
-        //    quota phrase. The result's `callId` anchors the match.
-        for (let i = messages.length - 1; i >= 0; i--) {
-            const message = messages[i];
-            const toolResultHit = this.findQuotaInToolResults(message);
-            if (toolResultHit) {
-                const owningToolName = this.lookupToolNameForCallId(messages, toolResultHit.callId);
-                if (owningToolName && LiteLLMProviderBase.REDACTABLE_TOOL_NAMES.includes(owningToolName)) {
-                    return {
-                        toolName: owningToolName,
-                        errorText: this.sanitizeErrorTextForLogs(toolResultHit.text),
-                        turnIndex: i,
-                        confidence: "high",
-                    };
-                }
-                // Tool result is for a tool we don't redact. Treat as
-                // low-confidence (observability only) and keep walking.
-                return {
-                    toolName: owningToolName ?? toolResultHit.callId,
-                    errorText: this.sanitizeErrorTextForLogs(toolResultHit.text),
-                    turnIndex: i,
-                    confidence: "low",
-                };
-            }
-        }
-
-        // 2. No qualifying tool result. Look for a quota phrase in any
-        //    OTHER text content. Strip Copilot wrappers first so we never
-        //    match the scaffolding. Only report as "low" if we find BOTH
-        //    a quota phrase AND a tool name in the text (mimicking original
-        //    behavior). If only quota is found without a tool name, treat
-        //    as "none" since there's nothing to redact.
-        const toolRegex = /(insert_edit_into_file|replace_string_in_file)/i;
-        for (let i = messages.length - 1; i >= 0; i--) {
-            const message = messages[i];
-            const text = this.collectMessageText(message);
-            if (!text) {
-                continue;
-            }
-            const stripped = this.stripCopilotWrappers(text);
-            if (!stripped) {
-                continue;
-            }
-            if (!LiteLLMProviderBase.QUOTA_PHRASE_REGEX.test(stripped)) {
-                continue;
-            }
-            // Check if there's also a tool name in the text
-            const toolMatch = stripped.match(toolRegex);
-            if (!toolMatch) {
-                // Quota phrase found but no tool name - not actionable
-                continue;
-            }
-            return {
-                toolName: "",
-                errorText: this.sanitizeErrorTextForLogs(text),
-                turnIndex: i,
-                confidence: "low",
-            };
-        }
-
-        return undefined;
+    protected sanitizeErrorTextForLogs(text: string): string {
+        return sanitizeErrorTextForLogsImpl(text);
     }
 
-    /**
-     * Returns the first quota phrase match that lives inside a
-     * `LanguageModelToolResultPart` on this message, plus the `callId` of
-     * that tool result. Returns `undefined` if no tool result part contains
-     * a quota phrase.
-     */
-    private findQuotaInToolResults(
-        message: LanguageModelChatRequestMessage
-    ): { callId: string; text: string } | undefined {
-        const parts = message.content ?? [];
-        for (const part of parts) {
-            if (!(part instanceof vscode.LanguageModelToolResultPart)) {
-                continue;
-            }
-            const text = this.collectPartText(part.content);
-            if (!text) {
-                continue;
-            }
-            if (!LiteLLMProviderBase.QUOTA_PHRASE_REGEX.test(text)) {
-                continue;
-            }
-            return { callId: part.callId, text };
-        }
-        return undefined;
-    }
-
-    /**
-     * Walks messages in reverse to find the assistant turn that produced
-     * `callId` via a `LanguageModelToolCallPart` and returns the tool name
-     * declared there. Returns `undefined` if no matching tool call is found.
-     */
-    private lookupToolNameForCallId(
-        messages: readonly LanguageModelChatRequestMessage[],
-        callId: string
-    ): string | undefined {
-        for (let i = messages.length - 1; i >= 0; i--) {
-            const parts = messages[i].content ?? [];
-            for (const part of parts) {
-                if (part instanceof vscode.LanguageModelToolCallPart && part.callId === callId) {
-                    return part.name;
-                }
-            }
-        }
-        return undefined;
-    }
-
-    /**
-     * Text-only projection of a tool result's content array. Mirrors
-     * `collectMessageText` but operates on a single part's `content` field
-     * (which is itself an array of `LanguageModelTextPart`-shaped objects).
-     */
-    private collectPartText(content: readonly unknown[]): string {
-        let text = "";
-        for (const part of content) {
-            if (part instanceof vscode.LanguageModelTextPart) {
-                text += part.value;
-            } else if (typeof part === "string") {
-                text += part;
-            }
-        }
-        return text.trim();
-    }
-
-    private sanitizeErrorTextForLogs(text: string): string {
-        const trimmed = (text || "").trim();
-        if (!trimmed) {
-            return "";
-        }
-
-        const withoutCopilotContext = trimmed
-            .replace(/<context>[\s\S]*?<\/context>/gi, "<context>…</context>")
-            .replace(/<editorContext>[\s\S]*?<\/editorContext>/gi, "<editorContext>…</editorContext>")
-            .replace(
-                /<reminderInstructions>[\s\S]*?<\/reminderInstructions>/gi,
-                "<reminderInstructions>…</reminderInstructions>"
-            );
-
-        return withoutCopilotContext.length > 500 ? `${withoutCopilotContext.slice(0, 500)}…` : withoutCopilotContext;
+    protected collectMessageText(message: LanguageModelChatRequestMessage): string {
+        return collectMessageTextImpl(message);
     }
 
     protected logRequestPayloadOnFailure(
@@ -1253,102 +881,7 @@ export abstract class LiteLLMProviderBase {
             modelInfoMode?: string;
         }
     ): void {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        const sanitizedError = this.sanitizeErrorTextForLogs(errorMessage);
-        const payloadSummary = this.summarizeRequestPayloadForLogs(request);
-
-        Logger.trace(
-            `[request-failure] stage=${context.stage} model=${context.modelId} caller=${context.caller ?? "unknown"} mode=${context.modelInfoMode ?? "unknown"} error=${sanitizedError}`,
-            payloadSummary
-        );
-    }
-
-    private summarizeRequestPayloadForLogs(request: OpenAIChatCompletionRequest): Record<string, unknown> {
-        const summarizeMessages = (request.messages ?? []).map(
-            (message: { role?: string; content?: unknown; tool_calls?: unknown[]; tool_call_id?: string }) => {
-                const content = message.content;
-                const contentSummary =
-                    typeof content === "string"
-                        ? `text(${content.length})`
-                        : Array.isArray(content)
-                          ? `parts(${content.length})`
-                          : typeof content;
-
-                return {
-                    role: message.role,
-                    content: contentSummary,
-                    hasToolCalls: Array.isArray(message.tool_calls) && message.tool_calls.length > 0,
-                    toolCallId: message.tool_call_id,
-                };
-            }
-        );
-
-        const summarizeTools = (request.tools ?? []).map((tool) => ({
-            type: tool.type,
-            name: tool.function?.name,
-            hasDescription: typeof tool.function?.description === "string" && tool.function.description.length > 0,
-        }));
-
-        return {
-            model: request.model,
-            stream: request.stream,
-            max_tokens: request.max_tokens,
-            temperature: request.temperature,
-            top_p: request.top_p,
-            frequency_penalty: request.frequency_penalty,
-            presence_penalty: request.presence_penalty,
-            stop: request.stop,
-            reasoning_effort: request.reasoning_effort,
-            stream_options: request.stream_options,
-            tool_choice: request.tool_choice,
-            messageCount: request.messages?.length ?? 0,
-            messages: summarizeMessages,
-            toolCount: request.tools?.length ?? 0,
-            tools: summarizeTools,
-            hasExtraBody: typeof request.extra_body === "object" && request.extra_body !== null,
-        };
-    }
-
-    private collectMessageText(message: LanguageModelChatRequestMessage): string {
-        const parts = message.content ?? [];
-        let text = "";
-        for (const part of parts) {
-            if (part instanceof vscode.LanguageModelTextPart) {
-                text += part.value;
-            } else if (typeof part === "string") {
-                text += part;
-            }
-        }
-        return text.trim();
-    }
-
-    /**
-     * Strips Copilot-injected prompt scaffolding wrappers from `text` and
-     * returns the cleaned, trimmed result. This is the SAME list of wrappers
-     * the log sanitizer collapses, but applied *before* the quota regex runs
-     * so the detector never matches on prompt scaffolding.
-     *
-     * Why this lives here: Copilot Chat injects `<context>`, `<editorContext>`,
-     * `<reminderInstructions>`, and `<userRequest>` blocks into every user
-     * message. The `<reminderInstructions>` block routinely documents the
-     * exact tool-error handling rules that contain both the quota phrase
-     * and the `insert_edit_into_file` / `replace_string_in_file` tool names
-     * — a structural false positive for the legacy regex-pair detector.
-     *
-     * Invariant: this function is pure (no I/O, no side effects). The
-     * original `text` is not mutated.
-     */
-    private stripCopilotWrappers(text: string): string {
-        const trimmed = (text || "").trim();
-        if (!trimmed) {
-            return "";
-        }
-        return trimmed
-            .replace(/<context>[\s\S]*?<\/context>/gi, "")
-            .replace(/<editorContext>[\s\S]*?<\/editorContext>/gi, "")
-            .replace(/<reminderInstructions>[\s\S]*?<\/reminderInstructions>/gi, "")
-            .replace(/<userRequest>[\s\S]*?<\/userRequest>/gi, "")
-            .trim();
+        logRequestPayloadOnFailureImpl(request, error, context);
     }
 
     protected buildCapabilities(modelInfo: LiteLLMModelInfo | undefined): vscode.LanguageModelChatCapabilities {

--- a/src/providers/liteLLMProviderBase.ts
+++ b/src/providers/liteLLMProviderBase.ts
@@ -19,6 +19,7 @@ import { ConfigManager } from "../config/configManager";
 import { Logger } from "../utils/logger";
 import { LiteLLMTelemetry } from "../utils/telemetry";
 import type { TelemetryService } from "../telemetry/telemetryService";
+import type { ReviewPromptService } from "../engagement/reviewPromptService";
 import { getSupportedReasoningEfforts } from "../utils/modelCapabilities";
 import type { SupportedReasoningEffort } from "../types";
 import {
@@ -106,6 +107,7 @@ export abstract class LiteLLMProviderBase {
     private _usageOptOutModels = new Set<string>();
 
     protected _telemetryService?: TelemetryService;
+    protected _reviewPromptService?: ReviewPromptService;
 
     private _onModernConfigurationDetected?: () => void;
 
@@ -158,6 +160,14 @@ export abstract class LiteLLMProviderBase {
 
     public setTelemetryService(service: TelemetryService): void {
         this._telemetryService = service;
+    }
+
+    /**
+     * Supplies the activation-owned review prompt service. The base class only stores this
+     * optional dependency; chat protocol code decides which request outcomes count as turns.
+     */
+    public setReviewPromptService(service: ReviewPromptService): void {
+        this._reviewPromptService = service;
     }
 
     /**

--- a/src/providers/test/chatProvider.test.ts
+++ b/src/providers/test/chatProvider.test.ts
@@ -900,6 +900,64 @@ suite("LiteLLM Chat Provider Unit Tests", () => {
         sinon.assert.calledWithMatch(telemetrySpy, sinon.match({ tokensIn: 12, tokensOut: 7 }));
     });
 
+    test("reports a chat start and one successful turn to the review prompt service", async () => {
+        const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
+        const reviewPromptService: {
+            recordChatRequestStarted: sinon.SinonStub;
+            recordSuccessfulChatTurn: sinon.SinonStub;
+        } = {
+            recordChatRequestStarted: sandbox.stub(),
+            recordSuccessfulChatTurn: sandbox.stub().resolves(),
+        };
+        provider.setReviewPromptService(
+            reviewPromptService as unknown as import("../../engagement/reviewPromptService").ReviewPromptService
+        );
+        seedDiscoveredBackend(sandbox, provider, "model-review-prompt");
+
+        const encoder = new TextEncoder();
+        sandbox.stub(LiteLLMClient.prototype, "chat").resolves(
+            new ReadableStream<Uint8Array>({
+                start(controller) {
+                    controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n'));
+                    controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+                    controller.close();
+                },
+            })
+        );
+
+        await provider.provideLanguageModelChatResponse(
+            {
+                id: "model-review-prompt",
+                name: "model-review-prompt",
+                tooltip: "",
+                family: "litellm",
+                version: "1.0.0",
+                maxInputTokens: 1000,
+                maxOutputTokens: 1000,
+                capabilities: { toolCalling: true, imageInput: false },
+            },
+            [
+                {
+                    role: vscode.LanguageModelChatMessageRole.User,
+                    name: undefined,
+                    content: [new vscode.LanguageModelTextPart("hello")],
+                },
+            ],
+            {
+                modelOptions: {},
+                tools: [],
+                toolMode: vscode.LanguageModelChatToolMode.Auto,
+                requestInitiator: "test",
+                configuration: { baseUrl: "http://localhost:4000", apiKey: "test-api-key" },
+            } as unknown as vscode.ProvideLanguageModelChatResponseOptions,
+            { report: () => undefined },
+            new vscode.CancellationTokenSource().token
+        );
+
+        assert.strictEqual(reviewPromptService.recordChatRequestStarted.calledOnce, true);
+        assert.strictEqual(reviewPromptService.recordSuccessfulChatTurn.calledOnce, true);
+    });
+
     test("merges partial usage frames to avoid dropping previously reported token details", async () => {
         const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
         sandbox

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -164,6 +164,25 @@ export class TelemetryService implements vscode.Disposable {
         this.capture("extension_deactivated", { uptime_seconds: uptimeSeconds });
     }
 
+    captureReviewPromptEligible(props: { installDate: number; successfulTurnCount: number }): void {
+        this.capture("review_prompt_eligible", {
+            install_date: props.installDate,
+            successful_turn_count: props.successfulTurnCount,
+        });
+    }
+
+    captureReviewPromptChoice(props: {
+        choice: "review_or_rated" | "never_again" | "later";
+        installDate: number;
+        successfulTurnCount: number;
+    }): void {
+        this.capture("review_prompt_choice", {
+            choice: props.choice,
+            install_date: props.installDate,
+            successful_turn_count: props.successfulTurnCount,
+        });
+    }
+
     // Configuration
     captureConfigChanged(settingKey: string, source: string): void {
         this.capture("config_changed", { setting_key: settingKey, source });

--- a/src/telemetry/test/posthogAdapter.test.ts
+++ b/src/telemetry/test/posthogAdapter.test.ts
@@ -7,6 +7,7 @@ suite("PostHogAdapter (Node)", () => {
     let sandbox: sinon.SinonSandbox;
     let envCiaValue: string | undefined;
     let envMockValue: string | undefined;
+    let posthogCaptureStub: sinon.SinonStub;
     let posthogCaptureExceptionStub: sinon.SinonStub;
     let posthogIdentifyStub: sinon.SinonStub;
     let posthogIsFeatureEnabledStub: sinon.SinonStub;
@@ -20,6 +21,7 @@ suite("PostHogAdapter (Node)", () => {
         envMockValue = process.env.POSTHOG_MOCK;
         delete process.env.CI;
         delete process.env.POSTHOG_MOCK;
+        posthogCaptureStub = sandbox.stub(PostHog.prototype, "capture");
         posthogCaptureExceptionStub = sandbox.stub(PostHog.prototype, "captureException");
         posthogIdentifyStub = sandbox.stub(PostHog.prototype, "identify");
         posthogIsFeatureEnabledStub = sandbox.stub(PostHog.prototype, "isFeatureEnabled");
@@ -170,5 +172,26 @@ suite("PostHogAdapter (Node)", () => {
 
         await adapter.shutdown();
         assert.strictEqual(posthogShutdownStub.calledOnce, true);
+    });
+
+    test("does not forward review prompt telemetry while telemetry is disabled", () => {
+        const adapter = new PostHogAdapter();
+        adapter.initialize({
+            apiKey: "test-key",
+            host: "test-host",
+            enabled: false,
+        });
+
+        adapter.capture({
+            event: "review_prompt_choice",
+            properties: {
+                distinctId: "test-machine-id",
+                choice: "later",
+                install_date: 1764523200000,
+                successful_turn_count: 10,
+            },
+        });
+
+        assert.strictEqual(posthogCaptureStub.called, false);
     });
 });

--- a/src/telemetry/test/telemetryService.test.ts
+++ b/src/telemetry/test/telemetryService.test.ts
@@ -501,6 +501,47 @@ suite("TelemetryService", () => {
         });
     });
 
+    suite("Review Prompt Telemetry", () => {
+        test("captures review prompt eligibility with snake_case properties", () => {
+            const mockContext = {
+                extension: { packageJSON: { version: "1.0.0" } },
+            } as unknown as vscode.ExtensionContext;
+            telemetryService.initialize(mockContext);
+
+            telemetryService.captureReviewPromptEligible({
+                installDate: 1764523200000,
+                successfulTurnCount: 10,
+            });
+
+            assert.strictEqual(adapterMock.capture.calledOnce, true);
+            const event = adapterMock.capture.firstCall.args[0];
+            assert.strictEqual(event.event, "review_prompt_eligible");
+            assert.strictEqual(event.properties.install_date, 1764523200000);
+            assert.strictEqual(event.properties.successful_turn_count, 10);
+            assert.strictEqual(event.properties.distinctId, "test-machine-id");
+        });
+
+        test("captures review prompt choices with snake_case properties", () => {
+            const mockContext = {
+                extension: { packageJSON: { version: "1.0.0" } },
+            } as unknown as vscode.ExtensionContext;
+            telemetryService.initialize(mockContext);
+
+            telemetryService.captureReviewPromptChoice({
+                choice: "review_or_rated",
+                installDate: 1764523200000,
+                successfulTurnCount: 10,
+            });
+
+            assert.strictEqual(adapterMock.capture.calledOnce, true);
+            const event = adapterMock.capture.firstCall.args[0];
+            assert.strictEqual(event.event, "review_prompt_choice");
+            assert.strictEqual(event.properties.choice, "review_or_rated");
+            assert.strictEqual(event.properties.install_date, 1764523200000);
+            assert.strictEqual(event.properties.successful_turn_count, 10);
+        });
+    });
+
     suite("Feature Adoption Tracking", () => {
         test("should capture feature_adoption events", () => {
             const mockContext = { packageJSON: { version: "1.0.0" } } as unknown as vscode.ExtensionContext;

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -80,6 +80,8 @@ function stubTelemetryService(sandbox: sinon.SinonSandbox): {
     captureFeatureAdoption: sinon.SinonStub;
     captureFeatureUsageSnapshot: sinon.SinonStub;
     captureModernConfigStatus: sinon.SinonStub;
+    captureReviewPromptEligible: sinon.SinonStub;
+    captureReviewPromptChoice: sinon.SinonStub;
 } {
     return {
         captureException: sandbox.stub(TelemetryService.prototype, "captureException"),
@@ -87,6 +89,8 @@ function stubTelemetryService(sandbox: sinon.SinonSandbox): {
         captureFeatureAdoption: sandbox.stub(TelemetryService.prototype, "captureFeatureAdoption"),
         captureFeatureUsageSnapshot: sandbox.stub(TelemetryService.prototype, "captureFeatureUsageSnapshot"),
         captureModernConfigStatus: sandbox.stub(TelemetryService.prototype, "captureModernConfigStatus"),
+        captureReviewPromptEligible: sandbox.stub(TelemetryService.prototype, "captureReviewPromptEligible"),
+        captureReviewPromptChoice: sandbox.stub(TelemetryService.prototype, "captureReviewPromptChoice"),
     };
 }
 
@@ -735,5 +739,28 @@ suite("Extension Activation Unit Tests", () => {
             true,
             "migration rejections should be logged"
         );
+    });
+
+    test("activate initializes and injects the review prompt service without requiring global state", async () => {
+        const context = {
+            subscriptions: [],
+            secrets: createMockSecrets(),
+        } as unknown as vscode.ExtensionContext;
+        sandbox.stub(vscode.window, "createOutputChannel").returns(createMockOutputChannel());
+        sandbox.stub(vscode.extensions, "getExtension").returns({ packageJSON: { version: "1.2.3" } } as never);
+        sandbox.stub(vscode.window, "showInformationMessage").resolves(undefined);
+        sandbox.stub(vscode.lm, "registerLanguageModelChatProvider").returns({ dispose() {} } as vscode.Disposable);
+        sandbox.stub(vscode.commands, "registerCommand").returns({ dispose() {} } as vscode.Disposable);
+        const setReviewPromptService = sandbox.stub(providers.LiteLLMChatProvider.prototype, "setReviewPromptService");
+        sandbox.stub(TelemetryService.prototype, "captureExtensionActivated");
+        sandbox.stub(TelemetryService.prototype, "captureFeatureAdoption");
+        sandbox.stub(TelemetryService.prototype, "captureFeatureUsageSnapshot");
+        sandbox.stub(TelemetryService.prototype, "captureModernConfigStatus");
+
+        extension.activate(context);
+        await new Promise<void>((resolve) => setImmediate(resolve));
+
+        assert.strictEqual(setReviewPromptService.calledOnce, true);
+        assert.ok(context.subscriptions.length > 0);
     });
 });


### PR DESCRIPTION
## Change Log / Overview

Release `v2.2.3`. This PR ships the idle-time Marketplace review prompt for engaged users, a session-scoped "Maybe Later" deferral with a race-condition fix, and a refactor of the provider base into focused helper modules.

### ✨ Features
- **💬 Idle-time review prompt** — After 10 successful chat turns and 5 minutes of idle time, the extension offers a non-modal notification to leave a Marketplace review. Users can **Leave a Review**, **Maybe Later** (suppresses for the rest of the active VS Code session via `sessionId`, in-memory only), or **Don't Ask Again** (permanently opts out via `globalState`). No user-identifying telemetry is sent. (`src/engagement/reviewPromptService.ts`)
- **🛠️ Dev-only review prompt reset command** — `litellm-connector.dev.resetReviewPrompt` clears durable review-prompt state for local testing. Gated on a `litellm-connector.isDevBuild` context key that is `true` only for `-devN` builds. (`src/commands/devTools.ts`, `package.json`)
- **🔕 Session-scoped "Maybe Later" suppression** — Deferring the prompt now suppresses it for the remainder of the active VS Code session only (tracked in memory via `vscode.env.sessionId`), so a restart restarts the eligibility cycle.

### 🐛 Fixes
- **🛡️ Stop re-prompting after "Maybe Later" when a chat starts during the displayed notification** — `showPromptIfEligible()` now re-checks session deferral at the display boundary as defense-in-depth. Previously, a 5-minute idle timer armed while the notification was already on screen (e.g. a chat started during the `await showInformationMessage()` window) could fire after the user deferred and re-prompt despite the "Maybe Later" choice. (`src/engagement/reviewPromptService.ts`)

### 🔧 Tweaks
- **🔗 Marketplace review deep-link** — The "Leave a Review" action now opens the `#review-details` anchor so users land directly on the rating/review form. (`src/engagement/reviewPromptService.ts`)

### 🧠 Provider & Telemetry
- Typed telemetry capture methods `captureReviewPromptEligible` / `captureReviewPromptChoice` added to `TelemetryService`.
- `LiteLLMProviderBase` exposes `setReviewPromptService()` for optional dependency injection.
- `LiteLLMChatProvider` calls `recordChatRequestStarted()` on request start and `recordSuccessfulChatTurn()` after success metric reporting (failed/cancelled/commit paths excluded).
- `ReviewPromptService` instantiated and injected into the chat provider during activation.

### ♻️ Refactor
- Split provider base logic into focused helper modules to keep `LiteLLMProviderBase` thinner and easier to test:
  - `src/providers/base/callConfig.ts` — call-time config resolution
  - `src/providers/base/parameterFiltering.ts` — capability-aware parameter filtering
  - `src/providers/base/quotaRedaction.ts` — quota failure redaction

### 🧹 Chores
- Bump extension version `2.2.3-dev3` → `2.2.3` (`package.json`, `package-lock.json`).
- Promote `CHANGELOG.md` `[Unreleased]` → `## [2.2.3] - 2026-07-31`; repoint footer `[Unreleased]` link to `rel/v2.2.3...HEAD`.
- Update "What's New" sections in `README.md` and `README.marketplace.md` to 2.2.3.
- Memory profiler test excluded from CI execution to prevent flaky interactions with concurrent Mocha runs. (`.vscode-test.mjs`)
- Update VS Code engine guidance in `AGENTS.md` to reflect `^1.125.0` target.

## Related Issues, Builds, Pipeline Runs, etc.

- Replaces closed Dependabot PRs #79 and #111 (sinon bumps deferred — no open PR; will need separate testing in a future release).
- Follows the v2.2.2 reasoning-metadata release (tag `rel/v2.2.2`).

## Pull Request Pre-check

- [x] Linting Validation Passed
- [x] Formatting Validation Passed
- [x] Unit Testing Passes
- [x] Documentation Updated

**Validation summary:** `npm run compile` ✅ · `npm run lint` (0 errors) ✅ · `npm run format` ✅ · `npm run test:coverage` — **918 passing**, exit 0 (Statements 90.13%, Branches 81.15%, Functions 87.72%, Lines 90.13%).