### PR TITLE
🚀 Release v2.5.2 — stabilize reasoning continuity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ All notable changes to this project will be documented in this file.
 ### 🐛 Fixes
 
 * **🧼 Keep native model rows price-free**: Removed inline pricing from the VS Code model dropdown while retaining pricing in picker details, hovers, cost metadata, and extension-owned model pickers. (`src/providers/liteLLMProviderRegistry.ts`)
+* **🧠 Fix thinking-block replay across model switches**: Switching models mid-session no longer hard-fails when the previous model's reasoning continuity is replayed. Serialized thinking blocks were missing Anthropic's required `type` discriminant and, for the real streaming shape, could emit a signature with no `thinking` text — either defect made the next model reject the whole turn. Blocks are now always complete wire objects. (`src/types.ts`, `src/utils.ts`)
+* **🔗 Recombine split streaming reasoning**: LiteLLM's chat endpoint streams visible reasoning text and its signature as separate parts. Message normalization now pairs adjacent thinking text with the signature that follows it, producing one complete `{ type, thinking, signature }` block. Pairing is strictly adjacent — any text, data, tool-call, or tool-result part clears unpaired text so a later signature cannot bind to the wrong block. Orphaned signatures are omitted instead of serialized invalidly. (`src/utils.ts`)
+* **♻️ Recover once from continuity rejection**: A recognized HTTP 400 that specifically rejects prior-turn continuity now triggers exactly one retry with message-level `thinking_blocks` removed. Valid continuity is always attempted first — nothing is stripped based on model names or capability guesses. Authentication, authorization, quota, cancellation, context overflow, 5xx, and network failures are excluded so the retry cannot mask unrelated errors. (`src/providers/base/thinkingBlockRetry.ts`, `src/providers/liteLLMProviderBase.ts`)
+* **🔒 Keep redaction durable across overflow rebuilds**: Context-overflow retries rebuild the request from the original VS Code history, which previously restored continuity that had just been rejected. The rebuilt request now re-strips continuity when a redaction is already in effect. (`src/providers/liteLLMProviderBase.ts`)
+* **🎚️ Keep adaptive reasoning fields coherent**: During reasoning-effort fallback, `reasoning_effort` and `output_config.effort` now stay synchronized, and adaptive `thinking`/`output_config` are dropped together when effort becomes absent or `none`. Adaptive fields are never created on a non-adaptive request. (`src/providers/liteLLMProviderBase.ts`)
+
+### 🛡️ Preserved behavior
+
+* Continuity redaction removes only message-level `thinking_blocks`; top-level `reasoning_effort`, adaptive `thinking`, `output_config`, tools, `stream_options`, and `extra_body` are retained. Responses-routed requests keep endpoint-native `reasoning: { effort }`, and the existing `/responses` → `/chat/completions` fallback routing and retry count are unchanged. (`src/adapters/responsesAdapter.ts`, `src/providers/base/transport.ts`)
+
+### 🧪 Tests
+
+* Added regression coverage for complete block serialization, streamed text/signature recombination, adjacency boundaries, and orphan omission. (`src/utils/test/messageNormalization.test.ts`)
+* Added unit coverage for continuity detection, redaction immutability, and narrow HTTP 400 error classification. (`src/providers/base/test/thinkingBlockRetry.test.ts`)
+* Added live-path coverage for the one-shot continuity retry, unrelated-failure exclusion, composed include-usage + continuity retries, overflow persistence, adaptive effort synchronization, and an end-to-end stream-to-model-switch round trip using the real stream interpreter. (`src/providers/test/liteLLMProviderBase.test.ts`)
+* Added coverage proving the configured endpoint fallback preserves native reasoning and continuity across both attempts. (`src/providers/base/test/transport.fallback.test.ts`)
+
+### 🧹 Chores
+
+* **🧯 Tighten thinking-block typing**: `OpenAIThinkingBlock` is now a discriminated union, making a type-less or signature-only normal block unrepresentable. The Responses adapter narrows by `type` instead of optional-field casts, with identical emitted wire behavior. (`src/types.ts`, `src/adapters/responsesAdapter.ts`)
 
 ## [2.5.1] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.5.2] - 2026-08-21
+
 ### 🐛 Fixes
 
 * **🧼 Keep native model rows price-free**: Removed inline pricing from the VS Code model dropdown while retaining pricing in picker details, hovers, cost metadata, and extension-owned model pickers. (`src/providers/liteLLMProviderRegistry.ts`)
@@ -27,6 +29,8 @@ All notable changes to this project will be documented in this file.
 ### 🧹 Chores
 
 * **🧯 Tighten thinking-block typing**: `OpenAIThinkingBlock` is now a discriminated union, making a type-less or signature-only normal block unrepresentable. The Responses adapter narrows by `type` instead of optional-field casts, with identical emitted wire behavior. (`src/types.ts`, `src/adapters/responsesAdapter.ts`)
+
+* **🚀 Promote release version**: Promoted the package version to `2.5.2`. (`package.json`)
 
 ## [2.5.1] - 2026-08-19
 
@@ -807,7 +811,8 @@ There have been a tremendous amount of backend work done with this update to mak
 
 ---
 
-[Unreleased]: https://github.com/gethnet/litellm-connector-copilot/compare/rel/v2.5.1...HEAD
+[Unreleased]: https://github.com/gethnet/litellm-connector-copilot/compare/rel/v2.5.2...HEAD
+[2.5.2]: https://github.com/gethnet/litellm-connector-copilot/releases/tag/rel/v2.5.2
 [2.5.0]: https://github.com/gethnet/litellm-connector-copilot/releases/tag/rel/v2.5.0
 [2.3.0]: https://github.com/gethnet/litellm-connector-copilot/releases/tag/rel/v2.3.0
 [1.6.0]: https://github.com/gethnet/litellm-connector-copilot/releases/tag/rel/v1.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### 🐛 Fixes
+
+* **🧼 Keep native model rows price-free**: Removed inline pricing from the VS Code model dropdown while retaining pricing in picker details, hovers, cost metadata, and extension-owned model pickers. (`src/providers/liteLLMProviderRegistry.ts`)
+
 ## [2.5.1] - 2026-08-19
 
 ### 🚀 Features

--- a/README.marketplace.md
+++ b/README.marketplace.md
@@ -10,13 +10,14 @@ Bring **any LiteLLM-supported model** into the Copilot Chat model picker — Ope
 
 ---
 
-## 🆕 What's New in 2.5.1
+## 🆕 What's New in 2.5.2
 
-> Version 2.5.1 prepares LiteLLM models for model-aware OpenAI-compatible inline completion routing.
+> Version 2.5.2 makes reasoning continuity reliable when streaming and switching models.
 
-- 🧩 **Configurable FIM endpoints** — Provider groups can expose full OpenAI-compatible inline completion endpoints while preserving paths such as `/v1`.
-- 🎯 **Model-specific routing** — Per-model `completionsUrl` overrides take priority over group-level configuration and derived LiteLLM endpoints.
-- 🧪 **Safer endpoint resolution** — Endpoint derivation, path preservation, precedence, and invalid URL fallback are covered by focused tests.
+- 🧠 **Reliable model switching** — Thinking blocks are serialized completely and replay safely across model changes.
+- ♻️ **Resilient continuity recovery** — A narrowly classified continuity rejection retries once without invalid prior-turn thinking blocks.
+- 🎚️ **Consistent adaptive reasoning** — Reasoning effort and provider-specific adaptive fields remain synchronized during fallback.
+- 🧼 **Cleaner native model rows** — Pricing stays available in details and metadata without cluttering the VS Code model dropdown.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for previous release notes.
 

--- a/README.marketplace.md
+++ b/README.marketplace.md
@@ -150,7 +150,7 @@ Base URL + API key are configured through **VS Code's Language Models UI** (run 
 | `inactivityTimeout` | `60` | Seconds before stream is considered idle |
 | `disableCaching` | `false` | When enabled, bypass LiteLLM caching for models that advertise support for the `cache` parameter |
 | `enableModelOverrides` | `false` | Enable model-card override rules |
