### PR TITLE
🛠️ Preserve adaptive Claude thinking through retries

### DIFF
--- a/src/adapters/litellmClient.ts
+++ b/src/adapters/litellmClient.ts
@@ -240,11 +240,23 @@ export class LiteLLMClient {
 
                 // 1. Handle explicit mentions of parameters in the error message
                 // Common patterns: "unsupported parameter: 'temperature'", "unexpected keyword argument 'top_p'"
-                const paramMatch = errorText.match(/(?:parameter|argument|key)\s+['"]?([a-zA-Z0-9_-]+)['"]?/i);
+                const paramMatch = errorText.match(/(?:parameter|argument|key)\s*[: ]\s*['"]?([a-zA-Z0-9_.-]+)['"]?/i);
                 if (paramMatch && paramMatch[1]) {
                     const paramName = paramMatch[1];
                     Logger.info(`Stripping specific parameter: ${paramName}`);
-                    delete stripedAsAny[paramName];
+                    const rootParam = paramName.split(".")[0];
+                    delete stripedAsAny[rootParam];
+                    // Native adaptive fields are a pair. Dropping only one leaves
+                    // a mixed request that LiteLLM can still reject or remap.
+                    if (rootParam === "thinking" || rootParam === "output_config") {
+                        delete stripedAsAny.thinking;
+                        delete stripedAsAny.output_config;
+                    }
+                }
+
+                if (errorLower.includes("thinking") || errorLower.includes("output_config")) {
+                    delete stripedAsAny.thinking;
+                    delete stripedAsAny.output_config;
                 }
 
                 // Special-case: some providers reject a top-level `cache` object.

--- a/src/adapters/test/client.test.ts
+++ b/src/adapters/test/client.test.ts
@@ -178,6 +178,41 @@ suite("LiteLLM Client Unit Tests", () => {
         assert.strictEqual(secondCallHeaders["Cache-Control"], undefined);
     });
 
+    test("chat strips thinking and output_config together on a native-field 400", async () => {
+        const client = new LiteLLMClient(config, userAgent);
+        const errorResponse = {
+            ok: false,
+            status: 400,
+            statusText: "Bad Request",
+            text: async () => "Unsupported parameter: 'thinking'",
+            clone: function () {
+                return this;
+            },
+        };
+        const successResponse = {
+            ok: true,
+            status: 200,
+            body: new ReadableStream(),
+        };
+        const fetchStub = sandbox.stub(global, "fetch");
+        fetchStub.onCall(0).resolves(errorResponse as unknown as Response);
+        fetchStub.onCall(1).resolves(successResponse as unknown as Response);
+
+        await client.chat({
+            model: "claude-opus-5",
+            messages: [],
+            thinking: { type: "adaptive", display: "summarized" },
+            output_config: { effort: "medium" },
+        });
+
+        const retryBody = JSON.parse((fetchStub.getCall(1).args[1] as RequestInit).body as string) as Record<
+            string,
+            unknown
+        >;
+        assert.strictEqual("thinking" in retryBody, false);
+        assert.strictEqual("output_config" in retryBody, false);
+    });
+
     test("chat retries by stripping specific parameter mentioned in error", async () => {
         const client = new LiteLLMClient(config, userAgent);
 

--- a/src/providers/base/reasoningRetryState.ts
+++ b/src/providers/base/reasoningRetryState.ts
@@ -1,0 +1,126 @@
+import type { LiteLLMAdaptiveThinking, OpenAIChatCompletionRequest, SupportedReasoningEffort } from "../../types";
+
+const SUPPORTED_EFFORTS: readonly SupportedReasoningEffort[] = [
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+];
+
+const SUMMARY_VALUES = ["auto", "concise", "detailed"] as const;
+type ReasoningSummary = (typeof SUMMARY_VALUES)[number];
+
+export type ReasoningRetryState =
+    | { kind: "absent" }
+    | { kind: "none"; effort: "none" }
+    | { kind: "adaptive"; effort: SupportedReasoningEffort; thinking: LiteLLMAdaptiveThinking }
+    | { kind: "flat"; effort: SupportedReasoningEffort; summary?: ReasoningSummary };
+
+function isSupportedEffort(value: unknown): value is SupportedReasoningEffort {
+    return typeof value === "string" && (SUPPORTED_EFFORTS as readonly string[]).includes(value);
+}
+
+function isSummary(value: unknown): value is ReasoningSummary {
+    return typeof value === "string" && (SUMMARY_VALUES as readonly string[]).includes(value);
+}
+
+function parseFlatEffort(
+    value: OpenAIChatCompletionRequest["reasoning_effort"]
+): { effort: SupportedReasoningEffort; summary?: ReasoningSummary } | undefined {
+    if (isSupportedEffort(value)) {
+        return { effort: value };
+    }
+
+    if (value && typeof value === "object" && isSupportedEffort(value.effort)) {
+        return isSummary(value.summary) ? { effort: value.effort, summary: value.summary } : { effort: value.effort };
+    }
+
+    return undefined;
+}
+
+/**
+ * Reads the complete reasoning representation. Missing `reasoning_effort` is
+ * not "no effort" when native adaptive fields are present.
+ */
+export function readReasoningRetryState(request: OpenAIChatCompletionRequest): ReasoningRetryState {
+    const flat = parseFlatEffort(request.reasoning_effort);
+    // Explicit `none` is a disabled signal even if leftover native fields remain.
+    if (flat?.effort === "none" || request.output_config?.effort === "none") {
+        return { kind: "none", effort: "none" };
+    }
+
+    if (request.thinking?.type === "adaptive") {
+        const adaptiveEffort = isSupportedEffort(request.output_config?.effort)
+            ? request.output_config.effort
+            : undefined;
+        if (adaptiveEffort) {
+            return {
+                kind: "adaptive",
+                effort: adaptiveEffort,
+                thinking: { ...request.thinking },
+            };
+        }
+    }
+
+    if (!flat) {
+        return { kind: "absent" };
+    }
+    return flat.summary
+        ? { kind: "flat", effort: flat.effort, summary: flat.summary }
+        : { kind: "flat", effort: flat.effort };
+}
+
+/**
+ * Applies a (possibly lowered) effort without changing representation.
+ * Absent requests are left untouched. Adaptive requests never gain
+ * `reasoning_effort`; exhausted/disabled adaptive requests drop both native fields.
+ */
+export function applyReasoningRetryState(
+    request: OpenAIChatCompletionRequest,
+    state: ReasoningRetryState,
+    effort: SupportedReasoningEffort | undefined
+): void {
+    if (state.kind === "absent") {
+        return;
+    }
+
+    if (!effort || effort === "none") {
+        if (effort === "none" || state.kind === "none") {
+            request.reasoning_effort = "none";
+        } else {
+            delete request.reasoning_effort;
+        }
+        delete request.thinking;
+        delete request.output_config;
+        return;
+    }
+
+    if (state.kind === "adaptive") {
+        delete request.reasoning_effort;
+        request.thinking = { ...state.thinking };
+        request.output_config = { effort };
+        return;
+    }
+
+    request.reasoning_effort = state.kind === "flat" && state.summary ? { effort, summary: state.summary } : effort;
+    delete request.thinking;
+    delete request.output_config;
+}
+
+/**
+ * Overwrites rebuilt request reasoning with the live retry state. Unlike
+ * {@link applyReasoningRetryState}, an absent state clears restored picker fields.
+ */
+export function replaceReasoningRetryState(request: OpenAIChatCompletionRequest, state: ReasoningRetryState): void {
+    if (state.kind === "absent") {
+        delete request.reasoning_effort;
+        delete request.thinking;
+        delete request.output_config;
+        return;
+    }
+
+    applyReasoningRetryState(request, state, state.effort);
+}

--- a/src/providers/base/reasoningTransport.ts
+++ b/src/providers/base/reasoningTransport.ts
@@ -30,9 +30,14 @@ function shouldUseAdaptiveThinking(
 
 /**
  * Resolves transport-only reasoning fields for a chat-shaped LiteLLM request.
- * Flat `reasoning_effort` remains the compatibility baseline. Native adaptive
- * fields require advertised `thinking` support and an explicit capability or
- * a confirmed affected Claude family.
+ * Flat `reasoning_effort` remains the compatibility baseline for Grok/GPT and
+ * for picker `none`. Native adaptive fields require advertised `thinking`
+ * support and an explicit capability or a confirmed affected Claude family.
+ *
+ * When adaptive extras are emitted, omit `reasoning_effort`. LiteLLM's
+ * Anthropic mapper overwrites `thinking` with `{ type: "adaptive" }` and
+ * drops `display`. `display: "summarized"` is required so newer Claude
+ * returns thinking text / `reasoning_tokens` instead of omitted blocks.
  */
 export function resolveChatReasoningTransport(
     effort: string | undefined,
@@ -44,17 +49,12 @@ export function resolveChatReasoningTransport(
         return {};
     }
 
-    const fields: ChatReasoningTransportFields = supportsParameter("reasoning_effort", modelInfo, modelId)
-        ? { reasoning_effort: effort }
-        : {};
-
-    if (effort === "none" || !shouldUseAdaptiveThinking(modelId, modelInfo, supportsParameter)) {
-        return fields;
+    if (effort !== "none" && shouldUseAdaptiveThinking(modelId, modelInfo, supportsParameter)) {
+        return {
+            thinking: { type: "adaptive", display: "summarized" },
+            output_config: { effort },
+        };
     }
 
-    return {
-        ...fields,
-        thinking: { type: "adaptive" },
-        output_config: { effort },
-    };
+    return supportsParameter("reasoning_effort", modelInfo, modelId) ? { reasoning_effort: effort } : {};
 }

--- a/src/providers/base/test/reasoningRetryState.test.ts
+++ b/src/providers/base/test/reasoningRetryState.test.ts
@@ -1,0 +1,161 @@
+import * as assert from "assert";
+import type { OpenAIChatCompletionRequest } from "../../../types";
+import { applyReasoningRetryState, readReasoningRetryState, replaceReasoningRetryState } from "../reasoningRetryState";
+
+function request(overrides: Partial<OpenAIChatCompletionRequest> = {}): OpenAIChatCompletionRequest {
+    return {
+        model: "claude-opus-5",
+        messages: [{ role: "user", content: "hi" }],
+        ...overrides,
+    };
+}
+
+suite("reasoningRetryState", () => {
+    test("reads native adaptive fields without treating missing reasoning_effort as absent", () => {
+        const state = readReasoningRetryState(
+            request({
+                thinking: { type: "adaptive", display: "summarized" },
+                output_config: { effort: "medium" },
+            })
+        );
+
+        assert.deepStrictEqual(state, {
+            kind: "adaptive",
+            effort: "medium",
+            thinking: { type: "adaptive", display: "summarized" },
+        });
+    });
+
+    test("reads string and object-form flat reasoning", () => {
+        assert.deepStrictEqual(readReasoningRetryState(request({ reasoning_effort: "high" })), {
+            kind: "flat",
+            effort: "high",
+        });
+        assert.deepStrictEqual(
+            readReasoningRetryState(request({ reasoning_effort: { effort: "low", summary: "detailed" } })),
+            {
+                kind: "flat",
+                effort: "low",
+                summary: "detailed",
+            }
+        );
+    });
+
+    test("reads explicit none and absent independently", () => {
+        assert.deepStrictEqual(readReasoningRetryState(request({ reasoning_effort: "none" })), {
+            kind: "none",
+            effort: "none",
+        });
+        assert.deepStrictEqual(readReasoningRetryState(request()), { kind: "absent" });
+    });
+
+    test("prefers adaptive representation when mixed positive fields are present", () => {
+        const state = readReasoningRetryState(
+            request({
+                reasoning_effort: "high",
+                thinking: { type: "adaptive", display: "summarized" },
+                output_config: { effort: "high" },
+            })
+        );
+
+        assert.strictEqual(state.kind, "adaptive");
+        assert.strictEqual(state.effort, "high");
+    });
+
+    test("treats explicit none as disabled even with leftover adaptive fields", () => {
+        assert.deepStrictEqual(
+            readReasoningRetryState(
+                request({
+                    reasoning_effort: "none",
+                    thinking: { type: "adaptive", display: "summarized" },
+                    output_config: { effort: "high" },
+                })
+            ),
+            { kind: "none", effort: "none" }
+        );
+    });
+
+    test("lowers adaptive effort without writing reasoning_effort or changing display", () => {
+        const adaptive = request({
+            thinking: { type: "adaptive", display: "summarized" },
+            output_config: { effort: "high" },
+        });
+
+        applyReasoningRetryState(adaptive, readReasoningRetryState(adaptive), "medium");
+
+        assert.strictEqual(adaptive.reasoning_effort, undefined);
+        assert.deepStrictEqual(adaptive.thinking, { type: "adaptive", display: "summarized" });
+        assert.deepStrictEqual(adaptive.output_config, { effort: "medium" });
+    });
+
+    test("does not mutate an absent request", () => {
+        const empty = request();
+        applyReasoningRetryState(empty, readReasoningRetryState(empty), undefined);
+        assert.strictEqual(empty.reasoning_effort, undefined);
+        assert.strictEqual(empty.thinking, undefined);
+        assert.strictEqual(empty.output_config, undefined);
+    });
+
+    test("removes native fields for none or exhausted adaptive effort", () => {
+        const adaptive = request({
+            thinking: { type: "adaptive", display: "summarized" },
+            output_config: { effort: "low" },
+        });
+        applyReasoningRetryState(adaptive, readReasoningRetryState(adaptive), "none");
+        assert.strictEqual(adaptive.reasoning_effort, "none");
+        assert.strictEqual(adaptive.thinking, undefined);
+        assert.strictEqual(adaptive.output_config, undefined);
+
+        const exhausted = request({
+            thinking: { type: "adaptive", display: "summarized" },
+            output_config: { effort: "low" },
+        });
+        applyReasoningRetryState(exhausted, readReasoningRetryState(exhausted), undefined);
+        assert.strictEqual(exhausted.reasoning_effort, undefined);
+        assert.strictEqual(exhausted.thinking, undefined);
+        assert.strictEqual(exhausted.output_config, undefined);
+    });
+
+    test("preserves object-form summary when lowering flat effort", () => {
+        const flat = request({
+            model: "gpt-5.4",
+            reasoning_effort: { effort: "high", summary: "concise" },
+        });
+
+        applyReasoningRetryState(flat, readReasoningRetryState(flat), "medium");
+
+        assert.deepStrictEqual(flat.reasoning_effort, { effort: "medium", summary: "concise" });
+        assert.strictEqual(flat.thinking, undefined);
+    });
+
+    test("replace overwrites rebuilt picker fields with the current retry state", () => {
+        const rebuilt = request({
+            thinking: { type: "adaptive", display: "summarized" },
+            output_config: { effort: "high" },
+            reasoning_effort: "high",
+        });
+
+        replaceReasoningRetryState(rebuilt, {
+            kind: "adaptive",
+            effort: "medium",
+            thinking: { type: "adaptive", display: "summarized" },
+        });
+
+        assert.strictEqual(rebuilt.reasoning_effort, undefined);
+        assert.deepStrictEqual(rebuilt.thinking, { type: "adaptive", display: "summarized" });
+        assert.deepStrictEqual(rebuilt.output_config, { effort: "medium" });
+    });
+
+    test("replace clears restored reasoning when the live state is absent", () => {
+        const rebuilt = request({
+            thinking: { type: "adaptive", display: "summarized" },
+            output_config: { effort: "high" },
+        });
+
+        replaceReasoningRetryState(rebuilt, { kind: "absent" });
+
+        assert.strictEqual(rebuilt.reasoning_effort, undefined);
+        assert.strictEqual(rebuilt.thinking, undefined);
+        assert.strictEqual(rebuilt.output_config, undefined);
+    });
+});

--- a/src/providers/base/test/transport.fallback.test.ts
+++ b/src/providers/base/test/transport.fallback.test.ts
@@ -1,10 +1,12 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
+import * as sinon from "sinon";
 import { Transport } from "../transport";
 import type { TransportDeps } from "../types";
 import type { ConfigManager } from "../../../config/configManager";
 import type { LiteLLMClient } from "../../../adapters/litellmClient";
 import type { OpenAIChatCompletionRequest, LiteLLMModelInfo } from "../../../types";
+import { StructuredLogger } from "../../../observability/structuredLogger";
 
 // Test seam: a fake LiteLLMClient that records the `mode` passed to chat()
 // and can be programmed to fail the first call with a 500-shaped error.
@@ -194,5 +196,41 @@ suite("Transport /responses -> /chat/completions fallback", () => {
             assert.deepStrictEqual(sent.output_config, { effort: "high" });
             assert.ok(sent.messages[0].thinking_blocks);
         }
+    });
+
+    test("logs sanitized adaptive representation without payloads", async () => {
+        const fake = new FakeLiteLLMClient({ url: "https://x", key: "k" }, "test-ua");
+        const transport = new Transport(makeDeps(fake));
+        const infoStub = sinon.stub(StructuredLogger, "info");
+
+        try {
+            await transport.sendRequestToLiteLLM(
+                {
+                    model: "claude-opus-5",
+                    messages: [{ role: "user", content: "secret prompt" }],
+                    thinking: { type: "adaptive", display: "summarized" },
+                    output_config: { effort: "medium" },
+                    stream: true,
+                } as OpenAIChatCompletionRequest,
+                { report: () => {} } as unknown as vscode.Progress<vscode.LanguageModelResponsePart>,
+                new vscode.CancellationTokenSource().token,
+                "chat",
+                chatModelInfo,
+                { baseUrl: "https://x", apiKey: "k" }
+            );
+        } finally {
+            infoStub.restore();
+        }
+
+        const start = infoStub
+            .getCalls()
+            .map((call) => ({ event: call.args[0], data: call.args[1] as Record<string, unknown> }))
+            .find((entry) => entry.event === "transport.http_request_start");
+        assert.ok(start);
+        assert.strictEqual(start.data.reasoning_representation, "adaptive");
+        assert.strictEqual(start.data.reasoning_effort, "medium");
+        assert.strictEqual(start.data.thinking_display, "summarized");
+        assert.strictEqual(start.data.has_thinking, true);
+        assert.strictEqual(JSON.stringify(start.data).includes("secret prompt"), false);
     });
 });

--- a/src/providers/base/transport.ts
+++ b/src/providers/base/transport.ts
@@ -4,6 +4,7 @@ import { isContextOverflowError } from "../../adapters/tokenUtils";
 import { StructuredLogger } from "../../observability/structuredLogger";
 import type { LiteLLMModelInfo, OpenAIChatCompletionRequest } from "../../types";
 import type { SendRequestArgs, TransportDeps } from "./types";
+import { readReasoningRetryState } from "./reasoningRetryState";
 
 /**
  * Sends a LiteLLM request to the configured endpoint.
@@ -107,14 +108,17 @@ export class Transport {
         this.logger.info(
             `[transport.sendRequestToLiteLLM] Sending request to LiteLLM: model=${request.model} caller=${caller} streaming=true`
         );
+        const reasoningState = readReasoningRetryState(request);
         StructuredLogger.info("transport.http_request_start", {
             model: request.model,
             caller,
             endpoint: modelInfo?.mode,
             requestModel: request.model,
-            reasoning_effort: (request as { reasoning_effort?: string }).reasoning_effort,
-            has_thinking: (request as { thinking?: unknown }).thinking !== undefined,
-            has_output_config: (request as { output_config?: unknown }).output_config !== undefined,
+            reasoning_representation: reasoningState.kind,
+            reasoning_effort: reasoningState.kind === "absent" ? undefined : reasoningState.effort,
+            thinking_display: request.thinking?.display,
+            has_thinking: request.thinking !== undefined,
+            has_output_config: request.output_config !== undefined,
             max_tokens: request.max_tokens,
             temperature: request.temperature,
             top_p: request.top_p,

--- a/src/providers/liteLLMProviderBase.ts
+++ b/src/providers/liteLLMProviderBase.ts
@@ -37,6 +37,11 @@ import {
     requestHasThinkingBlocks,
     stripThinkingBlocksFromRequest,
 } from "./base/thinkingBlockRetry";
+import {
+    applyReasoningRetryState,
+    readReasoningRetryState,
+    replaceReasoningRetryState,
+} from "./base/reasoningRetryState";
 import { LiteLLMProviderRegistry } from "./liteLLMProviderRegistry";
 import {
     detectQuotaToolRedaction as detectQuotaToolRedactionImpl,
@@ -580,13 +585,14 @@ export abstract class LiteLLMProviderBase {
         // the usage/reasoning/continuity retries operate on `currentRequest`.
         let currentRequest = request;
         const modelId = currentRequest.model;
+        const reasoningState = readReasoningRetryState(currentRequest);
+        const originalEffort = reasoningState.kind === "absent" ? undefined : reasoningState.effort;
         Logger.debug(
-            `[sendRequestWithRetry] modelId: ${modelId}, reasoning_effort: ${currentRequest.reasoning_effort}`
+            `[sendRequestWithRetry] modelId: ${modelId}, reasoningKind: ${reasoningState.kind}, reasoning_effort: ${currentRequest.reasoning_effort}`
         );
-        const originalEffort = (currentRequest as { reasoning_effort?: SupportedReasoningEffort }).reasoning_effort;
         let effectiveEffort = this._effortFallbackCache.getEffectiveEffort(modelId, originalEffort);
         Logger.debug(`[sendRequestWithRetry] originalEffort: ${originalEffort}, effectiveEffort: ${effectiveEffort}`);
-        this.applyReasoningEffort(currentRequest, effectiveEffort);
+        applyReasoningRetryState(currentRequest, reasoningState, effectiveEffort);
 
         const notificationKeyEffort = originalEffort ?? effectiveEffort;
         let attempts = 0;
@@ -677,7 +683,7 @@ export abstract class LiteLLMProviderBase {
 
                 const previous = effectiveEffort;
                 effectiveEffort = nextEffort;
-                this.applyReasoningEffort(currentRequest, effectiveEffort);
+                applyReasoningRetryState(currentRequest, reasoningState, effectiveEffort);
 
                 if (notificationKeyEffort && previous && previous !== effectiveEffort) {
                     this.notifyReasoningFallback(modelId, notificationKeyEffort, effectiveEffort);
@@ -727,37 +733,16 @@ export abstract class LiteLLMProviderBase {
         effort: SupportedReasoningEffort | undefined,
         summary?: "auto" | "concise" | "detailed"
     ): void {
-        if (!effort) {
-            delete request.reasoning_effort;
-            // Removing effort also invalidates adaptive Claude reasoning, whose
-            // `thinking` and `output_config.effort` must always agree with
-            // `reasoning_effort`. Drop them together so a partially-downgraded
-            // request never sends an incoherent adaptive shape.
-            delete request.thinking;
-            delete request.output_config;
-            return;
-        }
-        // Object form is used by `gpt-5.4+` callers (and the OpenAI Responses API
-        // in general) to control whether summary text is returned alongside the
-        // reasoning text. The OpenAI Chat Completions spec still accepts the
-        // legacy string form; both are forwarded to LiteLLM unchanged.
-        request.reasoning_effort = summary ? { effort, summary } : effort;
-
-        // `none` is a valid wire value but signals no reasoning, so the adaptive
-        // Claude native fields must not be sent alongside it.
-        if (effort === "none") {
-            delete request.thinking;
-            delete request.output_config;
-            return;
-        }
-
-        // Keep an already-adaptive request coherent: when the existing fallback
-        // changes effort, `output_config.effort` must agree. This never creates
-        // adaptive fields on a non-adaptive request; it only updates an existing
-        // adaptive `output_config` so the two fields stay synchronized.
-        if (request.thinking?.type === "adaptive") {
-            request.output_config = { effort };
-        }
+        const current = readReasoningRetryState(request);
+        const state =
+            current.kind !== "absent"
+                ? current
+                : !effort
+                  ? current
+                  : effort === "none"
+                    ? { kind: "none" as const, effort: "none" as const }
+                    : { kind: "flat" as const, effort, summary };
+        applyReasoningRetryState(request, state, effort);
     }
 
     private notifyReasoningFallback(
@@ -822,6 +807,9 @@ export abstract class LiteLLMProviderBase {
             const retrimmedRequest = stripThinkingBlocksForRetry
                 ? stripThinkingBlocksFromRequest(rebuiltRequest)
                 : rebuiltRequest;
+            // Overflow rebuilds from the original picker options, so re-stamp
+            // the live retry representation instead of restoring picker effort.
+            replaceReasoningRetryState(retrimmedRequest, readReasoningRetryState(request));
 
             try {
                 return await this.sendRequestToLiteLLM(

--- a/src/providers/test/liteLLMProviderBase.requestBuilder.test.ts
+++ b/src/providers/test/liteLLMProviderBase.requestBuilder.test.ts
@@ -248,8 +248,8 @@ suite("RequestBuilder", () => {
             "test"
         );
 
-        assert.strictEqual(request.reasoning_effort, "high");
-        assert.deepStrictEqual(request.thinking, { type: "adaptive" });
+        assert.strictEqual(request.reasoning_effort, undefined);
+        assert.deepStrictEqual(request.thinking, { type: "adaptive", display: "summarized" });
         assert.deepStrictEqual(request.output_config, { effort: "high" });
     });
 

--- a/src/providers/test/liteLLMProviderBase.test.ts
+++ b/src/providers/test/liteLLMProviderBase.test.ts
@@ -362,6 +362,45 @@ suite("LiteLLMProviderBase", () => {
             return new LiteLLMChatProvider(mockSecrets, userAgent, new EffortFallbackCache());
         }
 
+        async function captureFirstSend(
+            provider: LiteLLMChatProvider,
+            request: OpenAIChatCompletionRequest
+        ): Promise<OpenAIChatCompletionRequest> {
+            const baseConfig = { baseUrl: "https://wolfram.example", apiKey: "k" };
+            seedBackendForCall(sandbox, provider, baseConfig, {
+                backendName: "wolfram",
+                baseUrl: "https://wolfram.example",
+                apiKey: "k",
+                client: {} as never,
+            });
+            const captured: OpenAIChatCompletionRequest[] = [];
+            sandbox.stub(access(provider)._transport, "sendRequestToLiteLLM").callsFake(async (candidate) => {
+                captured.push({
+                    ...candidate,
+                    thinking: candidate.thinking ? { ...candidate.thinking } : undefined,
+                    output_config: candidate.output_config ? { ...candidate.output_config } : undefined,
+                    reasoning_effort:
+                        typeof candidate.reasoning_effort === "object" && candidate.reasoning_effort
+                            ? { ...candidate.reasoning_effort }
+                            : candidate.reasoning_effort,
+                });
+                return new ReadableStream();
+            });
+
+            await access(provider).sendRequestWithRetry(
+                request,
+                [],
+                model,
+                { configuration: baseConfig } as unknown as vscode.ProvideLanguageModelChatResponseOptions,
+                { report: () => {} } as vscode.Progress<vscode.LanguageModelResponsePart>,
+                new vscode.CancellationTokenSource().token,
+                "test"
+            );
+
+            assert.ok(captured[0], "expected a first transport send");
+            return captured[0];
+        }
+
         test("retries once on reasoning 4xx and succeeds", async () => {
             const provider = setupProvider();
             const baseConfig = { baseUrl: "https://wolfram.example", apiKey: "k", reasoningEffort: "high" };
@@ -619,6 +658,76 @@ suite("LiteLLMProviderBase", () => {
             assert.ok(capturedRequests[0].reasoning_effort !== "high", "should have downgraded before first send");
         });
 
+        test("preserves native-only adaptive fields on the first HTTP send", async () => {
+            const provider = setupProvider();
+            const first = await captureFirstSend(provider, {
+                model: "claude-opus-5",
+                messages: [{ role: "user", content: "hi" }],
+                thinking: { type: "adaptive", display: "summarized" },
+                output_config: { effort: "medium" },
+            } as OpenAIChatCompletionRequest);
+
+            assert.strictEqual(first.reasoning_effort, undefined);
+            assert.deepStrictEqual(first.thinking, { type: "adaptive", display: "summarized" });
+            assert.deepStrictEqual(first.output_config, { effort: "medium" });
+        });
+
+        test("keeps a cached adaptive downgrade native on the first HTTP send", async () => {
+            const provider = setupProvider();
+            access(provider)._effortFallbackCache.recordFailure("claude-opus-5", "high");
+
+            const first = await captureFirstSend(provider, {
+                model: "claude-opus-5",
+                messages: [{ role: "user", content: "hi" }],
+                thinking: { type: "adaptive", display: "summarized" },
+                output_config: { effort: "high" },
+            } as OpenAIChatCompletionRequest);
+
+            assert.strictEqual(first.reasoning_effort, undefined);
+            assert.deepStrictEqual(first.thinking, { type: "adaptive", display: "summarized" });
+            assert.deepStrictEqual(first.output_config, { effort: "medium" });
+        });
+
+        test("does not add or remove reasoning fields when no effort is present", async () => {
+            const provider = setupProvider();
+            const first = await captureFirstSend(provider, {
+                model: "claude-opus-5",
+                messages: [{ role: "user", content: "hi" }],
+            });
+
+            assert.strictEqual(first.reasoning_effort, undefined);
+            assert.strictEqual(first.thinking, undefined);
+            assert.strictEqual(first.output_config, undefined);
+        });
+
+        test("keeps explicit none free of adaptive fields", async () => {
+            const provider = setupProvider();
+            const first = await captureFirstSend(provider, {
+                model: "claude-opus-5",
+                messages: [{ role: "user", content: "hi" }],
+                reasoning_effort: "none",
+                thinking: { type: "adaptive", display: "summarized" },
+                output_config: { effort: "high" },
+            } as OpenAIChatCompletionRequest);
+
+            assert.strictEqual(first.reasoning_effort, "none");
+            assert.strictEqual(first.thinking, undefined);
+            assert.strictEqual(first.output_config, undefined);
+        });
+
+        test("preserves object-form flat reasoning summary on the first HTTP send", async () => {
+            const provider = setupProvider();
+            const first = await captureFirstSend(provider, {
+                model: "gpt-5.4",
+                messages: [{ role: "user", content: "hi" }],
+                reasoning_effort: { effort: "high", summary: "detailed" },
+            });
+
+            assert.deepStrictEqual(first.reasoning_effort, { effort: "high", summary: "detailed" });
+            assert.strictEqual(first.thinking, undefined);
+            assert.strictEqual(first.output_config, undefined);
+        });
+
         test("retries once without thinking_blocks on a model-switch continuity rejection", async () => {
             const provider = setupProvider();
             const baseConfig = { baseUrl: "https://wolfram.example", apiKey: "k" };
@@ -641,8 +750,7 @@ suite("LiteLLMProviderBase", () => {
             const request: OpenAIChatCompletionRequest = {
                 model: "claude-opus-5",
                 stream: true,
-                reasoning_effort: "high",
-                thinking: { type: "adaptive" },
+                thinking: { type: "adaptive", display: "summarized" },
                 output_config: { effort: "high" },
                 messages: [
                     {
@@ -673,8 +781,8 @@ suite("LiteLLMProviderBase", () => {
             sinon.assert.calledTwice(sendStub);
             assert.ok(requests[0].messages[0].thinking_blocks, "first attempt must retain continuity");
             assert.strictEqual("thinking_blocks" in requests[1].messages[0], false);
-            assert.strictEqual(requests[1].reasoning_effort, "high");
-            assert.deepStrictEqual(requests[1].thinking, { type: "adaptive" });
+            assert.strictEqual(requests[1].reasoning_effort, undefined);
+            assert.deepStrictEqual(requests[1].thinking, { type: "adaptive", display: "summarized" });
             assert.deepStrictEqual(requests[1].output_config, { effort: "high" });
         });
 
@@ -739,10 +847,9 @@ suite("LiteLLMProviderBase", () => {
                 {
                     model: "claude-opus-5",
                     messages: [{ role: "user", content: "hi" }],
-                    reasoning_effort: "high",
-                    thinking: { type: "adaptive" },
+                    thinking: { type: "adaptive", display: "summarized" },
                     output_config: { effort: "high" },
-                },
+                } as OpenAIChatCompletionRequest,
                 [],
                 model,
                 { configuration: baseConfig } as unknown as vscode.ProvideLanguageModelChatResponseOptions,
@@ -751,8 +858,8 @@ suite("LiteLLMProviderBase", () => {
                 "test"
             );
 
-            assert.strictEqual(requests[1].reasoning_effort, "medium");
-            assert.deepStrictEqual(requests[1].thinking, { type: "adaptive" });
+            assert.strictEqual(requests[1].reasoning_effort, undefined);
+            assert.deepStrictEqual(requests[1].thinking, { type: "adaptive", display: "summarized" });
             assert.deepStrictEqual(requests[1].output_config, { effort: "medium" });
         });
 
@@ -862,6 +969,66 @@ suite("LiteLLMProviderBase", () => {
             assert.ok(sent[0].messages[0].thinking_blocks);
             assert.strictEqual("thinking_blocks" in sent[1].messages[0], false);
             assert.strictEqual("thinking_blocks" in sent[2].messages[0], false);
+        });
+
+        test("does not restore original adaptive effort after overflow rebuild", async () => {
+            const provider = setupProvider();
+            const baseConfig = { baseUrl: "https://wolfram.example", apiKey: "k" };
+            seedBackendForCall(sandbox, provider, baseConfig, {
+                backendName: "wolfram",
+                baseUrl: "https://wolfram.example",
+                apiKey: "k",
+                client: {} as never,
+            });
+            sandbox.stub(access(provider), "buildOpenAIChatRequest").resolves({
+                model: "claude-opus-5",
+                stream: true,
+                max_tokens: 100,
+                thinking: { type: "adaptive", display: "summarized" },
+                output_config: { effort: "high" },
+                messages: [{ role: "user", content: "trimmed" }],
+            } as OpenAIChatCompletionRequest);
+            const sent: OpenAIChatCompletionRequest[] = [];
+            sandbox.stub(access(provider)._transport, "sendRequestToLiteLLM").callsFake(async (candidate) => {
+                sent.push({
+                    ...candidate,
+                    thinking: candidate.thinking ? { ...candidate.thinking } : undefined,
+                    output_config: candidate.output_config ? { ...candidate.output_config } : undefined,
+                });
+                if (sent.length === 1) {
+                    throw new Error("context length exceeded");
+                }
+                return new ReadableStream();
+            });
+
+            await access(provider).sendRequestWithRetry(
+                {
+                    model: "claude-opus-5",
+                    stream: true,
+                    max_tokens: 100,
+                    thinking: { type: "adaptive", display: "summarized" },
+                    output_config: { effort: "medium" },
+                    messages: [{ role: "user", content: "hi" }],
+                } as OpenAIChatCompletionRequest,
+                [
+                    {
+                        role: vscode.LanguageModelChatMessageRole.User,
+                        name: undefined,
+                        content: [new vscode.LanguageModelTextPart("hi")],
+                    },
+                ],
+                model,
+                { configuration: baseConfig } as unknown as vscode.ProvideLanguageModelChatResponseOptions,
+                { report: () => {} } as vscode.Progress<vscode.LanguageModelResponsePart>,
+                new vscode.CancellationTokenSource().token,
+                "test",
+                { mode: "chat", max_input_tokens: 1000 } as unknown as LiteLLMModelInfo
+            );
+
+            assert.strictEqual(sent.length, 2);
+            assert.strictEqual(sent[1].reasoning_effort, undefined);
+            assert.deepStrictEqual(sent[1].thinking, { type: "adaptive", display: "summarized" });
+            assert.deepStrictEqual(sent[1].output_config, { effort: "medium" });
         });
 
         test("round-trips streamed continuity and recovers after switching models", async () => {

--- a/src/providers/test/reasoningTransport.test.ts
+++ b/src/providers/test/reasoningTransport.test.ts
@@ -14,14 +14,13 @@ suite("reasoningTransport", () => {
         assert.deepStrictEqual(
             resolveChatReasoningTransport("high", "vertex_ai/claude-opus-4-8", modelInfo, supports),
             {
-                reasoning_effort: "high",
-                thinking: { type: "adaptive" },
+                thinking: { type: "adaptive", display: "summarized" },
                 output_config: { effort: "high" },
             }
         );
         assert.deepStrictEqual(
             resolveChatReasoningTransport("medium", "anthropic/claude-sonnet-5", modelInfo, supports).thinking,
-            { type: "adaptive" }
+            { type: "adaptive", display: "summarized" }
         );
         assert.deepStrictEqual(
             resolveChatReasoningTransport("low", "claude-fable-5-1", modelInfo, supports).output_config,
@@ -38,10 +37,12 @@ suite("reasoningTransport", () => {
             supported_openai_params: ["reasoning_effort", "thinking"],
         };
 
-        assert.deepStrictEqual(
-            resolveChatReasoningTransport("high", "my-private-claude-alias", explicitInfo, supports).thinking,
-            { type: "adaptive" }
-        );
+        const alias = resolveChatReasoningTransport("high", "my-private-claude-alias", explicitInfo, supports);
+        assert.deepStrictEqual(alias, {
+            thinking: { type: "adaptive", display: "summarized" },
+            output_config: { effort: "high" },
+        });
+        assert.ok(!("reasoning_effort" in alias));
         assert.deepStrictEqual(
             resolveChatReasoningTransport("high", "anthropic/claude-opus-4-7", advertisedOnly, supports),
             { reasoning_effort: "high" }

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,6 +128,11 @@ export type SupportedReasoningEffort = "none" | "minimal" | "low" | "medium" | "
 
 export interface LiteLLMAdaptiveThinking {
     type: "adaptive";
+    /**
+     * Ask Anthropic to return thinking summaries. Omitted display still
+     * thinks but reports `reasoning_tokens: 0` and empty thinking parts.
+     */
+    display?: "summarized";
 }
 
 export interface LiteLLMReasoningOutputConfig {

--- a/src/utils/reasoningEffortFallback.ts
+++ b/src/utils/reasoningEffortFallback.ts
@@ -128,6 +128,23 @@ export function isReasoningError(error: unknown): boolean {
     }
 
     Logger.debug(`[isReasoningError] status: ${status}, text: ${text}`);
+    // Continuity rejections mention thinking blocks/signatures and must stay
+    // on the one-shot redaction path, not the effort-fallback ladder.
+    if (text.includes("thinking_blocks") || text.includes("signature")) {
+        return false;
+    }
+
+    if (text.includes("output_config")) {
+        return true;
+    }
+
+    if (
+        text.includes("thinking") &&
+        (text.includes("parameter") || text.includes("unsupported") || text.includes("unknown"))
+    ) {
+        return true;
+    }
+
     return text.includes("reasoning") && (text.includes("effort") || text.includes("parameter"));
 }
 

--- a/src/utils/test/reasoningEffortFallback.test.ts
+++ b/src/utils/test/reasoningEffortFallback.test.ts
@@ -102,6 +102,28 @@ suite("reasoningEffortFallback", () => {
 
             assert.strictEqual(isReasoningError(error), true);
         });
+
+        test("returns true for thinking and output_config compatibility 4xx", () => {
+            assert.strictEqual(
+                isReasoningError(buildError({ status: 400, message: "Unsupported parameter: 'thinking'" })),
+                true
+            );
+            assert.strictEqual(
+                isReasoningError(buildError({ status: 400, message: "unknown parameter output_config.effort" })),
+                true
+            );
+        });
+
+        test("returns false for thinking-block signature continuity 4xx", () => {
+            assert.strictEqual(
+                isReasoningError(buildError({ status: 400, message: "Invalid `signature` in `thinking` block" })),
+                false
+            );
+            assert.strictEqual(
+                isReasoningError(buildError({ status: 400, message: "thinking_blocks are not valid for this model" })),
+                false
+            );
+        });
     });
 
     test("clear resets cached failures", () => {


### PR DESCRIPTION
## Summary

Proposed follow-up to closed #134 / PR #136. I ran into a remaining gap on v2.5.2 where a selected adaptive Claude effort still did not reliably reach LiteLLM, so summarized thinking was missing even though thinking signatures could appear.

I am not sure this is the cleanest place to fix it — you know this retry path better than I do. If you would rather handle it differently, I am happy to close this or reshape it.

Related: umbrella #133. Prompt cache remains #135 and is not in this change.

## What I still see on v2.5.2

v2.5.2 already enables adaptive `thinking` and signed `thinking_blocks`. On live Opus 5 turns, though, the selected effort still did not survive to LiteLLM in the native shape:

1. The request builder can send native `thinking` **and** flat `reasoning_effort`. LiteLLM may remap that overlapping field and overwrite `thinking`, so `display: "summarized"` never arrives. Responses then look like thinking ran (`thinking` signatures) but `reasoning_tokens` stays `0` and summaries are omitted.
2. If `reasoning_effort` is omitted so `display` can survive, retry init still reads only that flat field. Native-only adaptive requests look like “no effort”, and `thinking` / `output_config` are deleted **before the first HTTP send**. Live Low / High / Medium then log `has_thinking: false`.

GPT / Grok on flat `reasoning_effort` looked fine.

## Proposed approach

Keep one native adaptive representation through first send, cached fallback, live fallback, overflow rebuild, and continuity retry:

```json
{
  "thinking": { "type": "adaptive", "display": "summarized" },
  "output_config": { "effort": "medium" }
}
```

and omit `reasoning_effort` on that path. Flat models stay on `reasoning_effort` only.

I extracted a small read/apply helper so retry state comes from the full representation (`thinking` + `output_config`, or flat `reasoning_effort`), not from `reasoning_effort` alone.

Version bump left out on purpose.

## Validation

- `npm run compile` / `lint` / `format` / `test:coverage`
- Live Low → High → Medium Opus 5, plus one Sonnet 5 High, after installing a rebuilt VSIX (Reload Window is not enough)
- Those outbound requests stayed `adaptive` with matching effort and `display: "summarized"`
- Visible thinking parts / `reasoning_tokens > 0` on the turns that actually thought
- Grok stayed flat (`reasoning_effort` only)

Happy to adjust if you would rather reopen #134, open a new follow-up, or take a different approach in the retry coordinator.
