### PR TITLE
🚀 Release v2.3.0 — restore readable model picker

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/common_pr.yml
+++ b/.github/PULL_REQUEST_TEMPLATE/common_pr.yml
@@ -20,6 +20,11 @@ body:
         - #13
         - #22
 
+  - type: markdown
+    attributes:
+      value: |
+        > ℹ️ **Stale PR policy:** PRs with no activity for 21 days are marked `stale` and auto-closed after 7 more days. Any comment or push resets the timer. Apply `exemption:pr-stale` if you need more time. See [CONTRIBUTING.md](../blob/main/.github/CONTRIBUTING.md).
+
   - type: checkboxes
     id: benchmarks
     attributes:

--- a/.github/hooks/block-bump-on-main.json
+++ b/.github/hooks/block-bump-on-main.json
@@ -1,0 +1,11 @@
+{
+    "hooks": {
+        "PreToolUse": [
+            {
+                "type": "command",
+                "command": "./scripts/block-bump-on-main.sh",
+                "timeout": 15
+            }
+        ]
+    }
+}

--- a/.github/prompts/finish-dev-version.prompt.md
+++ b/.github/prompts/finish-dev-version.prompt.md
@@ -1,0 +1,50 @@
+---
+description: "Finish a dev version cycle: promote the -devN version to a release version, update CHANGELOG and README release notes, run the validation gate, and open a release PR to main."
+name: "Finish dev version"
+argument-hint: "Optional: release notes emphasis or exclusions"
+agent: "agent"
+---
+
+Finish the current development cycle and prepare this branch for release. Promote the `-devN` pre-release version to its final release version, bring all release documentation up to date, validate everything, and open a release PR to `main`.
+
+Follow this workflow exactly:
+
+1. Read and follow [AGENTS.md](../../AGENTS.md) before making changes. Only use the permitted npm commands it lists.
+
+2. Confirm preconditions.
+   - The current branch must NOT be `main`. If it is, stop and tell the user to run this from a dev branch.
+   - Read the `version` field in [package.json](../../package.json). It should carry a `-devN` suffix; if it does not, ask the user whether the version was already promoted before continuing.
+   - Run `git status --short`; note any uncommitted changes and include them in the final summary.
+
+3. Promote the version.
+   - Strip the `-devN` suffix by editing `package.json` directly (e.g. `2.3.0-dev4` → `2.3.0`). Do NOT run `npm run bump-version` — the base version was already chosen when the dev cycle started; this step only removes the pre-release suffix.
+   - Sync `package-lock.json`: update the top-level `version` and the `packages[""].version` fields to match.
+
+4. Update [CHANGELOG.md](../../CHANGELOG.md).
+   - Promote the `## [Unreleased]` section to `## [<version>] - <today's date>`.
+   - Insert a fresh empty `## [Unreleased]` heading above it.
+   - Verify every notable change on this branch (vs `origin/main`) is represented; add missing entries following the existing tone, emoji usage, and subsection structure. Use `git log --oneline origin/main..HEAD` and `git diff --stat origin/main..HEAD` to cross-check.
+   - Update the footer `[Unreleased]` link reference to compare from `rel/v<version>...HEAD`.
+   - Update any stale "Version bump" chore bullet to reflect the final version.
+
+5. Update the "What's New" sections.
+   - Both [README.md](../../README.md) and [README.marketplace.md](../../README.marketplace.md) have a `## 🆕 What's New in <previous-version>` section near the top.
+   - Rewrite each as `## 🆕 What's New in <version>` with 2–4 outcome-focused bullets summarizing the user-facing highlights of this release. Keep the existing structure (blockquote summary line, bullets, CHANGELOG link).
+
+6. Run the full validation gate, each independently, and confirm each succeeds:
+   - `npm run compile`
+   - `npm run lint`
+   - `npm run format`
+   - `npm run test:coverage`
+
+7. Verify version consistency.
+   - `package.json`, `package-lock.json`, the CHANGELOG heading, and both README "What's New" headings must all show the same `<version>` with no `-devN` remnants anywhere. Search the repo for the old dev version string to be sure.
+
+8. Commit and open the release PR.
+   - Commit all release-prep changes with an emoji-prefixed, outcome-focused message (e.g. `🚀 Release v<version> — <short highlight>`), then push the branch.
+   - Open a PR targeting `main` following the PR template (`.github/PULL_REQUEST_TEMPLATE/common_pr.yml`): a Change Log / Overview grouped by category, related issues, and the pre-check checklist with the validation summary.
+   - Do NOT merge the PR, tag, or publish — the user squash-merges from the web UI, then tags `rel/v<version>` on `main` to trigger the release pipeline.
+
+9. Summarize.
+   - Report: old version → new version, files changed, validation results, and the PR URL.
+   - Remind the user of the remaining manual steps: squash-merge via web UI, then `git checkout main && git pull && git tag rel/v<version> && git push origin rel/v<version>`.

--- a/.github/prompts/start-next-dev-version.prompt.md
+++ b/.github/prompts/start-next-dev-version.prompt.md
@@ -1,0 +1,47 @@
+---
+description: "Start development on the next version: carry current workspace changes onto a new dev branch, then bump the version with the requested variant."
+name: "Start next dev version"
+argument-hint: "Optional: variant (major|minor|patch|dev) and/or a branch topic, e.g. 'minor reasoning-overhaul'"
+agent: "agent"
+---
+
+Start development on the next version of this extension. Carry any current local workspace changes onto a new dev branch, then bump the version.
+
+Follow this workflow exactly:
+
+1. Read and follow [AGENTS.md](../../AGENTS.md) before making changes. Only use the permitted npm commands it lists.
+
+2. Determine the version variant.
+   - Acceptable variants: `major`, `minor`, `patch`, `dev`.
+   - If the user supplied a variant in their request, use it.
+   - Otherwise, infer from context (e.g. the conversation or pending changes imply a feature → `minor`, a fix → `patch`).
+   - If nothing is implied, default to `dev`.
+   - Variant semantics (for reference):
+     - `major`: increments major, resets minor and patch to `0`, clears any `-devN` suffix unless `dev` is also passed.
+     - `minor`: increments minor, resets patch to `0`, clears `-devN` unless `dev` is also passed.
+     - `patch`: increments patch, clears `-devN` unless `dev` is also passed.
+     - `dev`: appends `-dev1` if missing, otherwise increments the `-devN` counter.
+
+3. Determine the dev branch name.
+   - If the user supplied a topic or branch name, use `dev/<topic>` (kebab-case).
+   - Otherwise, infer a short topic from the current changes or conversation context (e.g. `dev/byok-docs`, `dev/stale-policy`).
+   - If nothing is inferable, use `dev/next-<base-version>` where `<base-version>` is the version that will result from the bump (without the `-devN` suffix).
+   - Never reuse an existing branch name; check with `git branch --list` and append a numeric suffix if needed.
+
+4. Create the dev branch, carrying current changes.
+   - Run `git status --short` to record the current working-tree state.
+   - Ensure the current branch is up to date enough to branch from (do NOT pull or rebase automatically; branch from the current state as-is).
+   - Run `git switch -c <branch-name>`. Uncommitted changes travel with the switch automatically — do NOT stash, reset, or discard anything.
+   - Verify with `git branch --show-current` and confirm `git status --short` still lists the same changes.
+
+5. Bump the version on the new branch.
+   - Run `npm run bump-version <variant> dev` (always include the trailing `dev` so the new cycle starts as a `-dev1` pre-release, unless the user explicitly asked for a non-dev version).
+   - Note: the script is `bump-version` (hyphen), not `bump:version`.
+   - Verify the new version in [package.json](../../package.json) matches the expected result and includes a `-devN` suffix when `dev` was requested.
+   - If `package-lock.json` did not update automatically, sync it by updating its top-level `version` fields to match.
+
+6. Validate and summarize.
+   - Confirm the branch name, old version, and new version.
+   - Confirm all pre-existing workspace changes are still present and untouched.
+   - Do NOT commit or push unless the user explicitly asks.
+   - Summarize: branch created, version bump applied (old → new), and any files carried over.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,69 @@
+name: Stale PR Cleanup
+# Closes pull requests that have had no activity for 21 days, with a 7-day
+# warning before closure. VS Code ships weekly, so PRs can rot quickly when
+# contributors don't respond to review feedback.
+#
+# Exemption labels (apply any one to keep a PR open indefinitely):
+#   - chore:dependencies    (Dependabot / dependency bumps)
+#   - exemption:pr-stale    (manual maintainer override)
+#
+# Issues are intentionally left untouched (days-before-issue-* set to -1).
+# Schedule: daily at 01:30 UTC, off-peak for the GitHub Actions cron pool.
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Mark and close stale pull requests
+        uses: actions/stale@v11
+        with:
+          # --- PR stale/close timing (user policy: 21 + 7) ---
+          days-before-stale: -1
+          days-before-close: -1
+          days-before-pr-stale: 21
+          days-before-pr-close: 7
+
+          # Issues are not managed by this workflow.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # --- Stale warning (applied after 21 days idle) ---
+          stale-pr-message: |
+            📛 This pull request is **stale** because it has had no activity for 21 days.
+
+            VS Code releases weekly, so PRs can fall out of sync quickly. This PR will be **closed in 7 days** if no further activity occurs.
+
+            - **To keep it open:** push an update, leave a comment, or remove the `stale` label.
+            - **After closure:** you can reopen the PR once it's updated and ready for review.
+
+            If you need more time, ask a maintainer to apply the `exemption:pr-stale` label.
+          stale-pr-label: "stale"
+
+          # --- Closure notice (applied after 7 more days idle) ---
+          close-pr-message: |
+            🔒 This pull request was **closed** because it remained stale for 7 days with no activity.
+
+            This is not a reflection on the contribution — VS Code moves fast and stale branches often no longer apply cleanly. When you're ready, reopen the PR (or open a fresh one) with updated changes and it will be re-reviewed.
+
+          # --- Exemptions: any PR carrying one of these labels is skipped ---
+          exempt-pr-labels: "chore:dependencies,exemption:pr-stale"
+
+          # Draft PRs are explicitly WIP; leave them alone.
+          exempt-draft-pr: true
+
+          # Any comment or push removes the stale label and restarts the timer.
+          remove-stale-when-updated: true
+
+          # Keep API usage within GitHub rate limits; this repo has a small PR volume.
+          operations-per-run: 30

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
         "npx vscode-test": true,
         "npx tsc": true,
         "npx prettier": true,