-| `displayPricingInPicker` | `true` | Show model pricing in picker |
+| `displayPricingInPicker` | `true` | Show model pricing in picker details, hovers, and cost metadata; native model-name rows remain price-free |
 | `discoveryTimeoutMs` | `5000` | Timeout (ms) for model discovery |
 | `discoveryCacheTtlMs` | `60000` | Cache TTL (ms), 0 to disable |
 | `discoveryFireDebounceMs` | `250` | Debounce (ms) for change notifications |

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@
 
 [![License](https://img.shields.io/github/license/gethnet/litellm-connector-copilot)](LICENSE)
 
-## 🆕 What's New in 2.5.1
+## 🆕 What's New in 2.5.2
 
-> Version 2.5.1 prepares LiteLLM models for model-aware OpenAI-compatible inline completion routing.
+> Version 2.5.2 makes reasoning continuity reliable when streaming and switching models.
 
-- 🧩 **Configurable FIM endpoints** — Provider groups can expose full OpenAI-compatible inline completion endpoints while preserving paths such as `/v1`.
-- 🎯 **Model-specific routing** — Per-model `completionsUrl` overrides take priority over group-level configuration and derived LiteLLM endpoints.
-- 🧪 **Safer endpoint resolution** — Endpoint derivation, path preservation, precedence, and invalid URL fallback are covered by focused tests.
+- 🧠 **Reliable model switching** — Thinking blocks are serialized completely and replay safely across model changes.
+- ♻️ **Resilient continuity recovery** — A narrowly classified continuity rejection retries once without invalid prior-turn thinking blocks.
+- 🎚️ **Consistent adaptive reasoning** — Reasoning effort and provider-specific adaptive fields remain synchronized during fallback.
+- 🧼 **Cleaner native model rows** — Pricing stays available in details and metadata without cluttering the VS Code model dropdown.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for previous release notes.
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ The optional **Inline Completions URL** is a full OpenAI-compatible FIM `/comple
 | `litellm-connector.enableModelOverrides` | boolean | `false` | Master toggle for user and bundled model-card overrides |
 | `litellm-connector.modelOverrides` | array | `[]` | User-supplied regex-based field overrides; only explicitly defined fields replace LiteLLM data |
 | `litellm-connector.modelCapabilitiesOverrides` | object | `{}` | Enable `toolCalling`, `imageInput`, and explicit edit-tool hints for a model |
-| `litellm-connector.displayPricingInPicker` | boolean | `true` | Show model pricing in the model picker |
+| `litellm-connector.displayPricingInPicker` | boolean | `true` | Show model pricing in picker details, hovers, and cost metadata; native model-name rows remain price-free |
 | `litellm-connector.discoveryTimeoutMs` | number | `5000` | Timeout (ms) for `/model/info` discovery requests |
 | `litellm-connector.discoveryCacheTtlMs` | number | `60000` | TTL (ms) for cached discovery responses. Set 0 to disable |
 | `litellm-connector.discoveryFireDebounceMs` | number | `250` | Debounce window (ms) for model-change notifications |
@@ -215,9 +215,9 @@ The optional **Inline Completions URL** is a full OpenAI-compatible FIM `/comple
 
 ### Model-picker metadata
 
-The extension preserves its existing picker density rules: with multiple configured LiteLLM backends, the pinned model picker remains compact; with one backend, the picker can show fuller backend and pricing context. Pricing continues to use per-million-token values rounded to two decimal places, such as `$1.00`.
+The native VS Code model dropdown keeps each row focused on model identity: it does not show pricing inline with the model name. When `displayPricingInPicker` is enabled, prices remain available in native picker hovers and cost metadata, as well as the details of the extension-owned **LiteLLM: Show Available Models** and commit-model pickers. Pricing uses per-million-token values rounded to two decimal places, such as `$1.00`.
 
-The picker shows neutral route information through `infoText`, using the model's reported `provider` when available, then `litellm_provider`, and finally `litellm`. When `/model/info` supplies input or output pricing, the extension emits VS Code's numeric cost multiplier alongside its existing pricing fields.
+The picker shows neutral route information through `infoText`, using the model's reported `provider` when available, then `litellm_provider`, and finally `litellm`. When `/model/info` supplies input or output pricing, the extension emits VS Code's numeric cost multiplier and cost-category metadata without assigning the native inline pricing label.
 
 `warningText` is intentionally conditional. It appears only when a configured model override is active or when LiteLLM reports `blocked: true` for the model. Ordinary models do not receive a warning banner. A blocked model also receives a blocked status icon when supported by the host.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "litellm-connector-copilot",
 	"displayName": "LiteLLM Connector for Copilot",
-	"version": "2.5.1",
+	"version": "2.5.2-dev1",
 	"description": "An extension that integrates LiteLLM proxy into Copilot",
 	"categories": [
 		"AI",
@@ -276,7 +276,7 @@
 				"litellm-connector.displayPricingInPicker": {
 					"type": "boolean",
 					"default": true,
-					"description": "Show model pricing in the model picker when available."
+					"description": "Show model pricing in picker details, hovers, and cost metadata when available; prices are not shown inline with native model names."
 				},
 				"litellm-connector.discoveryTimeoutMs": {
 					"type": "number",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "litellm-connector-copilot",
 	"displayName": "LiteLLM Connector for Copilot",
-	"version": "2.5.2-dev3",
+	"version": "2.5.2-dev4",
 	"description": "An extension that integrates LiteLLM proxy into Copilot",
 	"categories": [
 		"AI",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "litellm-connector-copilot",
 	"displayName": "LiteLLM Connector for Copilot",
-	"version": "2.5.2-dev1",
+	"version": "2.5.2-dev3",
 	"description": "An extension that integrates LiteLLM proxy into Copilot",
 	"categories": [
 		"AI",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "litellm-connector-copilot",
 	"displayName": "LiteLLM Connector for Copilot",
-	"version": "2.5.2-dev4",
+	"version": "2.5.2-dev5",
 	"description": "An extension that integrates LiteLLM proxy into Copilot",
 	"categories": [
 		"AI",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "litellm-connector-copilot",
 	"displayName": "LiteLLM Connector for Copilot",
-	"version": "2.5.2-dev5",
+	"version": "2.5.2",
 	"description": "An extension that integrates LiteLLM proxy into Copilot",
 	"categories": [
 		"AI",

--- a/src/adapters/responsesAdapter.ts
+++ b/src/adapters/responsesAdapter.ts
@@ -8,6 +8,13 @@ import type {
 import { normalizeToolCallId } from "../utils";
 import { Logger } from "../utils/logger";
 
+function getResponsesReasoningEffort(effort: OpenAIChatCompletionRequest["reasoning_effort"]): string | undefined {
+    if (typeof effort === "string") {
+        return effort === "none" ? undefined : effort;
+    }
+    return effort?.effort === "none" ? undefined : effort?.effort;
+}
+
 /**
  * Transform a chat/completions request body to the responses API format.
  * The responses API uses "input" (array format) instead of "messages".
@@ -248,10 +255,17 @@ export function transformToResponsesFormat(requestBody: OpenAIChatCompletionRequ
         frequency_penalty: requestBody.frequency_penalty,
         presence_penalty: requestBody.presence_penalty,
         stop: requestBody.stop,
-        // LiteLLM /responses also accepts the flat `reasoning_effort` key. We pass it
-        // through unchanged so reasoning effort works identically across endpoints
-        // and the connector keeps a single canonical request shape.
+        // Preserve the flat compatibility field while also using the endpoint-native
+        // shape. Explicit Claude adaptive fields take precedence over `reasoning`.
         reasoning_effort: requestBody.reasoning_effort,
+        reasoning: requestBody.thinking
+            ? undefined
+            : (() => {
+                  const effort = getResponsesReasoningEffort(requestBody.reasoning_effort);
+                  return effort ? { effort } : undefined;
+              })(),
+        thinking: requestBody.thinking,
+        output_config: requestBody.output_config,
         stream_options: requestBody.stream_options,
         extra_body: requestBody.extra_body,
     };

--- a/src/adapters/responsesAdapter.ts
+++ b/src/adapters/responsesAdapter.ts
@@ -118,49 +118,33 @@ export function transformToResponsesFormat(requestBody: OpenAIChatCompletionRequ
                     }
                 }
             }
-            if ((msg as { thinking_blocks?: unknown[] }).thinking_blocks) {
-                const thinkingBlocks = (
-                    msg as {
-                        thinking_blocks?: {
-                            type?: string;
-                            thinking?: string;
-                            signature?: string;
-                            data?: string;
-                        }[];
-                    }
-                ).thinking_blocks;
-                if (Array.isArray(thinkingBlocks)) {
-                    for (const block of thinkingBlocks) {
-                        if (block && typeof block === "object") {
-                            if (typeof block.signature === "string") {
-                                // Emit a `reasoning` input item carrying the thinking text
-                                // (or empty string for redacted blocks) and the encrypted
-                                // signature. Anthropic uses the signature to verify the
-                                // thinking block was actually produced by the model.
-                                const thinkingText = typeof block.thinking === "string" ? block.thinking : "";
-                                inputArray.push({
-                                    type: "reasoning",
-                                    id: `reasoning_${inputArray.length}`,
-                                    summary: thinkingText ? [{ type: "summary_text", text: thinkingText }] : [],
-                                    encrypted_content: block.signature,
-                                } as unknown as LiteLLMResponseInputItem);
-                                Logger.trace(
-                                    `[responsesAdapter] Preserving thinking_block (${thinkingText.length} chars, sig ${block.signature.length} bytes)`
-                                );
-                            } else if (typeof block.data === "string") {
-                                // redacted_thinking block: opaque data, no text. The API
-                                // still requires it to be passed back unchanged.
-                                inputArray.push({
-                                    type: "reasoning",
-                                    id: `reasoning_${inputArray.length}`,
-                                    summary: [],
-                                    encrypted_content: block.data,
-                                } as unknown as LiteLLMResponseInputItem);
-                                Logger.trace(
-                                    `[responsesAdapter] Preserving redacted_thinking block (${block.data.length} bytes)`
-                                );
-                            }
-                        }
+            if (Array.isArray(msg.thinking_blocks)) {
+                for (const block of msg.thinking_blocks) {
+                    if (block.type === "thinking") {
+                        // Emit a `reasoning` input item carrying the visible thinking summary
+                        // and the encrypted signature. Anthropic uses the signature to verify
+                        // the thinking block was actually produced by the model.
+                        inputArray.push({
+                            type: "reasoning",
+                            id: `reasoning_${inputArray.length}`,
+                            summary: [{ type: "summary_text", text: block.thinking }],
+                            encrypted_content: block.signature,
+                        } as unknown as LiteLLMResponseInputItem);
+                        Logger.trace(
+                            `[responsesAdapter] Preserving thinking_block (${block.thinking.length} chars, sig ${block.signature.length} bytes)`
+                        );
+                    } else {
+                        // redacted_thinking block: opaque data, no text. The API still
+                        // requires it to be passed back unchanged.
+                        inputArray.push({
+                            type: "reasoning",
+                            id: `reasoning_${inputArray.length}`,
+                            summary: [],
+                            encrypted_content: block.data,
+                        } as unknown as LiteLLMResponseInputItem);
+                        Logger.trace(
+                            `[responsesAdapter] Preserving redacted_thinking block (${block.data.length} bytes)`
+                        );
                     }
                 }
             }

--- a/src/adapters/streaming/liteLLMStreamInterpreter.ts
+++ b/src/adapters/streaming/liteLLMStreamInterpreter.ts
@@ -362,6 +362,37 @@ export function interpretStreamEvent(json: unknown, state: StreamingState): Emit
             });
         }
 
+        // LiteLLM's chat endpoint sends visible Anthropic thinking through
+        // reasoning_content and the continuity metadata through thinking_blocks.
+        // Emit metadata-only parts here so the visible text is not duplicated.
+        if (Array.isArray(delta?.thinking_blocks)) {
+            for (const rawBlock of delta.thinking_blocks) {
+                if (!rawBlock || typeof rawBlock !== "object") {
+                    continue;
+                }
+                const block = rawBlock as { type?: unknown; signature?: unknown; data?: unknown };
+                if (block.type === "redacted_thinking" && typeof block.data === "string" && block.data.length > 0) {
+                    thinkingParts.push({
+                        type: "thinking",
+                        value: "",
+                        metadata: { redactedData: block.data, display: "omitted" },
+                    });
+                    StructuredLogger.trace("stream.chat_redacted_thinking_block", {
+                        dataLength: block.data.length,
+                    });
+                } else if (typeof block.signature === "string" && block.signature.length > 0) {
+                    thinkingParts.push({
+                        type: "thinking",
+                        value: "",
+                        metadata: { signature: block.signature },
+                    });
+                    StructuredLogger.trace("stream.chat_thinking_block_signature", {
+                        signatureLength: block.signature.length,
+                    });
+                }
+            }
+        }
+
         const deltaContent = typeof delta?.content === "string" && delta.content ? delta.content : undefined;
         const contentForParsing = mergeReasoningIntoContent
             ? `${reasoningContent ?? ""}${deltaContent ?? ""}`

--- a/src/adapters/streaming/test/liteLLMStreamInterpreter.test.ts
+++ b/src/adapters/streaming/test/liteLLMStreamInterpreter.test.ts
@@ -200,6 +200,88 @@ suite("LiteLLMStreamInterpreter - Tool Call Regressions", () => {
         }
     });
 
+    test("emits signature metadata from chat delta thinking_blocks without duplicating text", () => {
+        const state = createInitialStreamingState();
+
+        const parts = interpretStreamEvent(
+            {
+                choices: [
+                    {
+                        delta: {
+                            reasoning_content: "visible thought",
+                            thinking_blocks: [
+                                {
+                                    type: "thinking",
+                                    thinking: "visible thought",
+                                    signature: "sig-abc123",
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+            state
+        );
+
+        const thinkingParts = parts.filter((p) => p.type === "thinking");
+        assert.strictEqual(thinkingParts.length, 2);
+        const textPart = thinkingParts.find((p) => p.type === "thinking" && p.value === "visible thought");
+        const sigPart = thinkingParts.find((p) => p.type === "thinking" && p.metadata?.signature === "sig-abc123");
+        assert.ok(textPart, "expected visible thinking text part");
+        assert.ok(sigPart, "expected signature-bearing thinking part");
+        if (sigPart && sigPart.type === "thinking") {
+            assert.strictEqual(sigPart.value, "", "signature part must not repeat visible text");
+        }
+    });
+
+    test("emits redacted thinking_blocks from chat deltas as opaque redactedData metadata", () => {
+        const state = createInitialStreamingState();
+
+        const parts = interpretStreamEvent(
+            {
+                choices: [
+                    {
+                        delta: {
+                            thinking_blocks: [{ type: "redacted_thinking", data: "opaque-blob-xyz" }],
+                        },
+                    },
+                ],
+            },
+            state
+        );
+
+        const thinking = parts.find((p) => p.type === "thinking");
+        assert.ok(thinking, "expected a thinking part for the redacted block");
+        if (thinking && thinking.type === "thinking") {
+            assert.strictEqual(thinking.value, "");
+            assert.strictEqual(thinking.metadata?.redactedData, "opaque-blob-xyz");
+            assert.strictEqual(thinking.metadata?.display, "omitted");
+        }
+    });
+
+    test("ignores malformed thinking_blocks entries in chat deltas", () => {
+        const state = createInitialStreamingState();
+
+        const parts = interpretStreamEvent(
+            {
+                choices: [
+                    {
+                        delta: {
+                            thinking_blocks: [null, 42, { type: "thinking" }, { type: "thinking", signature: "" }],
+                        },
+                    },
+                ],
+            },
+            state
+        );
+
+        assert.strictEqual(
+            parts.filter((p) => p.type === "thinking").length,
+            0,
+            "entries without a non-empty signature or data must be skipped"
+        );
+    });
+
     test("should flush /responses tool calls on output_item.done when no completed frame", () => {
         const state = createInitialStreamingState();
 

--- a/src/adapters/streaming/test/vscodePartEmitter.test.ts
+++ b/src/adapters/streaming/test/vscodePartEmitter.test.ts
@@ -215,44 +215,26 @@ suite("vscodePartEmitter", () => {
     });
 
     test("falls back to *-wrapped text when LanguageModelThinkingPart is unavailable", () => {
-        const vscodeMutable = vscode as unknown as Record<string, unknown>;
-        const original = vscodeMutable.LanguageModelThinkingPart;
-        delete vscodeMutable.LanguageModelThinkingPart;
-        try {
-            const reported: vscode.LanguageModelResponsePart[] = [];
-            const progress = {
-                report: (part: vscode.LanguageModelResponsePart) => reported.push(part),
-            } as vscode.Progress<vscode.LanguageModelResponsePart>;
+        const reported: vscode.LanguageModelResponsePart[] = [];
+        const progress = {
+            report: (part: vscode.LanguageModelResponsePart) => reported.push(part),
+        } as vscode.Progress<vscode.LanguageModelResponsePart>;
 
-            emitV2PartsToVSCode([{ type: "thinking", value: "hidden reasoning" }], progress);
+        emitV2PartsToVSCode([{ type: "thinking", value: "hidden reasoning" }], progress, null);
 
-            assert.strictEqual(reported.length, 1, "thinking must not be silently dropped");
-            assert.ok(reported[0] instanceof vscode.LanguageModelTextPart);
-            assert.strictEqual((reported[0] as vscode.LanguageModelTextPart).value, "*hidden reasoning*");
-        } finally {
-            if (original !== undefined) {
-                vscodeMutable.LanguageModelThinkingPart = original;
-            }
-        }
+        assert.strictEqual(reported.length, 1, "thinking must not be silently dropped");
+        assert.ok(reported[0] instanceof vscode.LanguageModelTextPart);
+        assert.strictEqual((reported[0] as vscode.LanguageModelTextPart).value, "*hidden reasoning*");
     });
 
     test("skips fallback emission for metadata-only thinking parts when ThinkingPart is unavailable", () => {
-        const vscodeMutable = vscode as unknown as Record<string, unknown>;
-        const original = vscodeMutable.LanguageModelThinkingPart;
-        delete vscodeMutable.LanguageModelThinkingPart;
-        try {
-            const reported: vscode.LanguageModelResponsePart[] = [];
-            const progress = {
-                report: (part: vscode.LanguageModelResponsePart) => reported.push(part),
-            } as vscode.Progress<vscode.LanguageModelResponsePart>;
+        const reported: vscode.LanguageModelResponsePart[] = [];
+        const progress = {
+            report: (part: vscode.LanguageModelResponsePart) => reported.push(part),
+        } as vscode.Progress<vscode.LanguageModelResponsePart>;
 
-            emitV2PartsToVSCode([{ type: "thinking", value: "", metadata: { signature: "sig" } }], progress);
+        emitV2PartsToVSCode([{ type: "thinking", value: "", metadata: { signature: "sig" } }], progress, null);
 
-            assert.strictEqual(reported.length, 0, "empty-value signature parts have no text to fall back to");
-        } finally {
-            if (original !== undefined) {
-                vscodeMutable.LanguageModelThinkingPart = original;
-            }
-        }
+        assert.strictEqual(reported.length, 0, "empty-value signature parts have no text to fall back to");
     });
 });

--- a/src/adapters/streaming/test/vscodePartEmitter.test.ts
+++ b/src/adapters/streaming/test/vscodePartEmitter.test.ts
@@ -213,4 +213,46 @@ suite("vscodePartEmitter", () => {
         assert.strictEqual(part.id, "thought-1");
         assert.deepStrictEqual(part.metadata, metadata);
     });
+
+    test("falls back to *-wrapped text when LanguageModelThinkingPart is unavailable", () => {
+        const vscodeMutable = vscode as unknown as Record<string, unknown>;
+        const original = vscodeMutable.LanguageModelThinkingPart;
+        delete vscodeMutable.LanguageModelThinkingPart;
+        try {
+            const reported: vscode.LanguageModelResponsePart[] = [];
+            const progress = {
+                report: (part: vscode.LanguageModelResponsePart) => reported.push(part),
+            } as vscode.Progress<vscode.LanguageModelResponsePart>;
+
+            emitV2PartsToVSCode([{ type: "thinking", value: "hidden reasoning" }], progress);
+
+            assert.strictEqual(reported.length, 1, "thinking must not be silently dropped");
+            assert.ok(reported[0] instanceof vscode.LanguageModelTextPart);
+            assert.strictEqual((reported[0] as vscode.LanguageModelTextPart).value, "*hidden reasoning*");
+        } finally {
+            if (original !== undefined) {
+                vscodeMutable.LanguageModelThinkingPart = original;
+            }
+        }
+    });
+
+    test("skips fallback emission for metadata-only thinking parts when ThinkingPart is unavailable", () => {
+        const vscodeMutable = vscode as unknown as Record<string, unknown>;
+        const original = vscodeMutable.LanguageModelThinkingPart;
+        delete vscodeMutable.LanguageModelThinkingPart;
+        try {
+            const reported: vscode.LanguageModelResponsePart[] = [];
+            const progress = {
+                report: (part: vscode.LanguageModelResponsePart) => reported.push(part),
+            } as vscode.Progress<vscode.LanguageModelResponsePart>;
+
+            emitV2PartsToVSCode([{ type: "thinking", value: "", metadata: { signature: "sig" } }], progress);
+
+            assert.strictEqual(reported.length, 0, "empty-value signature parts have no text to fall back to");
+        } finally {
+            if (original !== undefined) {
+                vscodeMutable.LanguageModelThinkingPart = original;
+            }
+        }
+    });
 });

--- a/src/adapters/streaming/vscodePartEmitter.ts
+++ b/src/adapters/streaming/vscodePartEmitter.ts
@@ -106,9 +106,21 @@ export function emitV2PartsToVSCode(
                         preview: thinkingValue.substring(0, 100),
                     });
                 } else {
-                    Logger.warn(
-                        `[vscodePartEmitter] Part #${idx}: thinking part skipped (LanguageModelThinkingPart not available)`
-                    );
+                    const fallbackValue = typeof part.value === "string" ? part.value : String(part.value ?? "");
+                    if (fallbackValue.length > 0) {
+                        Logger.warn(
+                            `[vscodePartEmitter] Part #${idx}: ThinkingPart unavailable — emitting *text* fallback (${fallbackValue.length} chars)`
+                        );
+                        progress.report(new vscode.LanguageModelTextPart(`*${fallbackValue}*`));
+                        StructuredLogger.debug("vscode.thinking_part_fallback_emitted", {
+                            partIndex: idx,
+                            length: fallbackValue.length,
+                        });
+                    } else {
+                        Logger.warn(
+                            `[vscodePartEmitter] Part #${idx}: metadata-only thinking part skipped (ThinkingPart unavailable)`
+                        );
+                    }
                 }
                 break;
             }

--- a/src/adapters/streaming/vscodePartEmitter.ts
+++ b/src/adapters/streaming/vscodePartEmitter.ts
@@ -4,9 +4,21 @@ import { isCacheControlMimeType } from "../../utils";
 import { StructuredLogger } from "../../observability/structuredLogger";
 import type { EmittedPart } from "./liteLLMStreamInterpreter";
 
+type ThinkingPartConstructor = new (
+    value: string | string[],
+    id?: string,
+    metadata?: Record<string, unknown>
+) => vscode.LanguageModelResponsePart;
+
+function getThinkingPartConstructor(): ThinkingPartConstructor | undefined {
+    return (vscode as unknown as Record<string, unknown>).LanguageModelThinkingPart as
+        ThinkingPartConstructor | undefined;
+}
+
 export function emitV2PartsToVSCode(
     parts: EmittedPart[],
-    progress: vscode.Progress<vscode.LanguageModelResponsePart | vscode.LanguageModelDataPart>
+    progress: vscode.Progress<vscode.LanguageModelResponsePart | vscode.LanguageModelDataPart>,
+    thinkingPartConstructor: ThinkingPartConstructor | null | undefined = getThinkingPartConstructor()
 ): void {
     Logger.trace(`[vscodePartEmitter] Emitting ${parts.length} parts to VS Code`);
     StructuredLogger.trace("vscode.emit_parts_start", {
@@ -90,9 +102,7 @@ export function emitV2PartsToVSCode(
                 break;
             }
             case "thinking": {
-                const ThinkingPart = (vscode as unknown as Record<string, unknown>).LanguageModelThinkingPart as
-                    | (new (value: string | string[], id?: string, metadata?: Record<string, unknown>) => unknown)
-                    | undefined;
+                const ThinkingPart = thinkingPartConstructor;
                 if (ThinkingPart) {
                     const thinkingValue = typeof part.value === "string" ? part.value : String(part.value ?? "");
                     Logger.trace(`[vscodePartEmitter] Part #${idx}: thinking, ${thinkingValue.length} chars`);

--- a/src/adapters/test/responsesAdapter.test.ts
+++ b/src/adapters/test/responsesAdapter.test.ts
@@ -486,17 +486,39 @@ suite("Responses Adapter Unit Tests", () => {
         assert.strictEqual(body.input.length, 0);
     });
 
-    test("transformToResponsesFormat propagates reasoning_effort verbatim", () => {
-        // We deliberately use a single canonical request shape across endpoints.
-        // LiteLLM accepts the flat `reasoning_effort` key on /responses just as it
-        // does on /chat/completions, so the adapter passes it through unchanged
-        // rather than translating into a nested `reasoning: { effort }` shape.
+    test("transformToResponsesFormat emits native reasoning for a selected effort", () => {
         const body = transformToResponsesFormat({
-            model: "m",
+            model: "gpt-5.6",
             messages: [{ role: "user", content: "hi" }],
             reasoning_effort: "high",
         });
         assert.strictEqual(body.reasoning_effort, "high");
+        assert.deepStrictEqual(body.reasoning, { effort: "high" });
+    });
+
+    test("transformToResponsesFormat preserves explicit adaptive Claude fields", () => {
+        const body = transformToResponsesFormat({
+            model: "claude-opus-5",
+            messages: [{ role: "user", content: "hi" }],
+            reasoning_effort: "high",
+            thinking: { type: "adaptive" },
+            output_config: { effort: "high" },
+        });
+
+        assert.deepStrictEqual(body.thinking, { type: "adaptive" });
+        assert.deepStrictEqual(body.output_config, { effort: "high" });
+        assert.strictEqual(body.reasoning, undefined);
+    });
+
+    test("transformToResponsesFormat omits native reasoning for none", () => {
+        const body = transformToResponsesFormat({
+            model: "gpt-5.6",
+            messages: [{ role: "user", content: "hi" }],
+            reasoning_effort: "none",
+        });
+
+        assert.strictEqual(body.reasoning_effort, "none");
+        assert.strictEqual(body.reasoning, undefined);
     });
 
     test("transformToResponsesFormat omits reasoning_effort when source request did not set it", () => {

--- a/src/adapters/test/responsesAdapter.test.ts
+++ b/src/adapters/test/responsesAdapter.test.ts
@@ -244,6 +244,7 @@ suite("Responses Adapter Unit Tests", () => {
                     content: "I will continue the task.",
                     thinking_blocks: [
                         {
+                            type: "thinking",
                             thinking: "I need the earlier reasoning summary.",
                             signature: "signed-thinking-state",
                         },
@@ -273,7 +274,7 @@ suite("Responses Adapter Unit Tests", () => {
             messages: [
                 {
                     role: "assistant",
-                    thinking_blocks: [{ data: "opaque-redacted-thinking" }],
+                    thinking_blocks: [{ type: "redacted_thinking", data: "opaque-redacted-thinking" }],
                 },
             ],
         });

--- a/src/providers/base/parameterFiltering.ts
+++ b/src/providers/base/parameterFiltering.ts
@@ -33,6 +33,7 @@ const RESTRICTABLE_PARAMS: ReadonlySet<string> = new Set([
     "frequency_penalty",
     "stop",
     "reasoning_effort",
+    "thinking",
     "tool_choice",
     "cache",
 ]);

--- a/src/providers/base/reasoningTransport.ts
+++ b/src/providers/base/reasoningTransport.ts
@@ -1,0 +1,60 @@
+import type { ChatReasoningTransportFields, LiteLLMModelInfo } from "../../types";
+
+export type ParameterSupport = (
+    parameter: string,
+    modelInfo: LiteLLMModelInfo | undefined,
+    modelId?: string
+) => boolean;
+
+const CONFIRMED_ADAPTIVE_CLAUDE_FAMILIES: readonly RegExp[] = [
+    /(?:^|\/)claude[-_.]?opus[-_.]?(?:4[-_.]?8|[5-9]|[1-9]\d+)(?:[-_.]|$)/i,
+    /(?:^|\/)claude[-_.]?sonnet[-_.]?(?:[5-9]|[1-9]\d+)(?:[-_.]|$)/i,
+    /(?:^|\/)claude[-_.]?fable[-_.]?(?:[5-9]|[1-9]\d+)(?:[-_.]|$)/i,
+];
+
+function isConfirmedAdaptiveClaudeFamily(modelId: string): boolean {
+    return CONFIRMED_ADAPTIVE_CLAUDE_FAMILIES.some((pattern) => pattern.test(modelId));
+}
+
+function shouldUseAdaptiveThinking(
+    modelId: string,
+    modelInfo: LiteLLMModelInfo | undefined,
+    supportsParameter: ParameterSupport
+): boolean {
+    if (!supportsParameter("thinking", modelInfo, modelId)) {
+        return false;
+    }
+
+    return modelInfo?.supports_adaptive_thinking === true || isConfirmedAdaptiveClaudeFamily(modelId);
+}
+
+/**
+ * Resolves transport-only reasoning fields for a chat-shaped LiteLLM request.
+ * Flat `reasoning_effort` remains the compatibility baseline. Native adaptive
+ * fields require advertised `thinking` support and an explicit capability or
+ * a confirmed affected Claude family.
+ */
+export function resolveChatReasoningTransport(
+    effort: string | undefined,
+    modelId: string,
+    modelInfo: LiteLLMModelInfo | undefined,
+    supportsParameter: ParameterSupport
+): ChatReasoningTransportFields {
+    if (!effort) {
+        return {};
+    }
+
+    const fields: ChatReasoningTransportFields = supportsParameter("reasoning_effort", modelInfo, modelId)
+        ? { reasoning_effort: effort }
+        : {};
+
+    if (effort === "none" || !shouldUseAdaptiveThinking(modelId, modelInfo, supportsParameter)) {
+        return fields;
+    }
+
+    return {
+        ...fields,
+        thinking: { type: "adaptive" },
+        output_config: { effort },
+    };
+}

--- a/src/providers/base/requestBuilder.ts
+++ b/src/providers/base/requestBuilder.ts
@@ -10,6 +10,7 @@ import { trimMessagesToFitBudget, trimV2MessagesForBudget } from "../../adapters
 import type { LiteLLMModelInfo, OpenAIChatCompletionRequest, OpenAIFunctionToolDef } from "../../types";
 import type { RequestBuilderDeps } from "./types";
 import type { V2ChatMessage } from "../v2Types";
+import { resolveChatReasoningTransport } from "./reasoningTransport";
 
 export class RequestBuilder {
     private readonly configManager: RequestBuilderDeps["configManager"];
@@ -78,6 +79,12 @@ export class RequestBuilder {
         validateRequest(messagesToUse);
 
         const reasoningEffort = this.getReasoningEffort(options, model, modelInfo);
+        const reasoningTransport = resolveChatReasoningTransport(
+            reasoningEffort,
+            rawModelId,
+            modelInfo,
+            this.isParameterSupported
+        );
         const mo = (options.modelOptions as Record<string, unknown>) ?? {};
 
         const requestBody: OpenAIChatCompletionRequest = {
@@ -88,9 +95,7 @@ export class RequestBuilder {
                 typeof mo.max_tokens === "number"
                     ? Math.min(mo.max_tokens, model.maxOutputTokens)
                     : model.maxOutputTokens,
-            ...(this.isParameterSupported("reasoning_effort", modelInfo, rawModelId) && reasoningEffort
-                ? { reasoning_effort: reasoningEffort }
-                : {}),
+            ...reasoningTransport,
         };
 
         if (!this.usageOptOutModels.has(rawModelId)) {
@@ -165,6 +170,12 @@ export class RequestBuilder {
         validateV2Messages(trimmedMessages);
 
         const reasoningEffort = this.getReasoningEffort(options, model, modelInfo);
+        const reasoningTransport = resolveChatReasoningTransport(
+            reasoningEffort,
+            rawModelId,
+            modelInfo,
+            this.isParameterSupported
+        );
         const mo = (options.modelOptions as Record<string, unknown>) ?? {};
 
         const requestBody: OpenAIChatCompletionRequest = {
@@ -175,9 +186,7 @@ export class RequestBuilder {
                 typeof options.modelOptions?.max_tokens === "number"
                     ? Math.min(options.modelOptions.max_tokens, model.maxOutputTokens)
                     : model.maxOutputTokens,
-            ...(this.isParameterSupported("reasoning_effort", modelInfo, rawModelId) && reasoningEffort
-                ? { reasoning_effort: reasoningEffort }
-                : {}),
+            ...reasoningTransport,
         };
 
         if (this.isParameterSupported("temperature", modelInfo, rawModelId)) {

--- a/src/providers/base/test/thinkingBlockRetry.test.ts
+++ b/src/providers/base/test/thinkingBlockRetry.test.ts
@@ -1,0 +1,95 @@
+import * as assert from "assert";
+import {
+    isThinkingBlockRetryableError,
+    requestHasThinkingBlocks,
+    stripThinkingBlocksFromRequest,
+} from "../thinkingBlockRetry";
+import type { OpenAIChatCompletionRequest } from "../../../types";
+
+function httpError(message: string, status: number): Error & { status: number } {
+    const error = new Error(message) as Error & { status: number };
+    error.status = status;
+    return error;
+}
+
+suite("thinkingBlockRetry", () => {
+    const request: OpenAIChatCompletionRequest = {
+        model: "claude-opus-5",
+        stream: true,
+        reasoning_effort: "high",
+        thinking: { type: "adaptive" },
+        output_config: { effort: "high" },
+        stream_options: { include_usage: true },
+        extra_body: { cache: { "no-cache": true } },
+        messages: [
+            { role: "user", content: "hi" },
+            {
+                role: "assistant",
+                content: "answer",
+                thinking_blocks: [
+                    {
+                        type: "thinking",
+                        thinking: "prior reasoning",
+                        signature: "signature-from-old-model",
+                    },
+                ],
+            },
+        ],
+    };
+
+    test("detects only non-empty thinking_blocks arrays", () => {
+        assert.strictEqual(requestHasThinkingBlocks(request), true);
+        assert.strictEqual(
+            requestHasThinkingBlocks({ model: "m", messages: [{ role: "assistant", thinking_blocks: [] }] }),
+            false
+        );
+        assert.strictEqual(
+            requestHasThinkingBlocks({ model: "m", messages: [{ role: "user", content: "hi" }] }),
+            false
+        );
+    });
+
+    test("strips only message continuity and preserves native reasoning fields", () => {
+        const redacted = stripThinkingBlocksFromRequest(request);
+
+        assert.notStrictEqual(redacted, request);
+        assert.notStrictEqual(redacted.messages, request.messages);
+        assert.strictEqual("thinking_blocks" in redacted.messages[1], false);
+        assert.strictEqual(redacted.reasoning_effort, "high");
+        assert.deepStrictEqual(redacted.thinking, { type: "adaptive" });
+        assert.deepStrictEqual(redacted.output_config, { effort: "high" });
+        assert.deepStrictEqual(redacted.stream_options, { include_usage: true });
+        assert.deepStrictEqual(redacted.extra_body, { cache: { "no-cache": true } });
+        assert.ok(request.messages[1].thinking_blocks, "original request must remain unchanged");
+    });
+
+    test("classifies provider-specific HTTP 400 continuity rejections", () => {
+        const errors = [
+            httpError("Invalid `signature` in `thinking` block", 400),
+            httpError("thinking_blocks is not supported by this model", 400),
+            new Error("LiteLLM API error: 400 Bad Request\nunknown parameter: thinking_blocks"),
+            new Error("LiteLLM API error: 400 Bad Request\nmessages.1.content.0.thinking.signature: invalid value"),
+            new Error("LiteLLM API error: 400 Bad Request\nmessages.1.content.0.type: Field required"),
+        ];
+
+        for (const error of errors) {
+            assert.strictEqual(isThinkingBlockRetryableError(error), true, error.message);
+        }
+    });
+
+    test("rejects unrelated or unsafe retry classes", () => {
+        const errors = [
+            httpError("invalid api key", 401),
+            httpError("forbidden", 403),
+            httpError("rate limited", 429),
+            httpError("context length exceeded", 400),
+            httpError("internal server error mentioning thinking", 500),
+            new Error("network timeout while sending thinking_blocks"),
+            new Error("No baseUrl provided in call-time configuration"),
+        ];
+
+        for (const error of errors) {
+            assert.strictEqual(isThinkingBlockRetryableError(error), false, error.message);
+        }
+    });
+});

--- a/src/providers/base/test/transport.fallback.test.ts
+++ b/src/providers/base/test/transport.fallback.test.ts
@@ -10,6 +10,7 @@ import type { OpenAIChatCompletionRequest, LiteLLMModelInfo } from "../../../typ
 // and can be programmed to fail the first call with a 500-shaped error.
 class FakeLiteLLMClient {
     public calls: string[] = [];
+    public readonly requests: OpenAIChatCompletionRequest[] = [];
     public failFirstResponsesWith500 = false;
     public firstCallFailed = false;
     public readonly disableCaching?: boolean;
@@ -28,6 +29,7 @@ class FakeLiteLLMClient {
         _modelInfo?: LiteLLMModelInfo
     ): Promise<ReadableStream<Uint8Array>> {
         this.calls.push(mode ?? "undefined");
+        this.requests.push(_request);
         if (this.failFirstResponsesWith500 && !this.firstCallFailed && mode === "responses") {
             this.firstCallFailed = true;
             throw new Error(
@@ -149,5 +151,48 @@ suite("Transport /responses -> /chat/completions fallback", () => {
             /400 Bad Request/
         );
         assert.deepStrictEqual(fake.calls, ["responses"]);
+    });
+
+    test("configured /responses -> chat fallback preserves native reasoning and continuity", async () => {
+        const fake = new FakeLiteLLMClient({ url: "https://x", key: "k" }, "test-ua");
+        fake.failFirstResponsesWith500 = true;
+        const transport = new Transport(makeDeps(fake));
+
+        const request: OpenAIChatCompletionRequest = {
+            model: "claude-opus-5",
+            messages: [
+                {
+                    role: "assistant",
+                    thinking_blocks: [{ type: "thinking", thinking: "prior reasoning", signature: "valid-signature" }],
+                },
+            ],
+            reasoning_effort: "high",
+            thinking: { type: "adaptive" },
+            output_config: { effort: "high" },
+            stream: true,
+        };
+
+        const stream = await transport.sendRequestToLiteLLM(
+            request,
+            { report: () => {} } as unknown as vscode.Progress<vscode.LanguageModelResponsePart>,
+            new vscode.CancellationTokenSource().token,
+            "tools",
+            responsesModelInfo,
+            { baseUrl: "https://x", apiKey: "k", allowChatCompletionsFallback: true }
+        );
+        void stream;
+
+        // Exactly two endpoint attempts: /responses fails with 5xx, falls back to /chat.
+        assert.deepStrictEqual(fake.calls, ["responses", "chat"]);
+        assert.strictEqual(fake.requests.length, 2);
+        // Native reasoning fields and message continuity must survive the
+        // configured endpoint fallback unchanged — transport routing must not
+        // strip or alter request-shape fields.
+        for (const sent of fake.requests) {
+            assert.strictEqual(sent.reasoning_effort, "high");
+            assert.deepStrictEqual(sent.thinking, { type: "adaptive" });
+            assert.deepStrictEqual(sent.output_config, { effort: "high" });
+            assert.ok(sent.messages[0].thinking_blocks);
+        }
     });
 });

--- a/src/providers/base/thinkingBlockRetry.ts
+++ b/src/providers/base/thinkingBlockRetry.ts
@@ -1,0 +1,125 @@
+import type { OpenAIChatCompletionRequest, OpenAIChatMessage } from "../../types";
+
+/**
+ * Pure helpers for one-shot recovery from model-switch continuity rejection.
+ *
+ * These functions own only detection, redaction, and retry classification of
+ * prior-turn `thinking_blocks`. They never touch top-level native reasoning
+ * fields (`reasoning_effort`, adaptive `thinking`, `output_config`) so the
+ * live retry coordinator can redact continuity without regressing native
+ * reasoning transport.
+ */
+
+/** Resolves an HTTP-like status from an error object or embedded message text. */
+function getErrorStatus(error: unknown): number | undefined {
+    if (error && typeof error === "object") {
+        const status = (error as { status?: unknown }).status;
+        const statusCode = (error as { statusCode?: unknown }).statusCode;
+        if (typeof status === "number") {
+            return status;
+        }
+        if (typeof statusCode === "number") {
+            return statusCode;
+        }
+    }
+
+    // Some LiteLLM errors surface the status only inside the message body,
+    // e.g. "LiteLLM API error: 400 Bad Request\n<details>".
+    const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+    const match = /LiteLLM API error:\s*(\d{3})/i.exec(message);
+    return match ? Number(match[1]) : undefined;
+}
+
+/** Best-effort extraction of a human-readable message from an unknown error. */
+function getErrorText(error: unknown): string {
+    if (error instanceof Error) {
+        return error.message;
+    }
+    if (typeof error === "string") {
+        return error;
+    }
+    if (error && typeof error === "object" && "message" in error) {
+        const message = (error as { message?: unknown }).message;
+        return typeof message === "string" ? message : "";
+    }
+    return "";
+}
+
+/**
+ * Returns `true` only when at least one assistant message carries a non-empty
+ * `thinking_blocks` array. Used to gate the continuity retry so requests that
+ * never carried continuity are never redacted.
+ */
+export function requestHasThinkingBlocks(request: OpenAIChatCompletionRequest): boolean {
+    return request.messages.some(
+        (message) => Array.isArray(message.thinking_blocks) && message.thinking_blocks.length > 0
+    );
+}
+
+function stripThinkingBlocksFromMessages(messages: readonly OpenAIChatMessage[]): OpenAIChatMessage[] {
+    return messages.map((message) => {
+        if (!Array.isArray(message.thinking_blocks) || message.thinking_blocks.length === 0) {
+            return message;
+        }
+        // Shallow-copy the message and remove only the continuity field so the
+        // caller's original message array and all other fields stay intact.
+        const copy: OpenAIChatMessage = { ...message };
+        delete copy.thinking_blocks;
+        return copy;
+    });
+}
+
+/**
+ * Removes prior-turn continuity only; top-level native reasoning is preserved.
+ * Returns a new request with a new messages array; the original request is not
+ * mutated.
+ */
+export function stripThinkingBlocksFromRequest(request: OpenAIChatCompletionRequest): OpenAIChatCompletionRequest {
+    return {
+        ...request,
+        messages: stripThinkingBlocksFromMessages(request.messages),
+    };
+}
+
+/**
+ * Allows one retry only for HTTP 400 errors that identify rejected continuity.
+ *
+ * Recognized rejections:
+ * - messages mentioning thinking blocks with rejection wording
+ *   (invalid / not supported / unsupported / unknown parameter / unexpected)
+ * - a missing-block-discriminant validation error
+ *   (`messages.N.content.M.type: Field required`) — a narrow compatibility
+ *   exception for the exact shape produced when the prior serializer omitted
+ *   the `type` discriminant.
+ *
+ * Authentication, authorization, quota, cancellation, overflow, 5xx, network,
+ * and configuration failures are intentionally excluded so the retry cannot
+ * mask unrelated failures.
+ */
+export function isThinkingBlockRetryableError(error: unknown): boolean {
+    if (getErrorStatus(error) !== 400) {
+        return false;
+    }
+
+    // Strip backticks and quotes so provider messages like
+    // "Invalid `signature` in `thinking` block" still match the `thinking block`
+    // substring. This is normalization of formatting, not of the error class.
+    const text = getErrorText(error)
+        .toLowerCase()
+        .replace(/[`"'*]/g, "");
+    const identifiesThinking =
+        text.includes("thinking_blocks") ||
+        text.includes("thinking block") ||
+        text.includes("thinking.signature") ||
+        text.includes("redacted_thinking");
+    const identifiesRejection =
+        text.includes("invalid") ||
+        text.includes("not supported") ||
+        text.includes("unsupported") ||
+        text.includes("unknown parameter") ||
+        text.includes("unexpected");
+
+    const identifiesMissingBlockDiscriminant = /messages\.\d+\.content\.\d+\.type:\s*field required/.test(text);
+
+    return (identifiesThinking && identifiesRejection) || identifiesMissingBlockDiscriminant;
+}

--- a/src/providers/base/transport.ts
+++ b/src/providers/base/transport.ts
@@ -113,6 +113,8 @@ export class Transport {
             endpoint: modelInfo?.mode,
             requestModel: request.model,
             reasoning_effort: (request as { reasoning_effort?: string }).reasoning_effort,
+            has_thinking: (request as { thinking?: unknown }).thinking !== undefined,
+            has_output_config: (request as { output_config?: unknown }).output_config !== undefined,
             max_tokens: request.max_tokens,
             temperature: request.temperature,
             top_p: request.top_p,

--- a/src/providers/liteLLMChatProvider.ts
+++ b/src/providers/liteLLMChatProvider.ts
@@ -239,10 +239,10 @@ export class LiteLLMChatProvider extends LiteLLMProviderBase implements Language
         /************************************************
          * End of code block
          ***********************************************/
-        // Extract caller/justification from options or model tags
+        // Extract caller/justification from options. Model tags describe capabilities,
+        // not the request source; tags[0] is commonly "tools" and is not a caller.
         const telemetry = this.getTelemetryOptions(options);
-        const modelWithTags = model as vscode.LanguageModelChatInformation & { tags?: string[] };
-        const caller = telemetry.caller || modelWithTags.tags?.[0] || "chat";
+        const caller = telemetry.caller || "chat";
         const justification = telemetry.justification;
 
         if (this._telemetryService) {

--- a/src/providers/liteLLMProviderBase.ts
+++ b/src/providers/liteLLMProviderBase.ts
@@ -32,6 +32,11 @@ import type { BackendSession } from "./backendSession";
 import { RequestBuilder } from "./base/requestBuilder";
 import { Transport } from "./base/transport";
 import type { RequestBuilderDeps, TransportDeps } from "./base/types";
+import {
+    isThinkingBlockRetryableError,
+    requestHasThinkingBlocks,
+    stripThinkingBlocksFromRequest,
+} from "./base/thinkingBlockRetry";
 import { LiteLLMProviderRegistry } from "./liteLLMProviderRegistry";
 import {
     detectQuotaToolRedaction as detectQuotaToolRedactionImpl,
@@ -568,36 +573,50 @@ export abstract class LiteLLMProviderBase {
         caller?: string,
         modelInfo?: LiteLLMModelInfo
     ): Promise<ReadableStream<Uint8Array>> {
-        const modelId = request.model;
-        Logger.debug(`[sendRequestWithRetry] modelId: ${modelId}, reasoning_effort: ${request.reasoning_effort}`);
-        const originalEffort = (request as { reasoning_effort?: SupportedReasoningEffort }).reasoning_effort;
+        // `currentRequest` is the live request shape mutated across retries. It
+        // starts as the caller's request but is replaced (never the same
+        // reference) when continuity is redacted, so the caller's original
+        // message array and fields remain untouched. All in-method reads and
+        // the usage/reasoning/continuity retries operate on `currentRequest`.
+        let currentRequest = request;
+        const modelId = currentRequest.model;
+        Logger.debug(
+            `[sendRequestWithRetry] modelId: ${modelId}, reasoning_effort: ${currentRequest.reasoning_effort}`
+        );
+        const originalEffort = (currentRequest as { reasoning_effort?: SupportedReasoningEffort }).reasoning_effort;
         let effectiveEffort = this._effortFallbackCache.getEffectiveEffort(modelId, originalEffort);
         Logger.debug(`[sendRequestWithRetry] originalEffort: ${originalEffort}, effectiveEffort: ${effectiveEffort}`);
-        this.applyReasoningEffort(request, effectiveEffort);
+        this.applyReasoningEffort(currentRequest, effectiveEffort);
 
         const notificationKeyEffort = originalEffort ?? effectiveEffort;
         let attempts = 0;
         let lastError: unknown;
         let usageRetryAttempted = false;
+        // One-shot continuity retry: set when prior-turn thinking_blocks are
+        // redacted after a model-switch rejection. Bounded separately from the
+        // reasoning-effort `attempts` counter so each compatibility retry is
+        // independently capped at one.
+        let thinkingBlocksRetryAttempted = false;
 
         const clearUsageFlag = () => {
-            delete (request as { stream_options?: { include_usage?: boolean } }).stream_options;
+            delete currentRequest.stream_options;
         };
 
         while (attempts < 6) {
             try {
                 return await this.sendOnceWithOverflow(
-                    request,
+                    currentRequest,
                     messages,
                     model,
                     options,
                     progress,
                     token,
                     caller,
-                    modelInfo
+                    modelInfo,
+                    thinkingBlocksRetryAttempted
                 );
             } catch (err) {
-                this.logRequestPayloadOnFailure(request, err, {
+                this.logRequestPayloadOnFailure(currentRequest, err, {
                     stage: "sendRequestWithRetry",
                     modelId: model.id,
                     caller,
@@ -616,6 +635,24 @@ export abstract class LiteLLMProviderBase {
                         );
                         continue;
                     }
+                }
+
+                // Continuity retry: redact prior-turn thinking_blocks once when a
+                // model-switch HTTP 400 specifically rejects that continuity.
+                // This is a separate, one-time compatibility retry that does not
+                // consume the reasoning-effort `attempts` budget. Native
+                // reasoning fields are preserved by stripThinkingBlocksFromRequest.
+                if (
+                    !thinkingBlocksRetryAttempted &&
+                    requestHasThinkingBlocks(currentRequest) &&
+                    isThinkingBlockRetryableError(err)
+                ) {
+                    thinkingBlocksRetryAttempted = true;
+                    currentRequest = stripThinkingBlocksFromRequest(currentRequest);
+                    Logger.warn(
+                        `[sendRequestWithRetry] Retrying once without prior-turn thinking_blocks after model continuity rejection for ${model.id}`
+                    );
+                    continue;
                 }
 
                 Logger.debug(`[sendRequestWithRetry] Caught error, checking isReasoningError...`);
@@ -640,7 +677,7 @@ export abstract class LiteLLMProviderBase {
 
                 const previous = effectiveEffort;
                 effectiveEffort = nextEffort;
-                this.applyReasoningEffort(request, effectiveEffort);
+                this.applyReasoningEffort(currentRequest, effectiveEffort);
 
                 if (notificationKeyEffort && previous && previous !== effectiveEffort) {
                     this.notifyReasoningFallback(modelId, notificationKeyEffort, effectiveEffort);
@@ -691,8 +728,13 @@ export abstract class LiteLLMProviderBase {
         summary?: "auto" | "concise" | "detailed"
     ): void {
         if (!effort) {
-            const requestRecord = request as unknown as Record<string, unknown>;
-            delete requestRecord.reasoning_effort;
+            delete request.reasoning_effort;
+            // Removing effort also invalidates adaptive Claude reasoning, whose
+            // `thinking` and `output_config.effort` must always agree with
+            // `reasoning_effort`. Drop them together so a partially-downgraded
+            // request never sends an incoherent adaptive shape.
+            delete request.thinking;
+            delete request.output_config;
             return;
         }
         // Object form is used by `gpt-5.4+` callers (and the OpenAI Responses API
@@ -700,6 +742,22 @@ export abstract class LiteLLMProviderBase {
         // reasoning text. The OpenAI Chat Completions spec still accepts the
         // legacy string form; both are forwarded to LiteLLM unchanged.
         request.reasoning_effort = summary ? { effort, summary } : effort;
+
+        // `none` is a valid wire value but signals no reasoning, so the adaptive
+        // Claude native fields must not be sent alongside it.
+        if (effort === "none") {
+            delete request.thinking;
+            delete request.output_config;
+            return;
+        }
+
+        // Keep an already-adaptive request coherent: when the existing fallback
+        // changes effort, `output_config.effort` must agree. This never creates
+        // adaptive fields on a non-adaptive request; it only updates an existing
+        // adaptive `output_config` so the two fields stay synchronized.
+        if (request.thinking?.type === "adaptive") {
+            request.output_config = { effort };
+        }
     }
 
     private notifyReasoningFallback(
@@ -726,7 +784,11 @@ export abstract class LiteLLMProviderBase {
         progress: vscode.Progress<vscode.LanguageModelResponsePart>,
         token: vscode.CancellationToken,
         caller?: string,
-        modelInfo?: LiteLLMModelInfo
+        modelInfo?: LiteLLMModelInfo,
+        // When true, overflow rebuilding re-strips thinking_blocks so a prior
+        // continuity redaction survives the rebuild and is not restored from
+        // the original VS Code history.
+        stripThinkingBlocksForRetry = false
     ): Promise<ReadableStream<Uint8Array>> {
         try {
             return await this.sendRequestToLiteLLM(
@@ -747,13 +809,19 @@ export abstract class LiteLLMProviderBase {
             const toolConfig = convertTools(options);
             const hardBudget = Math.max(1, model.maxInputTokens - estimateToolTokens(toolConfig.tools));
             const trimmedMessages = trimMessagesToFitBudget(messages, toolConfig.tools, model, modelInfo, hardBudget);
-            const retrimmedRequest = await this.buildOpenAIChatRequest(
+            const rebuiltRequest = await this.buildOpenAIChatRequest(
                 trimmedMessages,
                 model,
                 options,
                 modelInfo,
                 caller
             );
+            // If continuity was already redacted on the outer retry, the rebuilt
+            // request (which re-reads the original history) would reintroduce
+            // thinking_blocks. Re-strip so the rejected continuity stays gone.
+            const retrimmedRequest = stripThinkingBlocksForRetry
+                ? stripThinkingBlocksFromRequest(rebuiltRequest)
+                : rebuiltRequest;
 
             try {
                 return await this.sendRequestToLiteLLM(

--- a/src/providers/liteLLMProviderRegistry.ts
+++ b/src/providers/liteLLMProviderRegistry.ts
@@ -826,7 +826,6 @@ export class LiteLLMProviderRegistry implements vscode.Disposable {
             tags?: string[];
             detail?: string;
             tooltip?: string;
-            pricing?: string;
             inputCost?: number;
             outputCost?: number;
             cacheCost?: number;
@@ -901,7 +900,9 @@ export class LiteLLMProviderRegistry implements vscode.Disposable {
             const round = (value?: number): number | undefined =>
                 value !== undefined ? Number.parseFloat(value.toFixed(2)) : undefined;
 
-            (info as { pricing?: string }).pricing = formatPricingForDetail(pricing);
+            // `pricing` is rendered inline with the native VS Code model name.
+            // Keep prices in numeric metadata, hover content, and extension-owned
+            // picker details without assigning that inline display label.
             (info as { inputCost?: number }).inputCost = round(inputCost);
             (info as { outputCost?: number }).outputCost = round(outputCost);
             (info as { cacheCost?: number }).cacheCost = round(cacheCost);

--- a/src/providers/test/chatProvider.test.ts
+++ b/src/providers/test/chatProvider.test.ts
@@ -648,6 +648,55 @@ suite("LiteLLM Chat Provider Unit Tests", () => {
         assert.strictEqual(textParts.map((p) => p.value).join(""), "Hello");
     });
 
+    test("caller defaults to 'chat' instead of the model's first tag", async () => {
+        const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
+        seedDiscoveredBackend(sandbox, provider, "model-1");
+        const encoder = new TextEncoder();
+        const stream = new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'));
+                controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+                controller.close();
+            },
+        });
+        sandbox.stub(LiteLLMClient.prototype, "chat").resolves(stream);
+        const reportMetricSpy = sandbox.spy(LiteLLMTelemetry, "reportMetric");
+
+        await provider.provideLanguageModelChatResponse(
+            {
+                id: "model-1",
+                name: "model-1",
+                tooltip: "",
+                family: "litellm",
+                version: "1.0.0",
+                maxInputTokens: 1000,
+                maxOutputTokens: 1000,
+                capabilities: { toolCalling: true, imageInput: false },
+                tags: ["tools", "vision"],
+            } as unknown as vscode.LanguageModelChatInformation,
+            [
+                {
+                    role: vscode.LanguageModelChatMessageRole.User,
+                    name: undefined,
+                    content: [new vscode.LanguageModelTextPart("hello")],
+                },
+            ],
+            {
+                modelOptions: {},
+                tools: [],
+                toolMode: vscode.LanguageModelChatToolMode.Auto,
+                requestInitiator: "test",
+                configuration: { baseUrl: "http://localhost:4000", apiKey: "k" },
+            } as unknown as vscode.ProvideLanguageModelChatResponseOptions,
+            { report: () => undefined },
+            new vscode.CancellationTokenSource().token
+        );
+
+        const metric = reportMetricSpy.firstCall?.args[0] as { caller?: string } | undefined;
+        assert.ok(metric, "expected a telemetry metric");
+        assert.strictEqual(metric.caller, "chat", "caller must not fall back to tags[0]");
+    });
+
     test("preserves redacted thinking metadata when includeEncryptedThinking is requested", async () => {
         const vscodeWithThinking = vscode as unknown as {
             LanguageModelThinkingPart?: new (

--- a/src/providers/test/liteLLMProviderBase.modelDisplay.test.ts
+++ b/src/providers/test/liteLLMProviderBase.modelDisplay.test.ts
@@ -166,6 +166,7 @@ suite("LiteLLM model display", () => {
             category?: string;
             detail?: string;
             multiplierNumeric?: number;
+            tooltip?: string;
             warningText?: Record<string, string>;
             infoText?: Record<string, string>;
         };
@@ -177,9 +178,20 @@ suite("LiteLLM model display", () => {
         assert.strictEqual(info.cacheWriteCost, 1.25); // $0.00000125 * 1_000_000
         assert.strictEqual(info.priceCategory, "low");
 
-        // Pricing label uses compact detail formatter ($X/1M inp • $Y/1M out)
-        assert.strictEqual(info.pricing, "$1.00/1M inp • $5.00/1M out");
+        // VS Code renders `pricing` inline in its native model dropdown. Keep that
+        // row focused on the model identity while preserving pricing in every other
+        // picker surface and native cost metadata.
+        assert.strictEqual(info.pricing, undefined);
         assert.strictEqual(info.detail, "example • $1.00/1M inp • $5.00/1M out");
+        assert.strictEqual(
+            info.tooltip,
+            "Provider: openai, Model: priced-model via example\n" +
+                "Input: $1.00/1M tokens\n" +
+                "Output: $5.00/1M tokens\n" +
+                "Cache read: $0.10/1M tokens\n" +
+                "Cache write: $1.25/1M tokens\n" +
+                "Limits: input 4,096 tokens, output 4,096 tokens"
+        );
         assert.strictEqual(info.multiplierNumeric, 5);
         assert.strictEqual(info.warningText, undefined);
 

--- a/src/providers/test/liteLLMProviderBase.requestBuilder.test.ts
+++ b/src/providers/test/liteLLMProviderBase.requestBuilder.test.ts
@@ -214,6 +214,84 @@ suite("RequestBuilder", () => {
         assert.strictEqual(request.reasoning_effort, "none");
     });
 
+    test("buildOpenAIChatRequest emits adaptive fields for an affected Claude route", async () => {
+        configManager.getConfig.resolves({});
+        const adaptiveBuilder = new RequestBuilder({
+            configManager,
+            getReasoningEffort: () => "high",
+            detectQuotaToolRedaction: (messages, tools) => ({ tools, confidence: "none" as const }),
+            stripUnsupportedParametersFromRequest: () => {},
+            isParameterSupported: (parameter, modelInfo) =>
+                modelInfo?.supported_openai_params?.includes(parameter) === true,
+            getTelemetryOptions: () => ({ caller: "test", justification: undefined, modelConfiguration: {} }),
+            usageOptOutModels: new Set(),
+            extractRawModelName: (id: string) => id,
+        });
+        const model = {
+            id: "vertex_ai/claude-opus-4-8",
+            maxInputTokens: 100_000,
+            maxOutputTokens: 8_192,
+        } as vscode.LanguageModelChatInformation;
+        const messages: vscode.LanguageModelChatRequestMessage[] = [
+            {
+                role: vscode.LanguageModelChatMessageRole.User,
+                content: [new vscode.LanguageModelTextPart("hi")],
+                name: undefined,
+            },
+        ];
+
+        const request = await adaptiveBuilder.buildOpenAIChatRequest(
+            messages,
+            model,
+            { modelOptions: {} } as vscode.ProvideLanguageModelChatResponseOptions,
+            { supported_openai_params: ["reasoning_effort", "thinking"] },
+            "test"
+        );
+
+        assert.strictEqual(request.reasoning_effort, "high");
+        assert.deepStrictEqual(request.thinking, { type: "adaptive" });
+        assert.deepStrictEqual(request.output_config, { effort: "high" });
+    });
+
+    test("buildOpenAIChatRequest keeps Opus 4.7 on flat reasoning_effort", async () => {
+        configManager.getConfig.resolves({});
+        const standardBuilder = new RequestBuilder({
+            configManager,
+            getReasoningEffort: () => "high",
+            detectQuotaToolRedaction: (messages, tools) => ({ tools, confidence: "none" as const }),
+            stripUnsupportedParametersFromRequest: () => {},
+            isParameterSupported: (parameter, modelInfo) =>
+                modelInfo?.supported_openai_params?.includes(parameter) === true,
+            getTelemetryOptions: () => ({ caller: "test", justification: undefined, modelConfiguration: {} }),
+            usageOptOutModels: new Set(),
+            extractRawModelName: (id: string) => id,
+        });
+        const model = {
+            id: "anthropic/claude-opus-4-7",
+            maxInputTokens: 100_000,
+            maxOutputTokens: 8_192,
+        } as vscode.LanguageModelChatInformation;
+        const messages: vscode.LanguageModelChatRequestMessage[] = [
+            {
+                role: vscode.LanguageModelChatMessageRole.User,
+                content: [new vscode.LanguageModelTextPart("hi")],
+                name: undefined,
+            },
+        ];
+
+        const request = await standardBuilder.buildOpenAIChatRequest(
+            messages,
+            model,
+            { modelOptions: {} } as vscode.ProvideLanguageModelChatResponseOptions,
+            { supported_openai_params: ["reasoning_effort", "thinking"] },
+            "test"
+        );
+
+        assert.strictEqual(request.reasoning_effort, "high");
+        assert.strictEqual(request.thinking, undefined);
+        assert.strictEqual(request.output_config, undefined);
+    });
+
     test("buildV2ChatRequest omits none when reasoning_effort is unsupported", async () => {
         configManager.getConfig.resolves({});
         const noneBuilder = new RequestBuilder({

--- a/src/providers/test/liteLLMProviderBase.test.ts
+++ b/src/providers/test/liteLLMProviderBase.test.ts
@@ -10,6 +10,8 @@ import { createTelemetryMocks } from "../../test/utils/telemetryMock";
 import { getModelTags } from "../../utils/modelCapabilities";
 import type { DerivedModelCapabilities } from "../../utils/modelCapabilities";
 import type { BackendSession } from "../backendSession";
+import { convertMessages } from "../../utils";
+import { createInitialStreamingState, interpretStreamEvent } from "../../adapters/streaming/liteLLMStreamInterpreter";
 
 function createDerived(overrides: Partial<DerivedModelCapabilities> = {}): DerivedModelCapabilities {
     return {
@@ -215,6 +217,23 @@ suite("LiteLLMProviderBase", () => {
 
                 const recordRequest = request as unknown as Record<string, unknown>;
                 assert.strictEqual(recordRequest.reasoning_effort, "high");
+            });
+
+            test("removes adaptive native fields when effort becomes none", () => {
+                const provider = new LiteLLMChatProvider(mockSecrets, userAgent);
+                const request: OpenAIChatCompletionRequest = {
+                    model: "claude-opus-5",
+                    messages: [],
+                    reasoning_effort: "high",
+                    thinking: { type: "adaptive" },
+                    output_config: { effort: "high" },
+                };
+
+                access(provider).applyReasoningEffort(request, "none");
+
+                assert.strictEqual(request.reasoning_effort, "none");
+                assert.strictEqual(request.thinking, undefined);
+                assert.strictEqual(request.output_config, undefined);
             });
         });
 
@@ -598,6 +617,332 @@ suite("LiteLLMProviderBase", () => {
             );
 
             assert.ok(capturedRequests[0].reasoning_effort !== "high", "should have downgraded before first send");
+        });
+
+        test("retries once without thinking_blocks on a model-switch continuity rejection", async () => {
+            const provider = setupProvider();
+            const baseConfig = { baseUrl: "https://wolfram.example", apiKey: "k" };
+            seedBackendForCall(sandbox, provider, baseConfig, {
+                backendName: "wolfram",
+                baseUrl: "https://wolfram.example",
+                apiKey: "k",
+                client: {} as never,
+            });
+            const requests: OpenAIChatCompletionRequest[] = [];
+            const sendStub = sandbox
+                .stub(access(provider)._transport, "sendRequestToLiteLLM")
+                .callsFake(async (request) => {
+                    requests.push(request);
+                    if (requests.length === 1) {
+                        throw apiError("Invalid `signature` in `thinking` block", 400);
+                    }
+                    return new ReadableStream();
+                });
+            const request: OpenAIChatCompletionRequest = {
+                model: "claude-opus-5",
+                stream: true,
+                reasoning_effort: "high",
+                thinking: { type: "adaptive" },
+                output_config: { effort: "high" },
+                messages: [
+                    {
+                        role: "assistant",
+                        content: "answer",
+                        thinking_blocks: [
+                            {
+                                type: "thinking",
+                                thinking: "prior reasoning",
+                                signature: "old-model-signature",
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            const stream = await access(provider).sendRequestWithRetry(
+                request,
+                [],
+                model,
+                { configuration: baseConfig } as unknown as vscode.ProvideLanguageModelChatResponseOptions,
+                { report: () => {} } as vscode.Progress<vscode.LanguageModelResponsePart>,
+                new vscode.CancellationTokenSource().token,
+                "test"
+            );
+
+            assert.ok(stream);
+            sinon.assert.calledTwice(sendStub);
+            assert.ok(requests[0].messages[0].thinking_blocks, "first attempt must retain continuity");
+            assert.strictEqual("thinking_blocks" in requests[1].messages[0], false);
+            assert.strictEqual(requests[1].reasoning_effort, "high");
+            assert.deepStrictEqual(requests[1].thinking, { type: "adaptive" });
+            assert.deepStrictEqual(requests[1].output_config, { effort: "high" });
+        });
+
+        test("does not continuity-retry an authentication failure", async () => {
+            const provider = setupProvider();
+            const baseConfig = { baseUrl: "https://wolfram.example", apiKey: "k" };
+            seedBackendForCall(sandbox, provider, baseConfig, {
+                backendName: "wolfram",
+                baseUrl: "https://wolfram.example",
+                apiKey: "k",
+                client: {} as never,
+            });
+            const sendStub = sandbox
+                .stub(access(provider)._transport, "sendRequestToLiteLLM")
+                .rejects(apiError("thinking_blocks request used an invalid api key", 401));
+
+            await assert.rejects(() =>
+                access(provider).sendRequestWithRetry(
+                    {
+                        model: "claude-opus-5",
+                        messages: [
+                            {
+                                role: "assistant",
+                                thinking_blocks: [{ type: "thinking", thinking: "thought", signature: "sig" }],
+                            },
+                        ],
+                    },
+                    [],
+                    model,
+                    { configuration: baseConfig } as unknown as vscode.ProvideLanguageModelChatResponseOptions,
+                    { report: () => {} } as vscode.Progress<vscode.LanguageModelResponsePart>,
+                    new vscode.CancellationTokenSource().token,
+                    "test"
+                )
+            );
+
+            sinon.assert.calledOnce(sendStub);
+        });
+
+        test("keeps adaptive output_config synchronized during effort fallback", async () => {
+            const provider = setupProvider();
+            const baseConfig = { baseUrl: "https://wolfram.example", apiKey: "k" };
+            seedBackendForCall(sandbox, provider, baseConfig, {
+                backendName: "wolfram",
+                baseUrl: "https://wolfram.example",
+                apiKey: "k",
+                client: {} as never,
+            });
+            const requests: OpenAIChatCompletionRequest[] = [];
+            sandbox.stub(access(provider)._transport, "sendRequestToLiteLLM").callsFake(async (request) => {
+                requests.push({
+                    ...request,
+                    output_config: request.output_config ? { ...request.output_config } : undefined,
+                });
+                if (requests.length === 1) {
+                    throw apiError("reasoning_effort parameter is not supported", 400);
+                }
+                return new ReadableStream();
+            });
+
+            await access(provider).sendRequestWithRetry(
+                {
+                    model: "claude-opus-5",
+                    messages: [{ role: "user", content: "hi" }],
+                    reasoning_effort: "high",
+                    thinking: { type: "adaptive" },
+                    output_config: { effort: "high" },
+                },
+                [],
+                model,
+                { configuration: baseConfig } as unknown as vscode.ProvideLanguageModelChatResponseOptions,
+                { report: () => {} } as vscode.Progress<vscode.LanguageModelResponsePart>,
+                new vscode.CancellationTokenSource().token,
+                "test"
+            );
+
+            assert.strictEqual(requests[1].reasoning_effort, "medium");
+            assert.deepStrictEqual(requests[1].thinking, { type: "adaptive" });
+            assert.deepStrictEqual(requests[1].output_config, { effort: "medium" });
+        });
+
+        test("composes include-usage and continuity retries without restoring either field", async () => {
+            const provider = setupProvider();
+            const baseConfig = { baseUrl: "https://wolfram.example", apiKey: "k" };
+            seedBackendForCall(sandbox, provider, baseConfig, {
+                backendName: "wolfram",
+                baseUrl: "https://wolfram.example",
+                apiKey: "k",
+                client: {} as never,
+            });
+            const sent: OpenAIChatCompletionRequest[] = [];
+            sandbox.stub(access(provider)._transport, "sendRequestToLiteLLM").callsFake(async (request) => {
+                sent.push(request);
+                if (sent.length === 1) {
+                    throw apiError("stream_options.include_usage is not supported", 400);
+                }
+                if (sent.length === 2) {
+                    throw apiError("Invalid `signature` in `thinking` block", 400);
+                }
+                return new ReadableStream();
+            });
+
+            await access(provider).sendRequestWithRetry(
+                {
+                    model: "claude-opus-5",
+                    stream: true,
+                    stream_options: { include_usage: true },
+                    messages: [
+                        {
+                            role: "assistant",
+                            thinking_blocks: [
+                                { type: "thinking", thinking: "prior reasoning", signature: "old-signature" },
+                            ],
+                        },
+                    ],
+                },
+                [],
+                model,
+                { configuration: baseConfig } as unknown as vscode.ProvideLanguageModelChatResponseOptions,
+                { report: () => {} } as vscode.Progress<vscode.LanguageModelResponsePart>,
+                new vscode.CancellationTokenSource().token,
+                "test"
+            );
+
+            assert.strictEqual(sent.length, 3);
+            assert.strictEqual(sent[2].stream_options, undefined);
+            assert.strictEqual("thinking_blocks" in sent[2].messages[0], false);
+        });
+
+        test("keeps continuity stripped when overflow rebuilding recreates the request", async () => {
+            const provider = setupProvider();
+            const baseConfig = { baseUrl: "https://wolfram.example", apiKey: "k" };
+            seedBackendForCall(sandbox, provider, baseConfig, {
+                backendName: "wolfram",
+                baseUrl: "https://wolfram.example",
+                apiKey: "k",
+                client: {} as never,
+            });
+            const history = [
+                {
+                    role: vscode.LanguageModelChatMessageRole.Assistant,
+                    content: [new vscode.LanguageModelTextPart("answer")],
+                    name: undefined,
+                },
+            ];
+            const requestWithContinuity = (): OpenAIChatCompletionRequest => ({
+                model: "claude-opus-5",
+                stream: true,
+                max_tokens: 100,
+                messages: [
+                    {
+                        role: "assistant",
+                        content: "answer",
+                        thinking_blocks: [
+                            { type: "thinking", thinking: "prior reasoning", signature: "old-signature" },
+                        ],
+                    },
+                ],
+            });
+            sandbox.stub(access(provider), "buildOpenAIChatRequest").resolves(requestWithContinuity());
+            const sent: OpenAIChatCompletionRequest[] = [];
+            sandbox.stub(access(provider)._transport, "sendRequestToLiteLLM").callsFake(async (candidate) => {
+                sent.push(candidate);
+                if (sent.length === 1) {
+                    throw apiError("Invalid `signature` in `thinking` block", 400);
+                }
+                if (sent.length === 2) {
+                    throw new Error("context length exceeded");
+                }
+                return new ReadableStream();
+            });
+
+            await access(provider).sendRequestWithRetry(
+                requestWithContinuity(),
+                history as unknown as vscode.LanguageModelChatRequestMessage[],
+                model,
+                { configuration: baseConfig } as unknown as vscode.ProvideLanguageModelChatResponseOptions,
+                { report: () => {} } as vscode.Progress<vscode.LanguageModelResponsePart>,
+                new vscode.CancellationTokenSource().token,
+                "test",
+                { mode: "chat", max_input_tokens: 1000 } as unknown as LiteLLMModelInfo
+            );
+
+            assert.strictEqual(sent.length, 3);
+            assert.ok(sent[0].messages[0].thinking_blocks);
+            assert.strictEqual("thinking_blocks" in sent[1].messages[0], false);
+            assert.strictEqual("thinking_blocks" in sent[2].messages[0], false);
+        });
+
+        test("round-trips streamed continuity and recovers after switching models", async () => {
+            const provider = setupProvider();
+            const baseConfig = { baseUrl: "https://proxy.example", apiKey: "k" };
+            seedBackendForCall(sandbox, provider, baseConfig, {
+                backendName: "proxy",
+                baseUrl: "https://proxy.example",
+                apiKey: "k",
+                client: {} as never,
+            });
+            // Use the real stream interpreter to produce the split shape:
+            // visible reasoning_content text followed by a signature-only
+            // thinking_blocks metadata entry. convertMessages must recombine
+            // these into a complete { type, thinking, signature } block.
+            const emitted = interpretStreamEvent(
+                {
+                    choices: [
+                        {
+                            delta: {
+                                reasoning_content: "Reasoning produced by the first model.",
+                                thinking_blocks: [
+                                    {
+                                        type: "thinking",
+                                        thinking: "Reasoning produced by the first model.",
+                                        signature: "signature-from-first-model",
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+                createInitialStreamingState()
+            );
+            const history = [
+                {
+                    role: vscode.LanguageModelChatMessageRole.Assistant,
+                    content: emitted,
+                },
+                {
+                    role: vscode.LanguageModelChatMessageRole.User,
+                    content: [new vscode.LanguageModelTextPart("Continue after switching models.")],
+                },
+            ] as unknown as vscode.LanguageModelChatRequestMessage[];
+            const messages = convertMessages(history);
+
+            assert.deepStrictEqual(messages[0].thinking_blocks, [
+                {
+                    type: "thinking",
+                    thinking: "Reasoning produced by the first model.",
+                    signature: "signature-from-first-model",
+                },
+            ]);
+
+            const sent: OpenAIChatCompletionRequest[] = [];
+            sandbox.stub(access(provider)._transport, "sendRequestToLiteLLM").callsFake(async (request) => {
+                sent.push(request);
+                if (sent.length === 1) {
+                    throw apiError("Invalid `signature` in `thinking` block", 400);
+                }
+                return new ReadableStream();
+            });
+
+            await access(provider).sendRequestWithRetry(
+                {
+                    model: "azure_ai/claude-haiku-4-5",
+                    messages,
+                    stream: true,
+                    reasoning_effort: "high",
+                },
+                history,
+                model,
+                { configuration: baseConfig } as unknown as vscode.ProvideLanguageModelChatResponseOptions,
+                { report: () => {} } as vscode.Progress<vscode.LanguageModelResponsePart>,
+                new vscode.CancellationTokenSource().token,
+                "chat"
+            );
+
+            assert.ok(sent[0].messages[0].thinking_blocks, "first attempt must preserve continuity");
+            assert.strictEqual("thinking_blocks" in sent[1].messages[0], false);
+            assert.strictEqual(sent[1].reasoning_effort, "high");
         });
     });
 

--- a/src/providers/test/parameterValidation.test.ts
+++ b/src/providers/test/parameterValidation.test.ts
@@ -115,6 +115,22 @@ suite("Parameter Validation from supported_openai_params", () => {
         assert.strictEqual(result, true);
     });
 
+    test("thinking is restrictable and requires explicit support", () => {
+        const modelInfo: LiteLLMModelInfo = {
+            supported_openai_params: ["reasoning_effort", "stream"],
+        };
+
+        assert.strictEqual(provider.testIsParameterSupported("thinking", modelInfo, "claude-opus-5"), false);
+    });
+
+    test("thinking is supported when listed in supported_openai_params", () => {
+        const modelInfo: LiteLLMModelInfo = {
+            supported_openai_params: ["reasoning_effort", "thinking", "stream"],
+        };
+
+        assert.strictEqual(provider.testIsParameterSupported("thinking", modelInfo, "claude-opus-5"), true);
+    });
+
     test("keeps reasoning_effort restricted when explicit effort metadata exists but the parameter is absent", () => {
         const modelInfo: LiteLLMModelInfo = {
             supports_reasoning: true,

--- a/src/providers/test/reasoningTransport.test.ts
+++ b/src/providers/test/reasoningTransport.test.ts
@@ -1,0 +1,95 @@
+import * as assert from "assert";
+import type { LiteLLMModelInfo } from "../../types";
+import { resolveChatReasoningTransport } from "../base/reasoningTransport";
+
+suite("reasoningTransport", () => {
+    const supports = (parameter: string, modelInfo: LiteLLMModelInfo | undefined): boolean =>
+        modelInfo?.supported_openai_params?.includes(parameter) === true;
+
+    test("enables adaptive thinking for confirmed Claude families", () => {
+        const modelInfo: LiteLLMModelInfo = {
+            supported_openai_params: ["reasoning_effort", "thinking"],
+        };
+
+        assert.deepStrictEqual(
+            resolveChatReasoningTransport("high", "vertex_ai/claude-opus-4-8", modelInfo, supports),
+            {
+                reasoning_effort: "high",
+                thinking: { type: "adaptive" },
+                output_config: { effort: "high" },
+            }
+        );
+        assert.deepStrictEqual(
+            resolveChatReasoningTransport("medium", "anthropic/claude-sonnet-5", modelInfo, supports).thinking,
+            { type: "adaptive" }
+        );
+        assert.deepStrictEqual(
+            resolveChatReasoningTransport("low", "claude-fable-5-1", modelInfo, supports).output_config,
+            { effort: "low" }
+        );
+    });
+
+    test("requires explicit capability for aliases and leaves Opus 4.7 and Mythos unchanged", () => {
+        const explicitInfo: LiteLLMModelInfo = {
+            supports_adaptive_thinking: true,
+            supported_openai_params: ["reasoning_effort", "thinking"],
+        };
+        const advertisedOnly: LiteLLMModelInfo = {
+            supported_openai_params: ["reasoning_effort", "thinking"],
+        };
+
+        assert.deepStrictEqual(
+            resolveChatReasoningTransport("high", "my-private-claude-alias", explicitInfo, supports).thinking,
+            { type: "adaptive" }
+        );
+        assert.deepStrictEqual(
+            resolveChatReasoningTransport("high", "anthropic/claude-opus-4-7", advertisedOnly, supports),
+            { reasoning_effort: "high" }
+        );
+        assert.deepStrictEqual(resolveChatReasoningTransport("high", "claude-mythos-5", advertisedOnly, supports), {
+            reasoning_effort: "high",
+        });
+    });
+
+    test("does not emit native fields when thinking is unavailable or effort is none", () => {
+        assert.deepStrictEqual(
+            resolveChatReasoningTransport(
+                "high",
+                "claude-opus-5",
+                { supports_adaptive_thinking: true, supported_openai_params: ["reasoning_effort"] },
+                supports
+            ),
+            { reasoning_effort: "high" }
+        );
+        assert.deepStrictEqual(
+            resolveChatReasoningTransport(
+                "none",
+                "claude-opus-5",
+                { supports_adaptive_thinking: true, supported_openai_params: ["reasoning_effort", "thinking"] },
+                supports
+            ),
+            { reasoning_effort: "none" }
+        );
+    });
+
+    test("omits reasoning when no effort is selected and keeps GPT on flat transport", () => {
+        assert.deepStrictEqual(
+            resolveChatReasoningTransport(
+                undefined,
+                "claude-opus-5",
+                { supports_adaptive_thinking: true, supported_openai_params: ["reasoning_effort", "thinking"] },
+                supports
+            ),
+            {}
+        );
+        assert.deepStrictEqual(
+            resolveChatReasoningTransport(
+                "high",
+                "azure_ai/gpt-5.6",
+                { supported_openai_params: ["reasoning_effort"] },
+                supports
+            ),
+            { reasoning_effort: "high" }
+        );
+    });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,24 @@ export interface ModelCapabilityOverride {
 
 export type SupportedReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 
+export interface LiteLLMAdaptiveThinking {
+    type: "adaptive";
+}
+
+export interface LiteLLMReasoningOutputConfig {
+    effort: string;
+}
+
+export interface LiteLLMResponsesReasoning {
+    effort: string;
+}
+
+export interface ChatReasoningTransportFields {
+    reasoning_effort?: OpenAIChatCompletionRequest["reasoning_effort"];
+    thinking?: LiteLLMAdaptiveThinking;
+    output_config?: LiteLLMReasoningOutputConfig;
+}
+
 export type ReasoningModelInfoField =
     | "supports_reasoning"
     | "supports_none_reasoning_effort"
@@ -326,6 +344,8 @@ export interface LiteLLMModelInfo {
     supports_web_search?: boolean | null;
     supports_url_context?: boolean | null;
     supports_reasoning?: boolean | null;
+    /** LiteLLM capability signal for Claude's adaptive thinking transport. */
+    supports_adaptive_thinking?: boolean | null;
     supports_computer_use?: boolean | null;
     // Pricing fields (per-token costs, USD). Optional; absent when backend does not return pricing.
     input_cost_per_token?: number | null;
@@ -420,6 +440,9 @@ export interface OpenAIChatCompletionRequest {
      * the model picker or modelOptions override.
      */
     reasoning_effort?: string | { effort: string; summary?: string };
+    /** Native adaptive-thinking fields forwarded by LiteLLM for affected Claude routes. */
+    thinking?: LiteLLMAdaptiveThinking;
+    output_config?: LiteLLMReasoningOutputConfig;
     /**
      * LiteLLM passthrough body.
      * Used for features like caching controls.
@@ -459,6 +482,10 @@ export interface LiteLLMResponsesRequest {
      * details.
      */
     reasoning_effort?: string | { effort: string; summary?: string };
+    /** Endpoint-native reasoning shape used when no explicit provider-native thinking is present. */
+    reasoning?: LiteLLMResponsesReasoning;
+    thinking?: LiteLLMAdaptiveThinking;
+    output_config?: LiteLLMReasoningOutputConfig;
     stream_options?: { include_usage?: boolean };
     /**
      * LiteLLM passthrough body.

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,17 +27,23 @@ export interface OpenAIChatMessageContentItem {
 }
 
 /**
- * Opaque reasoning continuity from a prior assistant turn.
+ * Complete Anthropic-native reasoning continuity from a prior assistant turn.
  *
- * A signature is a model-verifiable encrypted state paired with optional
- * visible summary text. `data` represents a fully redacted block and MUST
- * never be surfaced as ordinary assistant content.
+ * Normal blocks require a non-empty `thinking` summary paired with the
+ * model-verifiable `signature`. Redacted blocks carry only opaque `data`
+ * that MUST never be surfaced as ordinary assistant content. The `type`
+ * discriminant is required by Anthropic input and is always present.
  */
-export interface OpenAIThinkingBlock {
-    thinking?: string;
-    signature?: string;
-    data?: string;
-}
+export type OpenAIThinkingBlock =
+    | {
+          type: "thinking";
+          thinking: string;
+          signature: string;
+      }
+    | {
+          type: "redacted_thinking";
+          data: string;
+      };
 
 /**
  * OpenAI-style chat message used for router requests.
@@ -49,9 +55,10 @@ export interface OpenAIChatMessage {
     tool_calls?: OpenAIToolCall[];
     tool_call_id?: string;
     /**
-     * Assistant-only opaque thinking continuity. The `/responses` adapter
-     * turns these blocks into reasoning input items; `/chat/completions`
-     * deliberately ignores them because it has no portable equivalent.
+     * Assistant-only opaque thinking continuity. LiteLLM may translate these
+     * blocks into Anthropic-native message content on `/chat/completions`,
+     * while the `/responses` adapter converts them into reasoning input items.
+     * Every block must therefore be a complete discriminated wire object.
      */
     thinking_blocks?: OpenAIThinkingBlock[];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -305,6 +305,29 @@ interface ThinkingMetadata {
 }
 
 /**
+ * Extracts visible thinking text from a part's `value` field.
+ *
+ * The stream interpreter emits visible reasoning as one or more adjacent
+ * `thinking` parts whose `value` is a string (or array of string chunks).
+ * Returns the joined text when non-empty, otherwise `undefined` so callers
+ * can decide whether a later signature can bind to earlier text.
+ */
+function extractThinkingText(part: unknown): string | undefined {
+    if (!part || typeof part !== "object") {
+        return undefined;
+    }
+    const value = (part as ThinkingInputPart).value;
+    if (typeof value === "string") {
+        return value.length > 0 ? value : undefined;
+    }
+    if (Array.isArray(value) && value.every((entry) => typeof entry === "string")) {
+        const joined = value.join("");
+        return joined.length > 0 ? joined : undefined;
+    }
+    return undefined;
+}
+
+/**
  * Returns the transport-safe representation of a VS Code thinking part.
  *
  * The host may provide visible text plus an opaque encrypted state, or only
@@ -312,8 +335,16 @@ interface ThinkingMetadata {
  * representation, so it is intentionally omitted rather than leaked into
  * normal assistant content. The `/responses` adapter owns conversion of the
  * returned blocks into LiteLLM reasoning input items.
+ *
+ * Streaming splits a single Anthropic thinking block across adjacent parts:
+ * visible `reasoning_content` deltas (text) followed by a metadata-only part
+ * carrying the `signature`. `precedingThinkingText` lets the signature part
+ * bind back to the immediately preceding visible text so the reconstructed
+ * block is a complete `{ type, thinking, signature }` wire object. If no
+ * text can be paired with a signature, the block is omitted rather than
+ * serialized invalidly.
  */
-function extractOpaqueThinkingBlock(part: unknown): OpenAIThinkingBlock | undefined {
+function extractOpaqueThinkingBlock(part: unknown, precedingThinkingText: string): OpenAIThinkingBlock | undefined {
     if (!part || typeof part !== "object") {
         return undefined;
     }
@@ -326,7 +357,7 @@ function extractOpaqueThinkingBlock(part: unknown): OpenAIThinkingBlock | undefi
     const metadata = candidate.metadata as ThinkingMetadata;
     const redactedData = metadata.redactedData;
     if (typeof redactedData === "string" && redactedData.length > 0) {
-        return { data: redactedData };
+        return { type: "redacted_thinking", data: redactedData };
     }
 
     const encryptedContent = metadata.encrypted_content;
@@ -341,15 +372,8 @@ function extractOpaqueThinkingBlock(part: unknown): OpenAIThinkingBlock | undefi
         return undefined;
     }
 
-    const value = candidate.value;
-    const thinking =
-        typeof value === "string"
-            ? value
-            : Array.isArray(value) && value.every((entry) => typeof entry === "string")
-              ? value.join("")
-              : undefined;
-
-    return thinking ? { thinking, signature: opaqueState } : { signature: opaqueState };
+    const thinking = extractThinkingText(part) ?? precedingThinkingText;
+    return thinking.length > 0 ? { type: "thinking", thinking, signature: opaqueState } : undefined;
 }
 
 /**
@@ -370,11 +394,19 @@ export function convertMessages(messages: readonly vscode.LanguageModelChatReque
         const toolCalls: OpenAIToolCall[] = [];
         const toolResults: { callId: string; content: string }[] = [];
         const thinkingBlocks: OpenAIThinkingBlock[] = [];
+        // Streaming splits a thinking block into adjacent visible-text deltas
+        // followed by a signature metadata part. This accumulator binds a
+        // signature back to the immediately preceding visible text only; any
+        // non-thinking part resets it so a later signature cannot bind to the
+        // wrong block. It is message-local and never becomes assistant content.
+        let pendingThinkingText = "";
 
         for (const part of m.content ?? []) {
             if (part instanceof vscode.LanguageModelTextPart) {
+                pendingThinkingText = "";
                 textParts.push(part.value);
             } else if (part instanceof vscode.LanguageModelDataPart) {
+                pendingThinkingText = "";
                 // Handle image and other data parts
                 if (isCacheControlMimeType(part.mimeType)) {
                     // Drop cache_control metadata unconditionally (see
@@ -408,6 +440,7 @@ export function convertMessages(messages: readonly vscode.LanguageModelChatReque
                     textParts.push(textStr);
                 }
             } else if (part instanceof vscode.LanguageModelToolCallPart) {
+                pendingThinkingText = "";
                 const id = normalizeToolCallId(
                     part.callId || `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
                 );
@@ -420,6 +453,7 @@ export function convertMessages(messages: readonly vscode.LanguageModelChatReque
                 }
                 toolCalls.push({ id, type: "function", function: { name: part.name, arguments: args } });
             } else if (isToolResultPart(part)) {
+                pendingThinkingText = "";
                 const callId = normalizeToolCallId((part as { callId?: string }).callId ?? "");
                 Logger.trace(
                     `[convertMessages] Tool result: (orig: ${(part as { callId?: string }).callId}, norm: ${callId})`
@@ -427,9 +461,16 @@ export function convertMessages(messages: readonly vscode.LanguageModelChatReque
                 const content = collectToolResultText(part as { content?: readonly unknown[] });
                 toolResults.push({ callId, content });
             } else {
-                const thinkingBlock = extractOpaqueThinkingBlock(part);
+                const thinkingBlock = extractOpaqueThinkingBlock(part, pendingThinkingText);
                 if (thinkingBlock) {
                     thinkingBlocks.push(thinkingBlock);
+                    pendingThinkingText = "";
+                    continue;
+                }
+
+                const thinkingText = extractThinkingText(part);
+                if (thinkingText) {
+                    pendingThinkingText += thinkingText;
                 }
             }
         }

--- a/src/utils/test/messageNormalization.test.ts
+++ b/src/utils/test/messageNormalization.test.ts
@@ -62,6 +62,7 @@ suite("Message Normalization", () => {
             assert.strictEqual(out[0].content, "I will continue from the prior response.");
             assert.deepStrictEqual(out[0].thinking_blocks, [
                 {
+                    type: "thinking",
                     thinking: "I need to retain the prior reasoning summary.",
                     signature: "signed-thinking-state",
                 },
@@ -86,7 +87,9 @@ suite("Message Normalization", () => {
             assert.strictEqual(out.length, 1);
             assert.strictEqual(out[0].role, "assistant");
             assert.strictEqual(out[0].content, undefined);
-            assert.deepStrictEqual(out[0].thinking_blocks, [{ data: "opaque-redacted-thinking" }]);
+            assert.deepStrictEqual(out[0].thinking_blocks, [
+                { type: "redacted_thinking", data: "opaque-redacted-thinking" },
+            ]);
         });
 
         test("drops bare thinking text that has no opaque continuity state", () => {
@@ -105,6 +108,84 @@ suite("Message Normalization", () => {
             const out = convertMessages(messages as unknown as vscode.LanguageModelChatRequestMessage[]);
 
             assert.deepStrictEqual(out, []);
+        });
+
+        test("recombines adjacent streamed thinking text with its following signature", () => {
+            const messages = [
+                {
+                    role: vscode.LanguageModelChatMessageRole.Assistant,
+                    content: [
+                        { value: "first reasoning chunk " },
+                        { value: "second reasoning chunk" },
+                        { value: "", metadata: { signature: "signed-thinking-state" } },
+                        new vscode.LanguageModelTextPart("Visible answer"),
+                    ],
+                },
+            ];
+
+            const out = convertMessages(messages as unknown as vscode.LanguageModelChatRequestMessage[]);
+
+            assert.strictEqual(out.length, 1);
+            assert.strictEqual(out[0].content, "Visible answer");
+            assert.deepStrictEqual(out[0].thinking_blocks, [
+                {
+                    type: "thinking",
+                    thinking: "first reasoning chunk second reasoning chunk",
+                    signature: "signed-thinking-state",
+                },
+            ]);
+        });
+
+        test("omits a signature-only block instead of serializing an invalid native block", () => {
+            const messages = [
+                {
+                    role: vscode.LanguageModelChatMessageRole.Assistant,
+                    content: [{ value: "", metadata: { signature: "orphaned-signature" } }],
+                },
+            ];
+
+            const out = convertMessages(messages as unknown as vscode.LanguageModelChatRequestMessage[]);
+
+            assert.deepStrictEqual(out, []);
+        });
+
+        test("does not pair thinking text across an ordinary text boundary", () => {
+            const messages = [
+                {
+                    role: vscode.LanguageModelChatMessageRole.Assistant,
+                    content: [
+                        { value: "old thought" },
+                        new vscode.LanguageModelTextPart("Visible answer"),
+                        { value: "", metadata: { signature: "later-signature" } },
+                    ],
+                },
+            ];
+
+            const out = convertMessages(messages as unknown as vscode.LanguageModelChatRequestMessage[]);
+
+            assert.strictEqual(out[0].content, "Visible answer");
+            assert.strictEqual(out[0].thinking_blocks, undefined);
+        });
+
+        test("recombines multiple adjacent thinking blocks independently", () => {
+            const messages = [
+                {
+                    role: vscode.LanguageModelChatMessageRole.Assistant,
+                    content: [
+                        { value: "first thought" },
+                        { value: "", metadata: { signature: "first-signature" } },
+                        { value: "second thought" },
+                        { value: "", metadata: { signature: "second-signature" } },
+                    ],
+                },
+            ];
+
+            const out = convertMessages(messages as unknown as vscode.LanguageModelChatRequestMessage[]);
+
+            assert.deepStrictEqual(out[0].thinking_blocks, [
+                { type: "thinking", thinking: "first thought", signature: "first-signature" },
+                { type: "thinking", thinking: "second thought", signature: "second-signature" },
+            ]);
         });
     });
 


### PR DESCRIPTION
## Change Log / Overview

### 🐛 Fixes
- Harden thinking-block serialization and recombination so streamed reasoning replays safely across model switches.
- Retry once for narrowly classified continuity rejections by removing only invalid message-level thinking blocks.
- Preserve continuity redaction through context-overflow rebuilds and keep adaptive reasoning fields synchronized.
- Keep native VS Code model rows free of inline pricing while retaining pricing in details and metadata.

### 🧪 Tests
- Added regression, live-path, endpoint-fallback, and end-to-end coverage for reasoning continuity, adaptive effort fallback, streaming metadata, and model switching.

### 🧹 Chores
- Promoted the extension version from `2.5.2-dev5` to `2.5.2`.
- Updated `CHANGELOG.md`, `README.md`, and `README.marketplace.md`.

## Related Issues, Builds, Pipeline Runs, etc.
- None

## Pull Request Pre-check
- [x] Linting Validation Passed (`npm run lint`; existing warnings only)
- [x] Formatting Validation Passed (`npm run format`)
- [ ] Unit Testing Passes (`npm run test:coverage` reached the VS Code test host but the Electron renderer crashed in the container; exit code 1)
- [x] Documentation Updated

Validation summary:
- `npm run compile` — passed
- `npm run lint` — passed with 31 existing warnings, 0 errors
- `npm run format` — passed
- `npm run test:coverage` — blocked by VS Code/Electron renderer crash in the container; no tests executed and coverage was `Unknown% (0/0)`

Do not merge, tag, or publish from this workflow. Squash-merge from the web UI, then tag the release on `main` as instructed.