### PR TITLE
🚀 Release v2.5.1 — configure inline completion endpoints

### DIFF
--- a/.github/prompts/finish-dev-version.prompt.md
+++ b/.github/prompts/finish-dev-version.prompt.md
@@ -18,7 +18,7 @@ Follow this workflow exactly:
 
 3. Promote the version.
    - Strip the `-devN` suffix by editing `package.json` directly (e.g. `2.3.0-dev4` → `2.3.0`). Do NOT run `npm run bump-version` — the base version was already chosen when the dev cycle started; this step only removes the pre-release suffix.
-   - Sync `package-lock.json`: update the top-level `version` and the `packages[""].version` fields to match.
+   - Do not modify or synchronize `package-lock.json`; lock files are generated on demand by npm and are not part of this workflow.
 
 4. Update [CHANGELOG.md](../../CHANGELOG.md).
    - Promote the `## [Unreleased]` section to `## [<version>] - <today's date>`.
@@ -38,7 +38,7 @@ Follow this workflow exactly:
    - `npm run test:coverage`
 
 7. Verify version consistency.
-   - `package.json`, `package-lock.json`, the CHANGELOG heading, and both README "What's New" headings must all show the same `<version>` with no `-devN` remnants anywhere. Search the repo for the old dev version string to be sure.
+   - Verify `package.json`, the CHANGELOG heading, and both README "What's New" headings show the same `<version>` with no `-devN` remnants anywhere. Do not require `package-lock.json` to match. Search the repo for the old dev version string to be sure.
 
 8. Commit and open the release PR.
    - Commit all release-prep changes with an emoji-prefixed, outcome-focused message (e.g. `🚀 Release v<version> — <short highlight>`), then push the branch.

--- a/.github/prompts/start-next-dev-version.prompt.md
+++ b/.github/prompts/start-next-dev-version.prompt.md
@@ -38,7 +38,7 @@ Follow this workflow exactly:
    - Run `npm run bump-version <variant> dev` (always include the trailing `dev` so the new cycle starts as a `-dev1` pre-release, unless the user explicitly asked for a non-dev version).
    - Note: the script is `bump-version` (hyphen), not `bump:version`.
    - Verify the new version in [package.json](../../package.json) matches the expected result and includes a `-devN` suffix when `dev` was requested.
-   - If `package-lock.json` did not update automatically, sync it by updating its top-level `version` fields to match.
+   - Do not modify or synchronize `package-lock.json`; lock files are generated on demand by npm and are not part of this workflow.
 
 6. Validate and summarize.
    - Confirm the branch name, old version, and new version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.5.1] - 2026-08-19
+
+### 🚀 Features
+
+* **🧩 Configure model-aware inline completion endpoints**: LiteLLM provider groups can now expose an optional OpenAI-compatible FIM endpoint, preserving configured paths such as `/v1`; discovered models publish the resolved endpoint for downstream VS Code inline-completion support. (`package.json`, `src/providers/liteLLMProviderRegistry.ts`)
+* **🎯 Support model-specific completion routing**: Model overrides can provide `completionsUrl`, taking precedence over the group endpoint before falling back to the configured LiteLLM group URL plus `/completions`. (`src/config/modelOverrides.ts`, `src/providers/base/completionsUrl.ts`)
+
+### 🧪 Tests
+
+* Added coverage for endpoint derivation, `/v1` path preservation, URL precedence, and invalid URL fallback. (`src/providers/base/completionsUrl.test.ts`)
+
+### 🧹 Chores
+
+* **🚀 Promote release version**: Promoted the package version to `2.5.1`. (`package.json`)
+
 ## [2.5.0] - 2026-08-19
 
 ### 🚀 Features
@@ -768,7 +783,7 @@ There have been a tremendous amount of backend work done with this update to mak
 
 ---
 