-        "tee": true
+        "tee": true,
+        "git switch": true
     }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,6 +365,18 @@ The extension surfaces a small set of developer-only commands when the installed
 - Validate both behavior and implementation presence: passing tests alone are not enough if the requested file edits did not land.
 - When reporting completion, ensure the repository state reflects the requested changes and the final file contents match the intended outcome.
 
+### Stale pull request policy
+VS Code ships weekly, so PRs that go unanswered can rot quickly. The `Stale PR Cleanup` workflow (`.github/workflows/stale.yml`) runs daily and:
+- marks a PR `stale` after **21 days** of inactivity (posts a warning comment), then
+- auto-closes it **7 days** later if no further activity occurs.
+
+Any comment, push, or review resets the timer and removes the `stale` label. Exemptions (apply any one label):
+- `chore:dependencies` — Dependabot / dependency-bump PRs
+- `exemption:pr-stale` — manual maintainer override
+- Draft PRs are exempt by default (explicitly WIP).
+
+Closing a stale PR is not a rejection; it can be reopened or resubmitted when updated. Contributors should read `.github/CONTRIBUTING.md` for the full policy.
+
 ## 6) Updating existing code
 
 Any code you edit must be brought up to these standards:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-08-01
+
+### 🚀 Features
+
+* **📋 Restore fully qualified model-ID picker copying**: The available-model picker now exposes discovered LiteLLM models for copying into VS Code BYOK settings, including the required `litellm-connector/` selector prefix.
+* **🧭 Improve model picker readability**: Models are presented as `<group> :: <display name>` with the complete selectable ID on the secondary line, while provider pricing and token limits remain in the model details.
+
+### 🧹 Chores
+
+* **🛡️ Add stale pull request cleanup**: Repository automation now marks inactive pull requests stale after 21 days and closes them after an additional 7 days, with documented exemptions.
+* **📚 Clarify BYOK release guidance**: Release and contributor documentation now covers provider-group configuration, model selection, development-version workflows, and the release process.
+
+### 🧪 Tests
+
+* Added regression coverage for successful per-group discovery snapshots, fully qualified model-ID copying, selector-prefix normalization, and readable picker fields.
+
 ## [2.2.3] - 2026-07-31
 
 ### 🚀 Features
@@ -692,7 +708,8 @@ There have been a tremendous amount of backend work done with this update to mak
 
 ---
 
-[Unreleased]: https://github.com/gethnet/litellm-connector-copilot/compare/rel/v2.2.3...HEAD
+[Unreleased]: https://github.com/gethnet/litellm-connector-copilot/compare/rel/v2.3.0...HEAD
+[2.3.0]: https://github.com/gethnet/litellm-connector-copilot/releases/tag/rel/v2.3.0
 [1.6.0]: https://github.com/gethnet/litellm-connector-copilot/releases/tag/rel/v1.6.0
 [1.5.0]: https://github.com/gethnet/litellm-connector-copilot/releases/tag/rel/v1.5.0
 [1.4.6]: https://github.com/gethnet/litellm-connector-copilot/releases/tag/rel/v1.4.6

--- a/README.marketplace.md
+++ b/README.marketplace.md
@@ -10,12 +10,13 @@ Bring **any LiteLLM-supported model** into the Copilot Chat model picker — Ope
 
 ---
 
-## 🆕 What's New in 2.2.3
+## 🆕 What's New in 2.3.0
 
-> Version 2.2.3 adds an idle-time Marketplace review prompt for engaged users and fixes a re-prompt race after "Maybe Later".
+> Version 2.3.0 restores a readable model-ID picker for configuring LiteLLM models in VS Code BYOK settings.
 
-- 💬 **Idle-time review prompt** — After 10 successful chat turns and 5 minutes of idle time, the extension offers a non-modal notification to leave a Marketplace review. Choose **Leave a Review**, **Maybe Later** (suppresses for the rest of the session), or **Don't Ask Again** (permanently opts out). All state is local; no user-identifying telemetry is sent.
-- 🔕 **Smarter "Maybe Later"** — Deferring the prompt now suppresses it for the remainder of the active VS Code session only (tracked in memory via `sessionId`), and a race that could re-prompt after "Maybe Later" when a chat started while the notification was displayed is now fixed.
+- 📋 **Copy complete model IDs** — Use **LiteLLM: Show Available Models** to copy the exact `litellm-connector/<group>/<model>` selector required by VS Code BYOK settings.
+- 🧭 **Readability-focused picker** — Models show as `<group> :: <display name>` with the full selectable ID on the secondary line and provider metadata in the details.
+- 🔄 **Reliable discovery snapshot** — The picker is populated from successful per-group discovery without changing response-time routing behavior.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for previous release notes.
 

--- a/README.marketplace.md
+++ b/README.marketplace.md
@@ -46,8 +46,9 @@ See [`CHANGELOG.md`](CHANGELOG.md) for previous release notes.
 ## ✅ Requirements
 
 - 🖥️ **VS Code 1.120+**
-- 🤖 **GitHub Copilot** (Free Individual plan works)
 - 🌐 A **LiteLLM proxy URL** and **API key**
+
+> **No Copilot subscription required.** BYOK models work without a GitHub login or Copilot plan — including air-gapped scenarios. See [Using BYOK Without Copilot](#-using-byok-without-copilot) to redirect the Copilot-backed utility models to your LiteLLM models.
 
 ---
 
@@ -76,6 +77,63 @@ See [`CHANGELOG.md`](CHANGELOG.md) for previous release notes.
 1. Run **LiteLLM: Manage Configuration** and verify Base URL + API key
 2. Run **LiteLLM: Reload Models** to force refresh
 3. If stuck: Remove LiteLLM provider groups via **LiteLLM: Manage Configuration** → VS Code's Language Models UI, then re-add
+
+---
+
+## 🚫 Using BYOK Without Copilot
+
+**BYOK models work without signing into a GitHub account or a Copilot plan**, including fully air-gapped scenarios. Your LiteLLM Connector models appear in the Chat model picker and work for chat and agent workflows with no Copilot subscription required.
+
+A few Copilot-backed features stop working without a login because their defaults point at Copilot models. You can redirect **all** of them to your LiteLLM Connector models so the full chat experience keeps working offline.
+
+> ⚠️ **Keep `chat.byokUtilityModelDefault` set to `GitHub Copilot`.** This setting governs how BYOK models are surfaced. Changing it can prevent your BYOK models from appearing in the picker.
+
+### Settings that take a fully qualified model name
+
+A fully qualified model name is `litellm-connector/<provider-group>/<model>`, matching the identifier shown in the Chat model picker.
+
+| Setting | What it controls |
+|---------|------------------|
+| `github.copilot.selectedCompletionModel` | Inline completions model |
+| `github.copilot.chat.workspace.preferredEmbeddingsModel` | Semantic search embeddings |
+| `github.copilot.chat.instantApply.shortContextModelName` | Instant Apply short-context model |
+
+### Settings that use a model dropdown
+
+These settings present a dropdown of every available model (including your BYOK models). Pick the LiteLLM Connector model you want from the list.
+
+| Setting | What it controls |
+|---------|------------------|
+| `chat.utilityModel` | Background utility model (chat titles, rename suggestions) |
+| `chat.utilitySmallModel` | Lightweight utility model (commit messages, summaries) |
+
+### Example `settings.json`
+
+```jsonc
+{
+  // Keep this as "GitHub Copilot" so BYOK models are surfaced correctly.
+  "chat.byokUtilityModelDefault": "GitHub Copilot",
+
+  // Redirect Copilot-backed features to LiteLLM Connector models.
+  "github.copilot.selectedCompletionModel": "litellm-connector/<group>/<model>",
+  "github.copilot.chat.workspace.preferredEmbeddingsModel": "litellm-connector/<group>/<embedding-model>",
+  "github.copilot.chat.instantApply.shortContextModelName": "litellm-connector/<group>/<model>",
+
+  // Pick these from the model dropdown in Settings UI.
+  "chat.utilityModel": "litellm-connector/<group>/<model>",
+  "chat.utilitySmallModel": "litellm-connector/<group>/<small-model>"
+}
+```
+
+Replace `<group>` with your provider group name and the model placeholders with models from your LiteLLM proxy. Reload the window (`Developer: Reload Window`) for changes to take effect.
+
+### Copy a fully qualified model name
+
+After configuring a provider, run **LiteLLM: Reload Models**, then run **LiteLLM: Show Available Models**. Select a model to copy its fully qualified ID to the clipboard for use in VS Code BYOK settings.
+
+The picker shows a friendly model name but copies the complete model ID, including the provider-group namespace. Use the copied value for settings such as `github.copilot.selectedCompletionModel`, `chat.utilityModel`, and `chat.utilitySmallModel`.
+
+> **Enterprise note:** For Copilot Business or Enterprise, organization administrators can control BYOK availability through Copilot policy settings.
 
 ---
 
@@ -154,8 +212,9 @@ These aren't in Settings UI — add to `settings.json` if needed:
 
 ## 🧩 Notes
 
-- This extension is a **provider** for GitHub Copilot Chat
-- Requires the **GitHub Copilot Chat** extension
+- This extension is a **language model provider** for VS Code Chat
+- Works **with or without** GitHub Copilot (BYOK models work without a Copilot subscription)
+- VS Code Chat (formerly Copilot Chat) is built into VS Code 1.120+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ Your support keeps this project alive and improving! ❤️
 ### Prerequisites
 
 - ✅ **VS Code 1.120+** (required)
-- ✅ **GitHub Copilot Individual** subscription (Free or Paid Individual plans work)
 - 🌐 A **LiteLLM proxy** running somewhere (locally or in the cloud)
 - 🔑 Your **Base URL** and **API Key**
 
 > **New to LiteLLM?** Check out [their documentation](https://docs.litellm.ai) to learn how to set up a proxy that can route to any model provider.
+
+> **No Copilot subscription required.** BYOK models work **without signing into a GitHub account or a Copilot plan** — including fully air-gapped scenarios with local models. See [Using BYOK Without Copilot](#-using-byok-without-copilot) for how to replace the Copilot-backed utility models.
 
 ### Quick Setup
 
@@ -123,6 +124,64 @@ Fine-tune model metadata for specific models via `litellm-connector.modelOverrid
 - **Organizations** running private LLMs behind firewalls
 - **AI enthusiasts** testing new models as they're released
 - **Researchers** comparing model performance on real code
+
+---
+
+## 🚫 Using BYOK Without Copilot
+
+**BYOK models work without signing into a GitHub account or a Copilot plan**, including fully air-gapped scenarios. Your LiteLLM Connector models will appear in the Chat model picker and work for chat and agent workflows with no Copilot subscription required.
+
+A few Copilot-backed features stop working without a login because their defaults point at Copilot models. You can redirect **all** of them to your LiteLLM Connector models so the full chat experience keeps working offline.
+
+> ⚠️ **Keep `chat.byokUtilityModelDefault` set to `GitHub Copilot`.** This setting governs how BYOK models are surfaced. Changing it can prevent your BYOK models from appearing in the picker.
+
+### Settings that take a fully qualified model name
+
+A fully qualified model name is `litellm-connector/<provider-group>/<model>`, matching the identifier shown in the Chat model picker. For example: `litellm-connector/azure_ai/text-embedding-3-small`.
+
+| Setting | What it controls | Example value |
+|---------|------------------|---------------|
+| `github.copilot.selectedCompletionModel` | Inline completions model | `litellm-connector/<group>/<model>` |
+| `github.copilot.chat.workspace.preferredEmbeddingsModel` | Semantic search embeddings | `litellm-connector/<group>/<embedding-model>` |
+| `github.copilot.chat.instantApply.shortContextModelName` | Instant Apply short-context model | `litellm-connector/<group>/<model>` |
+
+### Settings that use a model dropdown
+
+These settings present a dropdown of every available model (including your BYOK models). Pick the LiteLLM Connector model you want from the list.
+
+| Setting | What it controls |
+|---------|------------------|
+| `chat.utilityModel` | Background utility model (chat titles, rename suggestions, etc.) |
+| `chat.utilitySmallModel` | Lightweight utility model (commit messages, summaries) |
+
+### Example `settings.json`
+
+```jsonc
+{
+  // Keep this as "GitHub Copilot" so BYOK models are surfaced correctly.
+  "chat.byokUtilityModelDefault": "GitHub Copilot",
+
+  // Redirect Copilot-backed features to LiteLLM Connector models.
+  // Use the fully qualified name from the Chat model picker.
+  "github.copilot.selectedCompletionModel": "litellm-connector/<group>/<model>",
+  "github.copilot.chat.workspace.preferredEmbeddingsModel": "litellm-connector/<group>/<embedding-model>",
+  "github.copilot.chat.instantApply.shortContextModelName": "litellm-connector/<group>/<model>",
+
+  // Pick these from the model dropdown in Settings UI.
+  "chat.utilityModel": "litellm-connector/<group>/<model>",
+  "chat.utilitySmallModel": "litellm-connector/<group>/<small-model>"
+}
+```
+
+Replace `<group>` with your configured provider group name and `<model>` / `<embedding-model>` / `<small-model>` with the model names from your LiteLLM proxy. After saving, reload the window (`Developer: Reload Window`) for the changes to take effect.
+
+### Copy a fully qualified model name
+
+Run **LiteLLM: Show Available Models** from the Command Palette after configuring a provider and running **LiteLLM: Reload Models**. Select a model to copy its fully qualified ID to the clipboard.
+
+The copied ID is the complete model ID shown by discovery, including the provider-group namespace. Use that value in settings such as `github.copilot.selectedCompletionModel`, `chat.utilityModel`, or `chat.utilitySmallModel`. The picker displays a friendly model name, but copies the complete routable ID.
+
+> **Enterprise note:** For Copilot Business or Enterprise, organization administrators can control BYOK availability through Copilot policy settings. If your admin has disabled BYOK, these models will not appear even after configuration.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@
 
 [![License](https://img.shields.io/github/license/gethnet/litellm-connector-copilot)](LICENSE)
 
-## 🆕 What's New in 2.2.3
+## 🆕 What's New in 2.3.0
 
-> Version 2.2.3 adds an idle-time Marketplace review prompt for engaged users and fixes a re-prompt race after "Maybe Later".
+> Version 2.3.0 restores a readable model-ID picker for configuring LiteLLM models in VS Code BYOK settings.
 
-- 💬 **Idle-time review prompt** — After 10 successful chat turns and 5 minutes of idle time, the extension offers a non-modal notification to leave a Marketplace review. Choose **Leave a Review**, **Maybe Later** (suppresses for the rest of the session), or **Don't Ask Again** (permanently opts out). All state is local; no user-identifying telemetry is sent.
-- 🔕 **Smarter "Maybe Later"** — Deferring the prompt now suppresses it for the remainder of the active VS Code session only (tracked in memory via `sessionId`), and a race that could re-prompt after "Maybe Later" when a chat started while the notification was displayed is now fixed.
+- 📋 **Copy complete model IDs** — Use **LiteLLM: Show Available Models** to copy the exact `litellm-connector/<group>/<model>` selector required by VS Code BYOK settings.
+- 🧭 **Readability-focused picker** — Models show as `<group> :: <display name>` with the full selectable ID on the secondary line and provider metadata in the details.
+- 🔄 **Reliable discovery snapshot** — The picker is populated from successful per-group discovery without changing response-time routing behavior.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for previous release notes.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "litellm-connector-copilot",
 	"displayName": "LiteLLM Connector for Copilot",
-	"version": "2.3.0-dev1",
+	"version": "2.3.0",
 	"description": "An extension that integrates LiteLLM proxy into Copilot",
 	"categories": [
 		"AI",

--- a/package.json
+++ b/package.json
@@ -1,354 +1,354 @@
 {
-  "name": "litellm-connector-copilot",
-  "displayName": "LiteLLM Connector for Copilot",
-  "version": "2.2.3",
-  "description": "An extension that integrates LiteLLM proxy into Copilot",
-  "categories": [
-    "AI",
-    "Chat",
-    "Machine Learning",
-    "Other"
-  ],
-  "keywords": [
-    "litellm",
-    "llm",
-    "copilot",
-    "ai-connector",
-    "openai",
-    "anthropic",
-    "local-llm",
-    "language model provider",
-    "language model",
-    "connector",
-    "copilot connector"
-  ],
-  "homepage": "https://github.com/gethnet/litellm-connector-copilot",
-  "bugs": {
-    "url": "https://github.com/gethnet/litellm-connector-copilot/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gethnet/litellm-connector-copilot"
-  },
-  "license": "Apache-2.0",
-  "maintainers": [
-    "amwdrizz"
-  ],
-  "contributors": [
-    "amwdrizz"
-  ],
-  "publisher": "GethNet",
-  "main": "./dist/extension.js",
-  "browser": "./dist/web/extension.js",
-  "scripts": {
-    "bump-version": "node scripts/bump-version.js",
-    "check": "npm run lint; npm run format; npm run test:coverage;",
-    "clean": "find ./dist ./out ./coverage ./test-results -delete || true",
-    "clean:build": "find ./dist ./out -delete || true",
-    "clean:tests": "find ./coverage ./test-results -delete || true",
-    "precompile": "npm run clean",
-    "compile": "tsc -p ./",
-    "coverage:serve": "npx serve coverage -p 8080",
-    "download-api": "yes | dts main && mv vscode.d.ts src/ && yes | dts dev && mv vscode.proposed.*.d.ts src/",
-    "format": "prettier --check .",
-    "format:fix": "prettier --write .",
-    "postinstall": "npm run download-api",
-    "lint": "eslint",
-    "lint:fix": "eslint --fix",
-    "memory-profile": "npm run compile && node scripts/run-memory-profile.mjs",
-    "package:marketplace": "node scripts/package-marketplace.mjs",
-    "pretest": "npm run compile",
-    "test": "xvfb-run vscode-test --args=\"--no-sandbox\"",
-    "pretest:coverage": "npm run compile",
-    "test:coverage": "node scripts/test-coverage.mjs",
-    "test:report": "npm run pretest && export VSCODE_TEST_RESULTS_DIR=$PWD/test-results && mkdir -p $VSCODE_TEST_RESULTS_DIR && npm run test",
-    "vscode:pack": "npm run clean:build && tsc --noEmit && node esbuild.js --production && npx vsce package",
-    "vscode:pack:dev": "npm run clean:build && tsc --noEmit && node esbuild.js && npx vsce package",
-    "watch": "tsc -watch -p ./"
-  },
-  "contributes": {
-    "commands": [
-      {
-        "command": "litellm-connector.showModels",
-        "title": "LiteLLM: Show Available Models"
-      },
-      {
-        "command": "litellm-connector.reloadModels",
-        "title": "LiteLLM: Reload Models"
-      },
-      {
-        "command": "litellm-connector.manage",
-        "title": "LiteLLM: Manage Configuration"
-      },
-      {
-        "command": "litellm-connector.resetConfiguration",
-        "title": "LiteLLM: Reset All Configuration"
-      },
-      {
-        "command": "litellm-connector.generateCommitMessage",
-        "title": "Generate Commit Message",
-        "icon": "$(sparkle)"
-      },
-      {
-        "command": "litellm-connector.setLogLevel",
-        "title": "LiteLLM: Set Log Level"
-      },
-      {
-        "command": "litellm-connector.dev.resetReviewPrompt",
-        "title": "LiteLLM: Dev Reset Review Prompt",
-        "enablement": "litellm-connector.isDevBuild",
-        "category": "LiteLLM (Dev)"
-      }
-    ],
-    "configuration": {
-      "title": "LiteLLM Connector",
-      "properties": {
-        "litellm-connector.modelIdOverride": {
-          "type": "string",
-          "default": "",
-          "description": "(Deprecated) Optional: force a specific LiteLLM model id for legacy workflows."
-        },
-        "litellm-connector.commitModelIdOverride": {
-          "type": "string",
-          "default": "",
-          "description": "Override the model ID for git commit message generation. If empty, the feature is disabled.",
-          "markdownDescription": "Override the model ID for git commit message generation. If empty, the feature is disabled."
-        },
-        "litellm-connector.disableQuotaToolRedaction": {
-          "type": "boolean",
-          "default": false,
-          "description": "Disable per-turn tool redaction when a quota error is detected in chat history. Leave off to keep redaction enabled."
-        },
-        "litellm-connector.modelOverrides": {
-          "type": "array",
-          "default": [],
-          "description": "User-supplied model overrides for reasoning capabilities. Merged on top of bundled overrides (user entries take precedence on regex match). Each entry: { match: string (regex), supportsReasoning?: boolean|null, reasoningEfforts?: string[], defaultEffort?: string, notes?: string }.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "match": {
-                "type": "string",
-                "description": "Regex pattern matched against the model id."
-              },
-              "supportsReasoning": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
-                "description": "Override reasoning support. null = inherit from proxy."
-              },
-              "reasoningEfforts": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "none",
-                    "minimal",
-                    "low",
-                    "medium",
-                    "high",
-                    "xhigh",
-                    "max"
-                  ]
-                }
-              },
-              "defaultEffort": {
-                "type": "string",
-                "enum": [
-                  "none",
-                  "minimal",
-                  "low",
-                  "medium",
-                  "high",
-                  "xhigh",
-                  "max"
-                ]
-              },
-              "notes": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "match"
-            ]
-          }
-        },
-        "litellm-connector.modelCapabilitiesOverrides": {
-          "type": "object",
-          "default": {},
-          "description": "Override model capabilities (toolCalling, imageInput) reported to VS Code. Key is the Model ID (e.g. 'gpt-4o'), value is a comma-separated list of capabilities to ENABLE (e.g. 'toolCalling,imageInput').",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "litellm-connector.inactivityTimeout": {
-          "type": "number",
-          "default": 60,
-          "description": "Timeout in seconds of inactivity before the LiteLLM proxy connection is considered idle."
-        },
-        "litellm-connector.disableCaching": {
-          "type": "boolean",
-          "default": false,
-          "description": "When enabled, bypass LiteLLM caching only for models whose supported OpenAI parameters include cache.",
-          "tags": [
-            "experimental"
-          ]
-        },
-        "litellm-connector.enableModelOverrides": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enable model-card overrides for matching models. When disabled, LiteLLM `/model/info` data is used unchanged. When enabled, only explicitly configured override fields replace incoming LiteLLM values."
-        },
-        "litellm-connector.displayPricingInPicker": {
-          "type": "boolean",
-          "default": true,
-          "description": "Show model pricing in the model picker when available."
-        },
-        "litellm-connector.discoveryTimeoutMs": {
-          "type": "number",
-          "default": 5000,
-          "minimum": 500,
-          "maximum": 60000,
-          "tags": [
-            "advanced"
-          ],
-          "description": "Timeout in milliseconds for /model/info discovery requests. Default: 5000."
-        },
-        "litellm-connector.discoveryCacheTtlMs": {
-          "type": "number",
-          "default": 60000,
-          "minimum": 0,
-          "maximum": 300000,
-          "tags": [
-            "advanced"
-          ],
-          "description": "TTL in milliseconds for cached /model/info discovery responses. Set to 0 to disable caching. Default: 60000."
-        },
-        "litellm-connector.discoveryFireDebounceMs": {
-          "type": "number",
-          "default": 250,
-          "minimum": 0,
-          "maximum": 5000,
-          "tags": [
-            "advanced"
-          ],
-          "description": "Trailing-edge debounce window in milliseconds for outward model-discovery change notifications. Set to 0 to disable debouncing. Default: 250."
-        },
-        "litellm-connector.discoveryFireMinIntervalMs": {
-          "type": "number",
-          "default": 2000,
-          "minimum": 0,
-          "maximum": 30000,
-          "tags": [
-            "advanced"
-          ],
-          "description": "Minimum interval in milliseconds between outward model-discovery change notifications. Set to 0 to disable rate limiting. Default: 2000."
-        }
-      }
-    },
-    "keybindings": [],
-    "languageModelChatProviders": [
-      {
-        "vendor": "litellm-connector",
-        "displayName": "LiteLLM",
-        "configuration": {
-          "type": "object",
-          "properties": {
-            "baseUrl": {
-              "type": "string",
-              "title": "Server URL",
-              "description": "Base URL for the LiteLLM proxy server (must start with http:// or https://).",
-              "pattern": "^https?:\\/\\/.+",
-              "group": "navigation"
-            },
-            "apiKey": {
-              "type": "string",
-              "title": "API Key",
-              "description": "API key used to authenticate with the LiteLLM proxy.",
-              "secret": true,
-              "minLength": 1
-            }
-          },
-          "required": [
-            "baseUrl",
-            "apiKey"
-          ]
-        }
-      }
-    ],
-    "menus": {
-      "scm/title": [
-        {
-          "command": "litellm-connector.generateCommitMessage",
-          "group": "navigation",
-          "when": "config.litellm-connector.commitModelIdOverride != ''"
-        }
-      ],
-      "commandPalette": [
-        {
-          "command": "litellm-connector.dev.resetReviewPrompt",
-          "when": "litellm-connector.isDevBuild"
-        }
-      ]
-    }
-  },
-  "activationEvents": [
-    "onLanguageModelChatProvider:litellm-connector",
-    "onStartupFinished"
-  ],
-  "devDependencies": {
-    "@eslint/js": "^10.0.0",
-    "@stylistic/eslint-plugin": "^5.7.1",
-    "@types/mocha": "^10.0.10",
-    "@types/node": "^26.1.1",
-    "@types/sinon": "^22.0.0",
-    "@types/vscode": "^1.125.0",
-    "@vscode/dts": "^0.4.1",
-    "@vscode/test-cli": "^0.0.15",
-    "@vscode/test-electron": "^3.0.0",
-    "@vscode/vsce": "^3.7.0",
-    "esbuild": "^0.28.0",
-    "eslint": "^10.7.0",
-    "mocha-junit-reporter": "^2.2.1",
-    "mocha-multi-reporters": "^1.5.0",
-    "ovsx": "^1.0.2",
-    "posthog-js": "^1.409.0",
-    "posthog-node": "^5.47.0",
-    "prettier": "^3.8.4",
-    "rimraf": "^6.0.1",
-    "serve": "^14.2.6",
-    "sinon": "^22.0.0",
-    "typescript": "^6.0.3",
-    "typescript-eslint": "^8.64.0",
-    "zx": "^8.8.5"
-  },
-  "engines": {
-    "vscode": "^1.125.0"
-  },
-  "icon": "assets/logo.png",
-  "badges": [
-    {
-      "description": "Star litellm-connector-copilot on Github",
-      "url": "https://img.shields.io/github/stars/gethnet/litellm-connector-copilot?style=social",
-      "href": "https://github.com/gethnet/litellm-connector-copilot"
-    }
-  ],
-  "galleryBanner": {
-    "color": "#100f11",
-    "theme": "dark"
-  },
-  "preview": true,
-  "enabledApiProposals": [
-    "chatProvider",
-    "languageModelCapabilities",
-    "languageModelPricing",
-    "languageModelProxy",
-    "languageModelSystem",
-    "languageModelThinkingPart",
-    "languageModelToolResultAudience",
-    "languageModelToolSupportsModel"
-  ],
-  "sponsor": {
-    "url": "https://buymeacoffee.com/amwdrizz"
-  }
+	"name": "litellm-connector-copilot",
+	"displayName": "LiteLLM Connector for Copilot",
+	"version": "2.3.0-dev1",
+	"description": "An extension that integrates LiteLLM proxy into Copilot",
+	"categories": [
+		"AI",
+		"Chat",
+		"Machine Learning",
+		"Other"
+	],
+	"keywords": [
+		"litellm",
+		"llm",
+		"copilot",
+		"ai-connector",
+		"openai",
+		"anthropic",
+		"local-llm",
+		"language model provider",
+		"language model",
+		"connector",
+		"copilot connector"
+	],
+	"homepage": "https://github.com/gethnet/litellm-connector-copilot",
+	"bugs": {
+		"url": "https://github.com/gethnet/litellm-connector-copilot/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/gethnet/litellm-connector-copilot"
+	},
+	"license": "Apache-2.0",
+	"maintainers": [
+		"amwdrizz"
+	],
+	"contributors": [
+		"amwdrizz"
+	],
+	"publisher": "GethNet",
+	"main": "./dist/extension.js",
+	"browser": "./dist/web/extension.js",
+	"scripts": {
+		"bump-version": "node scripts/bump-version.js",
+		"check": "npm run lint; npm run format; npm run test:coverage;",
+		"clean": "find ./dist ./out ./coverage ./test-results -delete || true",
+		"clean:build": "find ./dist ./out -delete || true",
+		"clean:tests": "find ./coverage ./test-results -delete || true",
+		"precompile": "npm run clean",
+		"compile": "tsc -p ./",
+		"coverage:serve": "npx serve coverage -p 8080",
+		"download-api": "yes | dts main && mv vscode.d.ts src/ && yes | dts dev && mv vscode.proposed.*.d.ts src/",
+		"format": "prettier --check .",
+		"format:fix": "prettier --write .",
+		"postinstall": "npm run download-api",
+		"lint": "eslint",
+		"lint:fix": "eslint --fix",
+		"memory-profile": "npm run compile && node scripts/run-memory-profile.mjs",
+		"package:marketplace": "node scripts/package-marketplace.mjs",
+		"pretest": "npm run compile",
+		"test": "xvfb-run vscode-test --args=\"--no-sandbox\"",
+		"pretest:coverage": "npm run compile",
+		"test:coverage": "node scripts/test-coverage.mjs",
+		"test:report": "npm run pretest && export VSCODE_TEST_RESULTS_DIR=$PWD/test-results && mkdir -p $VSCODE_TEST_RESULTS_DIR && npm run test",
+		"vscode:pack": "npm run clean:build && tsc --noEmit && node esbuild.js --production && npx vsce package",
+		"vscode:pack:dev": "npm run clean:build && tsc --noEmit && node esbuild.js && npx vsce package",
+		"watch": "tsc -watch -p ./"
+	},
+	"contributes": {
+		"commands": [
+			{
+				"command": "litellm-connector.showModels",
+				"title": "LiteLLM: Show Available Models"
+			},
+			{
+				"command": "litellm-connector.reloadModels",
+				"title": "LiteLLM: Reload Models"
+			},
+			{
+				"command": "litellm-connector.manage",
+				"title": "LiteLLM: Manage Configuration"
+			},
+			{
+				"command": "litellm-connector.resetConfiguration",
+				"title": "LiteLLM: Reset All Configuration"
+			},
+			{
+				"command": "litellm-connector.generateCommitMessage",
+				"title": "Generate Commit Message",
+				"icon": "$(sparkle)"
+			},
+			{
+				"command": "litellm-connector.setLogLevel",
+				"title": "LiteLLM: Set Log Level"
+			},
+			{
+				"command": "litellm-connector.dev.resetReviewPrompt",
+				"title": "LiteLLM: Dev Reset Review Prompt",
+				"enablement": "litellm-connector.isDevBuild",
+				"category": "LiteLLM (Dev)"
+			}
+		],
+		"configuration": {
+			"title": "LiteLLM Connector",
+			"properties": {
+				"litellm-connector.modelIdOverride": {
+					"type": "string",
+					"default": "",
+					"description": "(Deprecated) Optional: force a specific LiteLLM model id for legacy workflows."
+				},
+				"litellm-connector.commitModelIdOverride": {
+					"type": "string",
+					"default": "",
+					"description": "Override the model ID for git commit message generation. If empty, the feature is disabled.",
+					"markdownDescription": "Override the model ID for git commit message generation. If empty, the feature is disabled."
+				},
+				"litellm-connector.disableQuotaToolRedaction": {
+					"type": "boolean",
+					"default": false,
+					"description": "Disable per-turn tool redaction when a quota error is detected in chat history. Leave off to keep redaction enabled."
+				},
+				"litellm-connector.modelOverrides": {
+					"type": "array",
+					"default": [],
+					"description": "User-supplied model overrides for reasoning capabilities. Merged on top of bundled overrides (user entries take precedence on regex match). Each entry: { match: string (regex), supportsReasoning?: boolean|null, reasoningEfforts?: string[], defaultEffort?: string, notes?: string }.",
+					"items": {
+						"type": "object",
+						"properties": {
+							"match": {
+								"type": "string",
+								"description": "Regex pattern matched against the model id."
+							},
+							"supportsReasoning": {
+								"type": [
+									"boolean",
+									"null"
+								],
+								"description": "Override reasoning support. null = inherit from proxy."
+							},
+							"reasoningEfforts": {
+								"type": "array",
+								"items": {
+									"type": "string",
+									"enum": [
+										"none",
+										"minimal",
+										"low",
+										"medium",
+										"high",
+										"xhigh",
+										"max"
+									]
+								}
+							},
+							"defaultEffort": {
+								"type": "string",
+								"enum": [
+									"none",
+									"minimal",
+									"low",
+									"medium",
+									"high",
+									"xhigh",
+									"max"
+								]
+							},
+							"notes": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"match"
+						]
+					}
+				},
+				"litellm-connector.modelCapabilitiesOverrides": {
+					"type": "object",
+					"default": {},
+					"description": "Override model capabilities (toolCalling, imageInput) reported to VS Code. Key is the Model ID (e.g. 'gpt-4o'), value is a comma-separated list of capabilities to ENABLE (e.g. 'toolCalling,imageInput').",
+					"additionalProperties": {
+						"type": "string"
+					}
+				},
+				"litellm-connector.inactivityTimeout": {
+					"type": "number",
+					"default": 60,
+					"description": "Timeout in seconds of inactivity before the LiteLLM proxy connection is considered idle."
+				},
+				"litellm-connector.disableCaching": {
+					"type": "boolean",
+					"default": false,
+					"description": "When enabled, bypass LiteLLM caching only for models whose supported OpenAI parameters include cache.",
+					"tags": [
+						"experimental"
+					]
+				},
+				"litellm-connector.enableModelOverrides": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Enable model-card overrides for matching models. When disabled, LiteLLM `/model/info` data is used unchanged. When enabled, only explicitly configured override fields replace incoming LiteLLM values."
+				},
+				"litellm-connector.displayPricingInPicker": {
+					"type": "boolean",
+					"default": true,
+					"description": "Show model pricing in the model picker when available."
+				},
+				"litellm-connector.discoveryTimeoutMs": {
+					"type": "number",
+					"default": 5000,
+					"minimum": 500,
+					"maximum": 60000,
+					"tags": [
+						"advanced"
+					],
+					"description": "Timeout in milliseconds for /model/info discovery requests. Default: 5000."
+				},
+				"litellm-connector.discoveryCacheTtlMs": {
+					"type": "number",
+					"default": 60000,
+					"minimum": 0,
+					"maximum": 300000,
+					"tags": [
+						"advanced"
+					],
+					"description": "TTL in milliseconds for cached /model/info discovery responses. Set to 0 to disable caching. Default: 60000."
+				},
+				"litellm-connector.discoveryFireDebounceMs": {
+					"type": "number",
+					"default": 250,
+					"minimum": 0,
+					"maximum": 5000,
+					"tags": [
+						"advanced"
+					],
+					"description": "Trailing-edge debounce window in milliseconds for outward model-discovery change notifications. Set to 0 to disable debouncing. Default: 250."
+				},
+				"litellm-connector.discoveryFireMinIntervalMs": {
+					"type": "number",
+					"default": 2000,
+					"minimum": 0,
+					"maximum": 30000,
+					"tags": [
+						"advanced"
+					],
+					"description": "Minimum interval in milliseconds between outward model-discovery change notifications. Set to 0 to disable rate limiting. Default: 2000."
+				}
+			}
+		},
+		"keybindings": [],
+		"languageModelChatProviders": [
+			{
+				"vendor": "litellm-connector",
+				"displayName": "LiteLLM",
+				"configuration": {
+					"type": "object",
+					"properties": {
+						"baseUrl": {
+							"type": "string",
+							"title": "Server URL",
+							"description": "Base URL for the LiteLLM proxy server (must start with http:// or https://).",
+							"pattern": "^https?:\\/\\/.+",
+							"group": "navigation"
+						},
+						"apiKey": {
+							"type": "string",
+							"title": "API Key",
+							"description": "API key used to authenticate with the LiteLLM proxy.",
+							"secret": true,
+							"minLength": 1
+						}
+					},
+					"required": [
+						"baseUrl",
+						"apiKey"
+					]
+				}
+			}
+		],
+		"menus": {
+			"scm/title": [
+				{
+					"command": "litellm-connector.generateCommitMessage",
+					"group": "navigation",
+					"when": "config.litellm-connector.commitModelIdOverride != ''"
+				}
+			],
+			"commandPalette": [
+				{
+					"command": "litellm-connector.dev.resetReviewPrompt",
+					"when": "litellm-connector.isDevBuild"
+				}
+			]
+		}
+	},
+	"activationEvents": [
+		"onLanguageModelChatProvider:litellm-connector",
+		"onStartupFinished"
+	],
+	"devDependencies": {
+		"@eslint/js": "^10.0.0",
+		"@stylistic/eslint-plugin": "^5.7.1",
+		"@types/mocha": "^10.0.10",
+		"@types/node": "^26.1.1",
+		"@types/sinon": "^22.0.0",
+		"@types/vscode": "^1.125.0",
+		"@vscode/dts": "^0.4.1",
+		"@vscode/test-cli": "^0.0.15",
+		"@vscode/test-electron": "^3.0.0",
+		"@vscode/vsce": "^3.7.0",
+		"esbuild": "^0.28.0",
+		"eslint": "^10.7.0",
+		"mocha-junit-reporter": "^2.2.1",
+		"mocha-multi-reporters": "^1.5.0",
+		"ovsx": "^1.0.2",
+		"posthog-js": "^1.409.0",
+		"posthog-node": "^5.47.0",
+		"prettier": "^3.8.4",
+		"rimraf": "^6.0.1",
+		"serve": "^14.2.6",
+		"sinon": "^22.0.0",
+		"typescript": "^6.0.3",
+		"typescript-eslint": "^8.64.0",
+		"zx": "^8.8.5"
+	},
+	"engines": {
+		"vscode": "^1.125.0"
+	},
+	"icon": "assets/logo.png",
+	"badges": [
+		{
+			"description": "Star litellm-connector-copilot on Github",
+			"url": "https://img.shields.io/github/stars/gethnet/litellm-connector-copilot?style=social",
+			"href": "https://github.com/gethnet/litellm-connector-copilot"
+		}
+	],
+	"galleryBanner": {
+		"color": "#100f11",
+		"theme": "dark"
+	},
+	"preview": true,
+	"enabledApiProposals": [
+		"chatProvider",
+		"languageModelCapabilities",
+		"languageModelPricing",
+		"languageModelProxy",
+		"languageModelSystem",
+		"languageModelThinkingPart",
+		"languageModelToolResultAudience",
+		"languageModelToolSupportsModel"
+	],
+	"sponsor": {
+		"url": "https://buymeacoffee.com/amwdrizz"
+	}
 }

--- a/scripts/block-bump-on-main.sh
+++ b/scripts/block-bump-on-main.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# PreToolUse hook: block `npm run bump-version` while on the main branch.
+#
+# Version bumps must happen on a dev/* branch (see
+# .github/prompts/start-next-dev-version.prompt.md). Running the bump on main
+# risks polluting the release branch with an unreviewed version change.
+#
+# Contract: receives the PreToolUse JSON payload on stdin; emits a
+# hookSpecificOutput permissionDecision on stdout. Anything that is not a
+# bump-version terminal command on main is allowed through untouched.
+
+set -euo pipefail
+
+PAYLOAD=$(cat)
+
+# Only inspect terminal commands; allow everything else immediately.
+COMMAND=$(printf '%s' "$PAYLOAD" | node -e '
+  let data = "";
+  process.stdin.on("data", (c) => (data += c));
+  process.stdin.on("end", () => {
+    try {
+      const payload = JSON.parse(data);
+      // Tool input shape varies; check the common command-bearing fields.
+      const input = payload.tool_input ?? payload.toolInput ?? {};
+      process.stdout.write(String(input.command ?? ""));
+    } catch {
+      process.stdout.write("");
+    }
+  });
+' 2>/dev/null || true)
+
+if [[ "$COMMAND" != *"bump-version"* ]]; then
+  exit 0
+fi
+
+BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+
+if [[ "$BRANCH" == "main" ]]; then
+  cat <<'JSON'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Version bumps are not allowed on main. Create a dev branch first (run the start-next-dev-version prompt), then bump the version there."
+  }
+}
+JSON
+  exit 0
+fi
+
+exit 0

--- a/src/commands/manageConfig.ts
+++ b/src/commands/manageConfig.ts
@@ -4,6 +4,14 @@ import type { LiteLLMChatProvider } from "../providers";
 import type { TelemetryService } from "../telemetry/telemetryService";
 import { Logger } from "../utils/logger";
 
+type ModelQuickPickItem = vscode.QuickPickItem & { modelId: string };
+
+const MODEL_SELECTOR = "litellm-connector/";
+
+function toSelectableModelId(modelId: string): string {
+    return modelId.startsWith(MODEL_SELECTOR) ? modelId : `${MODEL_SELECTOR}${modelId}`;
+}
+
 function createConfigHandler(
     _configManager: ConfigManager,
     _provider?: LiteLLMChatProvider,
@@ -105,22 +113,28 @@ export function registerShowModelsCommand(
             return;
         }
 
-        type ModelQuickPickItem = vscode.QuickPickItem & { modelId: string };
-
-        // Show a quick pick list with user-facing backend:model label.
-        // Copy the internal routable model id to the clipboard.
+        // Keep the picker to the requested two-line layout. The model group and
+        // friendly name are the primary label; the complete ID is the secondary
+        // description. Existing model tooltip data remains in `detail` so the
+        // picker can surface provider pricing and limits without rebuilding it.
         const picked = await vscode.window.showQuickPick(
             models
                 .slice()
                 .sort((a: vscode.LanguageModelChatInformation, b: vscode.LanguageModelChatInformation) =>
                     a.id.localeCompare(b.id)
                 )
-                .map((m) => ({
-                    label: m.name,
-                    description: m.name !== m.id ? m.name : undefined,
-                    detail: m.tooltip,
-                    modelId: m.id,
-                })) as ModelQuickPickItem[],
+                .map((m) => {
+                    const selectableModelId = toSelectableModelId(m.id);
+                    return {
+                        label: `${
+                            (m as vscode.LanguageModelChatInformation & { backendName?: string }).backendName ??
+                            "LiteLLM"
+                        } :: ${m.name}`,
+                        description: selectableModelId,
+                        detail: m.tooltip,
+                        modelId: selectableModelId,
+                    };
+                }) as ModelQuickPickItem[],
             {
                 title: "LiteLLM: Available Models",
                 placeHolder: "Select a model to copy its fully qualified id to the clipboard",

--- a/src/commands/manageConfig.ts
+++ b/src/commands/manageConfig.ts
@@ -100,7 +100,7 @@ export function registerShowModelsCommand(
         const models = provider.getLastKnownModels();
         if (!models.length) {
             vscode.window.showInformationMessage(
-                "No cached models yet. Run 'LiteLLM: Reload Models' (or open the provider settings) to fetch models from LiteLLM."
+                "No models are available yet. Configure a LiteLLM provider with 'LiteLLM: Manage Configuration', then run 'LiteLLM: Reload Models' before opening this picker."
             );
             return;
         }
@@ -122,8 +122,8 @@ export function registerShowModelsCommand(
                     modelId: m.id,
                 })) as ModelQuickPickItem[],
             {
-                title: "LiteLLM: Available Models (cached)",
-                placeHolder: "Select a model to copy its id to clipboard",
+                title: "LiteLLM: Available Models",
+                placeHolder: "Select a model to copy its fully qualified id to the clipboard",
                 matchOnDescription: true,
                 matchOnDetail: true,
             }
@@ -134,7 +134,7 @@ export function registerShowModelsCommand(
         }
 
         await vscode.env.clipboard.writeText(picked.modelId);
-        vscode.window.showInformationMessage(`Copied model id: ${picked.modelId}`);
+        vscode.window.showInformationMessage(`Copied fully qualified model id: ${picked.modelId}`);
     });
 }
 

--- a/src/commands/test/manageConfig.test.ts
+++ b/src/commands/test/manageConfig.test.ts
@@ -177,7 +177,12 @@ suite("Model Commands Unit Tests", () => {
                 {
                     id: "test-backend/azure_ai/gpt-5.6-mini",
                     name: "azure_ai/gpt-5.6-mini",
-                    tooltip: "Provider: azure_ai, Model: azure_ai/gpt-5.6-mini via Test Backend",
+                    tooltip: "$5.00/1M in · $15.00/1M out · Input limit: 128000 · Output limit: 4096",
+                    backendName: "Test Backend",
+                    inputCost: 5,
+                    outputCost: 15,
+                    maxInputTokens: 128000,
+                    maxOutputTokens: 4096,
                     isUserSelectable: true,
                 },
             ],
@@ -187,7 +192,7 @@ suite("Model Commands Unit Tests", () => {
         const quickPickStub = sandbox.stub(vscode.window, "showQuickPick");
         quickPickStub.resolves({
             label: "azure_ai/gpt-5.6-mini",
-            modelId: "test-backend/azure_ai/gpt-5.6-mini",
+            modelId: "litellm-connector/test-backend/azure_ai/gpt-5.6-mini",
         } as unknown as vscode.QuickPickItem);
 
         let handler: (() => Promise<void>) | undefined;
@@ -202,15 +207,20 @@ suite("Model Commands Unit Tests", () => {
         await handler?.();
 
         const quickPickItems = quickPickStub.firstCall.args[0] as vscode.QuickPickItem[];
-        assert.strictEqual(quickPickItems[0].label, "azure_ai/gpt-5.6-mini");
+        assert.strictEqual(quickPickItems[0].label, "Test Backend :: azure_ai/gpt-5.6-mini");
+        assert.strictEqual(quickPickItems[0].description, "litellm-connector/test-backend/azure_ai/gpt-5.6-mini");
+        assert.strictEqual(
+            quickPickItems[0].detail,
+            "$5.00/1M in · $15.00/1M out · Input limit: 128000 · Output limit: 4096"
+        );
         assert.strictEqual(
             (quickPickItems[0] as vscode.QuickPickItem & { modelId: string }).modelId,
-            "test-backend/azure_ai/gpt-5.6-mini"
+            "litellm-connector/test-backend/azure_ai/gpt-5.6-mini"
         );
         assert.strictEqual(infoStub.calledOnce, true);
         assert.ok(
             String(infoStub.firstCall.args[0]).includes(
-                "Copied fully qualified model id: test-backend/azure_ai/gpt-5.6-mini"
+                "Copied fully qualified model id: litellm-connector/test-backend/azure_ai/gpt-5.6-mini"
             ),
             "Information message should announce the copied fully qualified model id"
         );

--- a/src/commands/test/manageConfig.test.ts
+++ b/src/commands/test/manageConfig.test.ts
@@ -163,21 +163,21 @@ suite("Model Commands Unit Tests", () => {
         await handler?.();
 
         assert.strictEqual(infoStub.calledOnce, true);
-        assert.ok(String(infoStub.firstCall.args[0]).includes("No cached models"));
+        assert.ok(String(infoStub.firstCall.args[0]).includes("No models are available yet"));
     });
 
     test("showModels: quick pick copies model id", async () => {
         // The `vscode.env.clipboard.writeText` property is non-configurable in the
         // extension host test environment, so we cannot stub it directly. Instead we
-        // assert the user-visible side-effect: the "Copied model id:" information
+        // assert the user-visible side-effect: the "Copied fully qualified model id:" information
         // message includes the model id the user selected. The clipboard write itself
         // is exercised manually in development.
         const provider = {
             getLastKnownModels: () => [
                 {
-                    id: "backend/model",
-                    name: "backend/model",
-                    tooltip: "t",
+                    id: "test-backend/azure_ai/gpt-5.6-mini",
+                    name: "azure_ai/gpt-5.6-mini",
+                    tooltip: "Provider: azure_ai, Model: azure_ai/gpt-5.6-mini via Test Backend",
                     isUserSelectable: true,
                 },
             ],
@@ -185,7 +185,10 @@ suite("Model Commands Unit Tests", () => {
 
         const infoStub = sandbox.stub(vscode.window, "showInformationMessage");
         const quickPickStub = sandbox.stub(vscode.window, "showQuickPick");
-        quickPickStub.resolves({ modelId: "backend/model" } as unknown as vscode.QuickPickItem);
+        quickPickStub.resolves({
+            label: "azure_ai/gpt-5.6-mini",
+            modelId: "test-backend/azure_ai/gpt-5.6-mini",
+        } as unknown as vscode.QuickPickItem);
 
         let handler: (() => Promise<void>) | undefined;
         sandbox.stub(vscode.commands, "registerCommand").callsFake((id, cb) => {
@@ -198,10 +201,18 @@ suite("Model Commands Unit Tests", () => {
         registerShowModelsCommand(provider);
         await handler?.();
 
+        const quickPickItems = quickPickStub.firstCall.args[0] as vscode.QuickPickItem[];
+        assert.strictEqual(quickPickItems[0].label, "azure_ai/gpt-5.6-mini");
+        assert.strictEqual(
+            (quickPickItems[0] as vscode.QuickPickItem & { modelId: string }).modelId,
+            "test-backend/azure_ai/gpt-5.6-mini"
+        );
         assert.strictEqual(infoStub.calledOnce, true);
         assert.ok(
-            String(infoStub.firstCall.args[0]).includes("Copied model id: backend/model"),
-            "Information message should announce the copied model id"
+            String(infoStub.firstCall.args[0]).includes(
+                "Copied fully qualified model id: test-backend/azure_ai/gpt-5.6-mini"
+            ),
+            "Information message should announce the copied fully qualified model id"
         );
     });
 });

--- a/src/providers/base/callConfig.ts
+++ b/src/providers/base/callConfig.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+import type * as vscode from "vscode";
 import { Logger } from "../../utils/logger";
 import type { ConfigManager } from "../../config/configManager";
 import type { LiteLLMProviderRegistry } from "../liteLLMProviderRegistry";

--- a/src/providers/liteLLMProviderBase.ts
+++ b/src/providers/liteLLMProviderBase.ts
@@ -222,16 +222,14 @@ export abstract class LiteLLMProviderBase {
     }
 
     /**
-     * Returns an empty array.
+     * Returns a defensive copy of the latest successful discovery view for
+     * display-only commands such as "LiteLLM: Show Available Models".
      *
-     * Stateless design: there is no model-list cache. The last-known-models
-     * view is gone because there is no list to be "last known" — every
-     * discovery call is a fresh fetch. This method is retained for
-     * backward compatibility with the public API surface; callers that
-     * need a model list should trigger a discovery and use the result.
+     * This is not a request-routing cache. Response-time routing continues to
+     * resolve the backend through per-call configuration and registry.lookup().
      */
     public getLastKnownModels(): LanguageModelChatInformation[] {
-        return [];
+        return this._registry.getDisplayedModels();
     }
 
     /**

--- a/src/providers/liteLLMProviderRegistry.ts
+++ b/src/providers/liteLLMProviderRegistry.ts
@@ -803,6 +803,7 @@ export class LiteLLMProviderRegistry implements vscode.Disposable {
             id: modelId,
             name: modelName,
             vendor: modelInfo?.litellm_provider ?? "litellm",
+            backendName: detailBase,
             tooltip: `Provider: ${modelInfo?.litellm_provider ?? "litellm"}, Model: ${modelName} via ${detailBase}`,
             detail,
             description: modelInfo?.litellm_provider ?? "",
@@ -856,6 +857,13 @@ export class LiteLLMProviderRegistry implements vscode.Disposable {
             if (pricingTooltip) {
                 (info as { tooltip?: string }).tooltip = `${info.tooltip}\n${pricingTooltip}`;
             }
+
+            // Keep the picker row focused on identity. Pricing and exact token
+            // limits belong in the model tooltip/detail instead of being
+            // reformatted into the QuickPick's primary label.
+            (info as { tooltip?: string }).tooltip =
+                `${info.tooltip}\nLimits: input ${derived.maxInputTokens.toLocaleString()} tokens, ` +
+                `output ${derived.maxOutputTokens.toLocaleString()} tokens`;
         }
 
         return info;

--- a/src/providers/liteLLMProviderRegistry.ts
+++ b/src/providers/liteLLMProviderRegistry.ts
@@ -180,6 +180,13 @@ export class LiteLLMProviderRegistry implements vscode.Disposable {
     private readonly modelsByBackend = new Map<string, LanguageModelChatInformation[]>();
 
     /**
+     * Last successful discovery view used only by the explicit "Show Available Models"
+     * command. Request routing MUST continue to use `entries` and per-call configuration;
+     * this snapshot is only a convenience view for copying namespaced model IDs.
+     */
+    private displayedModels: LanguageModelChatInformation[] = [];
+
+    /**
      * Tracks parameters that were auto-stripped after a failed request so callers
      * can proactively omit them on subsequent calls. Single source of truth for
      * dynamically-learned parameter limits.
@@ -396,6 +403,23 @@ export class LiteLLMProviderRegistry implements vscode.Disposable {
     }
 
     /**
+     * Returns a defensive copy of the latest successful model discovery view.
+     * This is not a routing cache. Callers may use the IDs for display or copying,
+     * but response-time routing must continue through lookup().
+     */
+    public getDisplayedModels(): LanguageModelChatInformation[] {
+        return this.displayedModels.slice();
+    }
+
+    private mergeDisplayedModels(models: readonly LanguageModelChatInformation[]): void {
+        const byId = new Map(this.displayedModels.map((model) => [model.id, model]));
+        for (const model of models) {
+            byId.set(model.id, model);
+        }
+        this.displayedModels = [...byId.values()].sort((left, right) => left.id.localeCompare(right.id));
+    }
+
+    /**
      * Wipes every routing entry and every per-backend model list. Call on
      * user-initiated model reload so the next discovery pass starts from a
      * clean slate. Does NOT touch the per-model capability caches; call
@@ -404,6 +428,7 @@ export class LiteLLMProviderRegistry implements vscode.Disposable {
     public clear(): void {
         this.entries.clear();
         this.modelsByBackend.clear();
+        this.displayedModels = [];
         this.discoveryResponseCache.clear();
     }
 
@@ -557,6 +582,10 @@ export class LiteLLMProviderRegistry implements vscode.Disposable {
             );
             if (session.apiKey) {
                 this.setModelsForBackend(baseUrl, session.apiKey, routingIdentity, models);
+                // Keep the command-facing view synchronized with successful discovery without
+                // making it part of response-time routing. Merge because VS Code may discover
+                // multiple configured provider groups independently.
+                this.mergeDisplayedModels(models);
             } else {
                 Logger.trace(
                     `LiteLLMProviderRegistry.discoverModels: skipping registry write (no session/apiKey) baseUrl="${baseUrl}" modelCount=${models.length}`

--- a/src/providers/test/liteLLMProviderBase.test.ts
+++ b/src/providers/test/liteLLMProviderBase.test.ts
@@ -657,6 +657,32 @@ suite("LiteLLMProviderBase", () => {
             assert.strictEqual(models1[0].id, models2[0].id, "model id is stable across calls");
         });
 
+        test("exposes fully qualified ids from successful discovery to the model picker", async () => {
+            const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
+            const configManager = access(provider)._configManager;
+            const mockSession = makeMockSession();
+            const getModelInfo = mockSession.client.getModelInfo as sinon.SinonStub;
+            getModelInfo.resolves({
+                data: [
+                    {
+                        model_name: "azure_ai/gpt-5.6-mini",
+                        model_info: { litellm_provider: "azure" },
+                    },
+                ],
+            });
+            sandbox.stub(configManager, "convertProviderConfiguration").returns(mockSession);
+
+            await provider.discoverModels(
+                { silent: true, configuration: config },
+                new vscode.CancellationTokenSource().token
+            );
+
+            const displayedModels = provider.getLastKnownModels();
+            assert.strictEqual(displayedModels.length, 1);
+            assert.strictEqual(displayedModels[0].id, "localhost:4000/azure_ai/gpt-5.6-mini");
+            assert.strictEqual(displayedModels[0].name, "azure_ai/gpt-5.6-mini");
+        });
+
         test("attaches reasoning configuration schema when supported", async () => {
             const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
             const configManager = access(provider)._configManager;


### PR DESCRIPTION
## Change Log / Overview

### 🚀 Features
- Restores the `LiteLLM: Show Available Models` picker from successful per-group discovery snapshots.
- Displays models as `<group> :: <display name>` and copies the complete `litellm-connector/<group>/<model>` selector.
- Keeps pricing and exact token limits in model details instead of the primary picker identity.

### 🧪 Tests
- Adds regression coverage for discovery snapshots, readable picker fields, and selector-prefixed copied IDs.

### 📚 Documentation
- Updates `CHANGELOG.md`, `README.md`, and `README.marketplace.md` for v2.3.0.

### Related Issues, Builds, Pipeline Runs
- None specified.

### Pull Request Pre-check
- [x] Linting validation passed (`npm run lint`; existing warnings only)
- [x] Formatting validation passed (`npm run format`)
- [x] Unit testing passes (`npm run test:coverage`)
- [x] Documentation updated

Validation:
- `npm run compile` passed
- `npm run lint` passed with 31 existing warnings and 0 errors
- `npm run format` passed
- `npm run test:coverage` passed

Do not merge, tag, or publish from this branch. After squash-merging via the web UI, tag `rel/v2.3.0` on `main` to trigger the release pipeline.