-[Unreleased]: https://github.com/gethnet/litellm-connector-copilot/compare/rel/v2.5.0...HEAD
+[Unreleased]: https://github.com/gethnet/litellm-connector-copilot/compare/rel/v2.5.1...HEAD
 [2.5.0]: https://github.com/gethnet/litellm-connector-copilot/releases/tag/rel/v2.5.0
 [2.3.0]: https://github.com/gethnet/litellm-connector-copilot/releases/tag/rel/v2.3.0
 [1.6.0]: https://github.com/gethnet/litellm-connector-copilot/releases/tag/rel/v1.6.0

--- a/README.marketplace.md
+++ b/README.marketplace.md
@@ -10,14 +10,13 @@ Bring **any LiteLLM-supported model** into the Copilot Chat model picker — Ope
 
 ---
 
-## 🆕 What's New in 2.5.0
+## 🆕 What's New in 2.5.1
 
-> Version 2.5.0 improves model identity and metadata in the VS Code picker and third-party LM consumers.
+> Version 2.5.1 prepares LiteLLM models for model-aware OpenAI-compatible inline completion routing.
 
-- 🔍 **Distinct model labels** — Third-party extensions can now distinguish models by backend and model name instead of showing duplicate provider labels.
-- 🔧 **Accurate group names** — User-defined provider-group names now flow through to discovered model metadata.
-- 🧭 **Richer picker context** — Model-picker metadata can show upstream provider and pricing information while preserving compact display behavior.
-- 🛠️ **Explicit capability configuration** — Administrators can provide tool-calling, image-input, and edit-tool hints when model cards are incomplete.
+- 🧩 **Configurable FIM endpoints** — Provider groups can expose full OpenAI-compatible inline completion endpoints while preserving paths such as `/v1`.
+- 🎯 **Model-specific routing** — Per-model `completionsUrl` overrides take priority over group-level configuration and derived LiteLLM endpoints.
+- 🧪 **Safer endpoint resolution** — Endpoint derivation, path preservation, precedence, and invalid URL fallback are covered by focused tests.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for previous release notes.
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@
 
 [![License](https://img.shields.io/github/license/gethnet/litellm-connector-copilot)](LICENSE)
 
-## 🆕 What's New in 2.5.0
+## 🆕 What's New in 2.5.1
 
-> Version 2.5.0 makes LiteLLM model metadata clearer and more useful across VS Code and third-party LM consumers.
+> Version 2.5.1 prepares LiteLLM models for model-aware OpenAI-compatible inline completion routing.
 
-- 🔍 **Distinguishable third-party display** — Models visible in third-party extensions (Cline, etc.) now render unique labels including both the configured backend name and model name instead of duplicate provider rows.
-- 🔧 **Group name propagation fix** — User-supplied group names from VS Code's group picker now correctly propagate to the model metadata.
-- 🧭 **Clearer model-picker metadata** — Picker information can identify the upstream provider and expose pricing details without obscuring the model's route.
-- 🛠️ **Explicit capability hints** — Model capability overrides support tool calling, image input, and explicitly configured edit-tool strategies.
+- 🧩 **Configurable FIM endpoints** — Provider groups can expose full OpenAI-compatible inline completion endpoints while preserving paths such as `/v1`.
+- 🎯 **Model-specific routing** — Per-model `completionsUrl` overrides take priority over group-level configuration and derived LiteLLM endpoints.
+- 🧪 **Safer endpoint resolution** — Endpoint derivation, path preservation, precedence, and invalid URL fallback are covered by focused tests.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for previous release notes.
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ The copied ID is the complete model ID shown by discovery, including the provide
 
 Base URL and API key are configured through **VS Code's Language Models provider-group UI**. Run **LiteLLM: Manage Configuration** or open Settings → Language Models.
 
+The optional **Inline Completions URL** is a full OpenAI-compatible FIM `/completions` endpoint. If omitted, the connector derives it by appending `/completions` to the configured provider-group URL: `/v1` is preserved when present and is not added when absent. A model-specific `completionsUrl` override takes precedence over the group value. Models without a resolved endpoint remain chat-only for inline suggestions.
+
 ### Workspace Settings
 
 | Setting | Type | Default | Description |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "litellm-connector-copilot",
 	"displayName": "LiteLLM Connector for Copilot",
-	"version": "2.5.1-dev1",
+	"version": "2.5.1",
 	"description": "An extension that integrates LiteLLM proxy into Copilot",
 	"categories": [
 		"AI",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "litellm-connector-copilot",
 	"displayName": "LiteLLM Connector for Copilot",
-	"version": "2.5.0",
+	"version": "2.5.1-dev1",
 	"description": "An extension that integrates LiteLLM proxy into Copilot",
 	"categories": [
 		"AI",
@@ -190,6 +190,11 @@
 								],
 								"description": "Override LiteLLM model_info.mode used for endpoint selection. Workspace forceResponsesEndpoint still forces chat → responses after overrides."
 							},
+							"completionsUrl": {
+								"type": "string",
+								"pattern": "^https?:\\/\\/.+",
+								"description": "Full OpenAI-compatible FIM endpoint for this model. Overrides the provider-group endpoint and is used verbatim."
+							},
 							"max_input_tokens": {
 								"type": "number",
 								"minimum": 1,
@@ -336,6 +341,13 @@
 							"description": "API key used to authenticate with the LiteLLM proxy.",
 							"secret": true,
 							"minLength": 1
+						},
+						"completionsUrl": {
+							"type": "string",
+							"title": "Inline Completions URL",
+							"description": "Optional full OpenAI-compatible FIM completions endpoint. When omitted, the provider URL with /completions appended is used.",
+							"pattern": "^https?:\\/\\/.+",
+							"group": "navigation"
 						}
 					},
 					"required": [

--- a/src/config/configManager.ts
+++ b/src/config/configManager.ts
@@ -5,6 +5,7 @@ import { LiteLLMClient } from "../adapters/litellmClient";
 import type { BackendSession } from "../providers/backendSession";
 import { Logger } from "../utils/logger";
 import { deriveGroupNameFromUrl } from "../utils";
+import { deriveCompletionsUrl } from "../providers/base/completionsUrl";
 
 const EDIT_TOOL_VALUES = new Set<VSCodeEditTool>(["find-replace", "multi-find-replace", "apply-patch", "code-rewrite"]);
 
@@ -299,6 +300,10 @@ export class ConfigManager {
     ): BackendSession | undefined {
         const baseUrl = typeof configuration.baseUrl === "string" ? configuration.baseUrl.trim() : "";
         const apiKey = typeof configuration.apiKey === "string" ? configuration.apiKey.trim() : "";
+        const completionsUrl =
+            typeof configuration.completionsUrl === "string"
+                ? configuration.completionsUrl.trim()
+                : deriveCompletionsUrl(baseUrl);
 
         if (!baseUrl || !/^https?:\/\//i.test(baseUrl)) {
             Logger.warn(
@@ -324,6 +329,7 @@ export class ConfigManager {
             backendName,
             baseUrl,
             apiKey,
+            ...(completionsUrl ? { completionsUrl } : {}),
             client: new LiteLLMClient({ url: baseUrl, key: apiKey }, userAgent),
         };
     }

--- a/src/config/modelOverrides.ts
+++ b/src/config/modelOverrides.ts
@@ -119,6 +119,12 @@ function isLiteLLMModelMode(value: unknown): value is LiteLLMModelMode {
     return value === "chat" || value === "responses" || value === "completions";
 }
 
+function toHttpUrl(value: unknown): string | undefined {
+    return typeof value === "string" && /^https?:\/\//i.test(value.trim())
+        ? value.trim().replace(/\/+$/, "")
+        : undefined;
+}
+
 /**
  * Accept only finite positive numbers for token-limit overrides.
  * Zero/negative/NaN values are rejected so bad settings cannot collapse budgets.
@@ -199,6 +205,7 @@ function validateOverride(entry: unknown, source: string): ModelOverride | undef
         supports_xhigh_reasoning_effort: candidate.supports_xhigh_reasoning_effort,
         supports_max_reasoning_effort: candidate.supports_max_reasoning_effort,
         mode,
+        completionsUrl: toHttpUrl(candidate.completionsUrl),
         max_input_tokens: maxInputTokens,
         max_output_tokens: maxOutputTokens,
         max_tokens: maxTokens,
@@ -329,7 +336,7 @@ export function applyModelInfoOverrides(
 
     const hasReasoningPatch = Object.keys(reasoningPatch).length > 0;
     const hasCardPatch = Object.keys(cardPatch).length > 0;
-    if (!hasReasoningPatch && !hasCardPatch && !hasSupportedParamsOverride) {
+    if (!hasReasoningPatch && !hasCardPatch && !hasSupportedParamsOverride && override.completionsUrl === undefined) {
         return modelInfo;
     }
 
@@ -340,6 +347,9 @@ export function applyModelInfoOverrides(
     };
     if (hasSupportedParamsOverride) {
         patched.supported_openai_params = override.supportedOpenaiParams;
+    }
+    if (override.completionsUrl !== undefined) {
+        patched.completionsUrl = override.completionsUrl;
     }
     return patched;
 }

--- a/src/providers/backendSession.ts
+++ b/src/providers/backendSession.ts
@@ -12,6 +12,8 @@ export interface BackendSession {
     readonly baseUrl: string;
     /** API key for authentication (undefined if not required) */
     readonly apiKey: string | undefined;
+    /** Optional full OpenAI-compatible FIM endpoint for this provider group. */
+    readonly completionsUrl?: string;
     /** HTTP client for making requests */
     readonly client: LiteLLMClient;
 }

--- a/src/providers/base/completionsUrl.test.ts
+++ b/src/providers/base/completionsUrl.test.ts
@@ -1,0 +1,36 @@
+import * as assert from "assert";
+import { deriveCompletionsUrl, resolveCompletionsUrl } from "./completionsUrl";
+
+suite("Completion URL resolution", () => {
+    test("preserves the configured group path when deriving the default endpoint", () => {
+        assert.strictEqual(deriveCompletionsUrl("https://llm.proxy.com/v1"), "https://llm.proxy.com/v1/completions");
+        assert.strictEqual(deriveCompletionsUrl("https://llm.proxy.com"), "https://llm.proxy.com/completions");
+    });
+
+    test("uses the highest-priority model URL before group and derived URLs", () => {
+        assert.strictEqual(
+            resolveCompletionsUrl(
+                "https://llm.proxy.com/v1",
+                "https://model.proxy.com/fim",
+                "https://group.proxy.com/fim"
+            ),
+            "https://model.proxy.com/fim"
+        );
+        assert.strictEqual(
+            resolveCompletionsUrl("https://llm.proxy.com/v1", undefined, "https://group.proxy.com/fim"),
+            "https://group.proxy.com/fim"
+        );
+        assert.strictEqual(
+            resolveCompletionsUrl("https://llm.proxy.com/v1", undefined, undefined),
+            "https://llm.proxy.com/v1/completions"
+        );
+    });
+
+    test("does not accept non-http completion URLs", () => {
+        assert.strictEqual(deriveCompletionsUrl("file:///tmp/litellm"), undefined);
+        assert.strictEqual(
+            resolveCompletionsUrl("https://llm.proxy.com", "file:///tmp/fim", undefined),
+            "https://llm.proxy.com/completions"
+        );
+    });
+});

--- a/src/providers/base/completionsUrl.ts
+++ b/src/providers/base/completionsUrl.ts
@@ -1,0 +1,37 @@
+const TERMINAL_COMPLETIONS_PATH = /\/completions\/?$/i;
+
+function normalizeUrl(value: string | undefined): string | undefined {
+    const trimmed = value?.trim() ?? "";
+    if (!/^https?:\/\//i.test(trimmed)) {
+        return undefined;
+    }
+
+    return trimmed.replace(/\/+$/, "");
+}
+
+/**
+ * Derives the OpenAI-compatible FIM endpoint from the configured LiteLLM group URL.
+ * The configured path is authoritative: `/v1` is preserved when supplied and is
+ * never inserted or removed by this helper.
+ */
+export function deriveCompletionsUrl(groupBaseUrl: string | undefined): string | undefined {
+    const normalized = normalizeUrl(groupBaseUrl);
+    if (!normalized) {
+        return undefined;
+    }
+
+    return TERMINAL_COMPLETIONS_PATH.test(normalized) ? normalized : `${normalized}/completions`;
+}
+
+/**
+ * Resolves model, group, and derived completion endpoints in upstream-compatible
+ * priority order. Invalid explicit URLs are ignored so a valid lower-priority
+ * endpoint can still advertise the model as inline-completion capable.
+ */
+export function resolveCompletionsUrl(
+    groupBaseUrl: string | undefined,
+    modelCompletionsUrl?: string,
+    groupCompletionsUrl?: string
+): string | undefined {
+    return normalizeUrl(modelCompletionsUrl) ?? normalizeUrl(groupCompletionsUrl) ?? deriveCompletionsUrl(groupBaseUrl);
+}

--- a/src/providers/liteLLMProviderRegistry.ts
+++ b/src/providers/liteLLMProviderRegistry.ts
@@ -88,6 +88,7 @@ import {
     formatPricingForDetail,
     formatPricingForTooltip,
 } from "../utils/pricingCalculator";
+import { resolveCompletionsUrl } from "./base/completionsUrl";
 
 /**
  * Cached result from a /model/info discovery call.
@@ -131,6 +132,7 @@ export interface RegistryEntry {
     readonly rawModelName: string;
     /** The routing identity (the part before the first `/` in the id). */
     readonly routingIdentity: string;
+    readonly completionsUrl?: string;
 }
 
 /**
@@ -498,11 +500,15 @@ export class LiteLLMProviderRegistry implements vscode.Disposable {
         );
         this.modelsByBackend.set(baseUrl, models);
         for (const model of models) {
+            const modelWithCompletionUrl = model as LanguageModelChatInformation & { completionsUrl?: string };
             this.entries.set(model.id, {
                 baseUrl,
                 apiKey,
                 rawModelName: this.extractRawName(model.id),
                 routingIdentity,
+                ...(modelWithCompletionUrl.completionsUrl
+                    ? { completionsUrl: modelWithCompletionUrl.completionsUrl }
+                    : {}),
             });
         }
         Logger.trace(
@@ -689,6 +695,7 @@ export class LiteLLMProviderRegistry implements vscode.Disposable {
                     { url: session.baseUrl, apiKey: session.apiKey },
                     displayLabel,
                     routingIdentity,
+                    session.completionsUrl,
                     config.forceResponsesEndpoint,
                     config.modelCapabilitiesOverrides,
                     config.displayPricingInPicker !== false
@@ -723,6 +730,7 @@ export class LiteLLMProviderRegistry implements vscode.Disposable {
         backend: { url?: string; apiKey?: string } | undefined,
         displayLabel: string,
         routingIdentity: string,
+        groupCompletionsUrl?: string,
         forceResponsesEndpoint?: boolean,
         modelCapabilitiesOverrides?: LiteLLMConfig["modelCapabilitiesOverrides"],
         displayPricingInPicker = true
@@ -771,7 +779,12 @@ export class LiteLLMProviderRegistry implements vscode.Disposable {
 
         const capabilityOverrides = modelCapabilitiesOverrides?.[modelId] ?? modelCapabilitiesOverrides?.[modelName];
         const capabilities = capabilitiesToVSCode(derived, capabilityOverrides);
-        const tags = getDerivedModelTags(modelId, derived, {}, capabilityOverrides);
+        const completionsUrl = resolveCompletionsUrl(
+            backend?.url,
+            modelInfo?.completionsUrl ?? modelInfo?.completions_url ?? activeModelOverride?.completionsUrl,
+            groupCompletionsUrl
+        );
+        const tags = getDerivedModelTags(modelId, derived, {}, capabilityOverrides, completionsUrl !== undefined);
         const supportedEfforts = getSupportedReasoningEfforts(modelInfo, modelId);
         const reasoningSchema = buildReasoningEffortConfigurationSchema(supportedEfforts, modelId, modelInfo);
 
@@ -853,6 +866,7 @@ export class LiteLLMProviderRegistry implements vscode.Disposable {
             tags,
             isUserSelectable: true,
             isBYOK: true,
+            ...(completionsUrl ? { completionsUrl } : {}),
             ...(statusIcon ? { statusIcon } : {}),
             ...(hasWarnings ? { warningText } : {}),
             infoText,

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,6 +161,8 @@ export interface ModelOverride {
      * Note: workspace `forceResponsesEndpoint` still forces chat → responses after overrides.
      */
     mode?: LiteLLMModelMode;
+    /** Full OpenAI-compatible FIM endpoint for inline completions. */
+    completionsUrl?: string;
     /**
      * Raw LiteLLM token-limit fields. Patched onto the model card before
      * `deriveCapabilitiesFromModelInfo` computes VS Code maxInput/maxOutput.
@@ -306,6 +308,9 @@ export interface LiteLLMModelInfo {
     blocked?: boolean;
     litellm_provider?: string;
     mode?: string;
+    /** Optional model-specific OpenAI-compatible FIM endpoint. */
+    completionsUrl?: string;
+    completions_url?: string;
     supports_system_messages?: boolean | null;
     supports_response_schema?: boolean;
     supports_vision?: boolean;

--- a/src/utils/modelCapabilities.ts
+++ b/src/utils/modelCapabilities.ts
@@ -124,7 +124,8 @@ export function getModelTags(
     modelId: string,
     derived: DerivedModelCapabilities,
     overrides?: Record<string, string[]>,
-    capabilityOverrides?: ModelCapabilityOverride
+    capabilityOverrides?: ModelCapabilityOverride,
+    hasCompletionsEndpoint = true
 ): string[] {
     const tags = new Set<string>();
 
@@ -155,7 +156,10 @@ export function getModelTags(
         tags.add("pdf");
     }
 
-    if (derived.supportsStreaming) {
+    // Preserve the utility's historical default for callers that only derive
+    // model tags. Provider discovery passes `false` explicitly when a model
+    // lacks an OpenAI-compatible FIM endpoint.
+    if (derived.supportsStreaming && hasCompletionsEndpoint !== false) {
         tags.add("inline-completions");
         tags.add("terminal-chat");
     }


### PR DESCRIPTION
## Change Log / Overview

### 🚀 Features
- Add optional provider-group `completionsUrl` configuration for OpenAI-compatible FIM endpoints.
- Preserve configured LiteLLM paths such as `/v1` when deriving `/completions`.
- Support model-level `completionsUrl` overrides with model → group → derived endpoint precedence.
- Publish resolved endpoint metadata for downstream VS Code inline-completion support.

### 🧪 Tests
- Add endpoint derivation, path preservation, precedence, and invalid URL fallback coverage.

### 📚 Documentation
- Update `README.md`, `README.marketplace.md`, and `CHANGELOG.md` for v2.5.1.

### Related Issues
- #130

### Pull Request Pre-check
- [x] Linting Validation Passed (`npm run lint`; existing warnings only)
- [x] Formatting Validation Passed (`npm run format`)
- [x] Unit Testing Passes (`npm run test:coverage`)
- [x] Documentation Updated
- [x] Compile Validation Passed (`npm run compile`)

> Note: Inline completion behavior still depends on upstream VS Code/Copilot support for contributed-provider `completionsUrl` consumption.
