### PR TITLE
⚡ Enable Anthropic prompt caching for eligible models (#135)

### DIFF
--- a/scripts/test-coverage.mjs
+++ b/scripts/test-coverage.mjs
@@ -67,8 +67,9 @@ const hasXvfb =
 
 let child;
 if (hasXvfb) {
-  // xvfb-run wraps the entire command
-  child = spawn("xvfb-run", ["vscode-test", ...testArgs], {
+  // Pick an unused display so stale or parallel WSL test sessions cannot
+  // collide with xvfb-run's default :99 display.
+  child = spawn("xvfb-run", ["-a", "vscode-test", ...testArgs], {
     stdio: "inherit",
     env: process.env,
   });

--- a/src/adapters/litellmClient.ts
+++ b/src/adapters/litellmClient.ts
@@ -227,7 +227,8 @@ export class LiteLLMClient {
                 errorLower.includes("unknown parameter") ||
                 errorLower.includes("extra_headers") ||
                 errorLower.includes("no-cache") ||
-                errorLower.includes("unexpected keyword argument")
+                errorLower.includes("unexpected keyword argument") ||
+                errorLower.includes("cache_control")
             ) {
                 Logger.warn(`Detected unsupported parameters for ${request.model}, attempting to strip and retry.`);
 
@@ -261,6 +262,13 @@ export class LiteLLMClient {
                 if (errorLower.includes("thinking") || errorLower.includes("output_config")) {
                     delete stripedAsAny.thinking;
                     delete stripedAsAny.output_config;
+                }
+
+                // Azure AI says "Unrecognized request argument supplied:
+                // cache_control". The generic regex captures "supplied", so
+                // always strip Path 1 / block stamps when the name appears.
+                if (errorLower.includes("cache_control")) {
+                    this.stripPromptCacheControls(strippedBody);
                 }
 
                 // Special-case: some providers reject a top-level `cache` object.

--- a/src/adapters/litellmClient.ts
+++ b/src/adapters/litellmClient.ts
@@ -11,6 +11,7 @@ import type {
 import { transformToResponsesFormat } from "./responsesAdapter";
 import { Logger } from "../utils/logger";
 import { isAnthropicModel } from "../utils/modelUtils";
+import { stripCacheBreakpoints } from "../utils/promptCacheControl";
 import type { TelemetryService } from "../telemetry/telemetryService";
 
 /**
@@ -246,6 +247,9 @@ export class LiteLLMClient {
                     Logger.info(`Stripping specific parameter: ${paramName}`);
                     const rootParam = paramName.split(".")[0];
                     delete stripedAsAny[rootParam];
+                    if (rootParam === "cache_control") {
+                        this.stripPromptCacheControls(strippedBody);
+                    }
                     // Native adaptive fields are a pair. Dropping only one leaves
                     // a mixed request that LiteLLM can still reject or remap.
                     if (rootParam === "thinking" || rootParam === "output_config") {
@@ -368,6 +372,24 @@ export class LiteLLMClient {
 
     private hasCacheBypassControl(body: OpenAIChatCompletionRequest | LiteLLMResponsesRequest | undefined): boolean {
         return body?.extra_body?.cache?.["no-cache"] === true;
+    }
+
+    /**
+     * Removes only Anthropic prompt-cache controls after the provider rejected
+     * `cache_control`. LiteLLM response caching under `extra_body.cache` is a
+     * separate feature and must survive this retry unchanged.
+     */
+    private stripPromptCacheControls(body: OpenAIChatCompletionRequest | LiteLLMResponsesRequest): void {
+        delete body.cache_control;
+        if ("messages" in body) {
+            stripCacheBreakpoints(body.messages);
+            return;
+        }
+        for (const input of body.input) {
+            if ("cache_control" in input) {
+                delete input.cache_control;
+            }
+        }
     }
 
     private getEndpoint(mode?: string): string {

--- a/src/adapters/responsesAdapter.ts
+++ b/src/adapters/responsesAdapter.ts
@@ -231,6 +231,7 @@ export function transformToResponsesFormat(requestBody: OpenAIChatCompletionRequ
     const responsesBody: LiteLLMResponsesRequest = {
         model: requestBody.model,
         input: finalInputArray,
+        cache_control: requestBody.cache_control,
         stream: requestBody.stream,
         instructions,
         max_tokens: requestBody.max_tokens,

--- a/src/adapters/streaming/liteLLMStreamInterpreter.ts
+++ b/src/adapters/streaming/liteLLMStreamInterpreter.ts
@@ -51,18 +51,31 @@ export function createInitialStreamingState(): StreamingState {
     };
 }
 
+interface RawUsagePromptTokenDetails {
+    cached_tokens?: number;
+    cache_creation_input_tokens?: number;
+}
+
 interface RawUsagePayload {
     prompt_tokens?: number;
     completion_tokens?: number;
     system_tokens?: number;
-    prompt_tokens_details?: { cached_tokens?: number; cache_creation_input_tokens?: number };
+    /**
+     * Anthropic reports prompt-cache accounting at the usage root rather than
+     * inside `prompt_tokens_details`. LiteLLM forwards the native shape
+     * unchanged for Claude models, so these are the only fields carrying cache
+     * write/read counts on that path.
+     */
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+    prompt_tokens_details?: RawUsagePromptTokenDetails;
     completion_tokens_details?: {
         reasoning_tokens?: number;
         tool_tokens?: number;
         accepted_prediction_tokens?: number;
         rejected_prediction_tokens?: number;
     };
-    input_token_details?: { cached_tokens?: number; cache_creation_input_tokens?: number };
+    input_token_details?: RawUsagePromptTokenDetails;
     output_token_details?: {
         reasoning_tokens?: number;
         tool_tokens?: number;
@@ -71,18 +84,30 @@ interface RawUsagePayload {
     };
 }
 
+function firstNumber(...values: (number | undefined)[]): number | undefined {
+    return values.find((value) => typeof value === "number");
+}
+
 function normalizeUsagePayload(usage: RawUsagePayload): OpenAIUsagePayload {
     const promptTokenDetails: OpenAIUsagePromptTokenDetails = {};
-    const cachedTokens = usage.prompt_tokens_details?.cached_tokens ?? usage.input_token_details?.cached_tokens;
+    const cachedTokens = firstNumber(
+        usage.prompt_tokens_details?.cached_tokens,
+        usage.input_token_details?.cached_tokens,
+        usage.cache_read_input_tokens
+    );
     if (typeof cachedTokens === "number") {
         promptTokenDetails.cached_tokens = cachedTokens;
     } else if (usage.input_token_details !== undefined || usage.prompt_tokens_details !== undefined) {
         promptTokenDetails.cached_tokens = 0;
     }
 
-    const cacheCreationInputTokens =
-        usage.prompt_tokens_details?.cache_creation_input_tokens ??
-        usage.input_token_details?.cache_creation_input_tokens;
+    // Nested OpenAI-compatible details win over the Anthropic root fields so a
+    // proxy that already normalized the payload is never second-guessed.
+    const cacheCreationInputTokens = firstNumber(
+        usage.prompt_tokens_details?.cache_creation_input_tokens,
+        usage.input_token_details?.cache_creation_input_tokens,
+        usage.cache_creation_input_tokens
+    );
     if (typeof cacheCreationInputTokens === "number") {
         promptTokenDetails.cache_creation_input_tokens = cacheCreationInputTokens;
     }

--- a/src/adapters/streaming/test/liteLLMStreamInterpreter.test.ts
+++ b/src/adapters/streaming/test/liteLLMStreamInterpreter.test.ts
@@ -485,6 +485,84 @@ suite("LiteLLMStreamInterpreter - Tool Call Regressions", () => {
         assert.deepStrictEqual(parts, []);
     });
 
+    // Anthropic reports prompt-cache accounting at the usage root, not inside
+    // prompt_tokens_details. Without these mappings a Claude cache write is
+    // invisible to the cost pipeline and every turn looks uncached.
+    test("should map Anthropic root cache write and read tokens into prompt details", () => {
+        const state = createInitialStreamingState();
+        const parts = interpretStreamEvent(
+            {
+                usage: {
+                    prompt_tokens: 40000,
+                    completion_tokens: 12,
+                    total_tokens: 40012,
+                    cache_creation_input_tokens: 39482,
+                    cache_read_input_tokens: 0,
+                    prompt_tokens_details: { cached_tokens: 0 },
+                },
+            },
+            state
+        );
+
+        const usage = parts.find((part) => part.type === "data");
+        assert.ok(usage && usage.type === "data");
+        if (usage.type === "data") {
+            assert.deepStrictEqual(usage.value, {
+                prompt_tokens: 40000,
+                completion_tokens: 12,
+                total_tokens: 40012,
+                prompt_tokens_details: {
+                    cached_tokens: 0,
+                    cache_creation_input_tokens: 39482,
+                },
+            });
+        }
+    });
+
+    test("should read root cache_read_input_tokens when no nested cached count exists", () => {
+        const state = createInitialStreamingState();
+        const parts = interpretStreamEvent(
+            { usage: { prompt_tokens: 38689, completion_tokens: 39, cache_read_input_tokens: 38368 } },
+            state
+        );
+
+        const usage = parts.find((part) => part.type === "data");
+        assert.ok(usage && usage.type === "data");
+        if (usage.type === "data") {
+            assert.deepStrictEqual((usage.value as { prompt_tokens_details?: object }).prompt_tokens_details, {
+                cached_tokens: 38368,
+            });
+        }
+    });
+
+    test("should prefer nested cache details over root Anthropic usage fields", () => {
+        const state = createInitialStreamingState();
+        const parts = interpretStreamEvent(
+            {
+                usage: {
+                    prompt_tokens: 40000,
+                    completion_tokens: 12,
+                    cache_creation_input_tokens: 1,
+                    cache_read_input_tokens: 2,
+                    prompt_tokens_details: {
+                        cached_tokens: 35000,
+                        cache_creation_input_tokens: 5000,
+                    },
+                },
+            },
+            state
+        );
+
+        const usage = parts.find((part) => part.type === "data");
+        assert.ok(usage && usage.type === "data");
+        if (usage.type === "data") {
+            assert.deepStrictEqual((usage.value as { prompt_tokens_details?: object }).prompt_tokens_details, {
+                cached_tokens: 35000,
+                cache_creation_input_tokens: 5000,
+            });
+        }
+    });
+
     test("should pass through non-cache-control VS Code DataPart carrier objects", () => {
         const state = createInitialStreamingState();
         const parts = interpretStreamEvent(

--- a/src/adapters/test/client.test.ts
+++ b/src/adapters/test/client.test.ts
@@ -302,6 +302,43 @@ suite("LiteLLM Client Unit Tests", () => {
         assert.strictEqual(retryHeaders["Cache-Control"], undefined);
     });
 
+    test("chat strips only prompt cache controls after a cache_control rejection", async () => {
+        const client = new LiteLLMClient(config, userAgent);
+        const errorResponse = {
+            ok: false,
+            status: 400,
+            statusText: "Bad Request",
+            text: async () => "Unsupported parameter: 'cache_control'",
+            clone: function () {
+                return this;
+            },
+        };
+        const successResponse = { ok: true, status: 200, body: new ReadableStream() };
+        const fetchStub = sandbox.stub(global, "fetch");
+        fetchStub.onCall(0).resolves(errorResponse as unknown as Response);
+        fetchStub.onCall(1).resolves(successResponse as unknown as Response);
+
+        await client.chat({
+            model: "claude-opus-5",
+            cache_control: { type: "ephemeral" },
+            extra_body: { cache: { "no-cache": true } },
+            messages: [
+                {
+                    role: "user",
+                    content: [{ type: "text", text: "reuse this prefix", cache_control: { type: "ephemeral" } }],
+                },
+            ],
+        });
+
+        const retryBody = JSON.parse((fetchStub.getCall(1).args[1] as RequestInit).body as string) as Record<
+            string,
+            unknown
+        >;
+        assert.strictEqual(retryBody.cache_control, undefined);
+        assert.deepStrictEqual(retryBody.extra_body, { cache: { "no-cache": true } });
+        assert.ok(!JSON.stringify(retryBody.messages).includes("cache_control"));
+    });
+
     test("parseRetryAfterDelayMs handles seconds, future date, and invalid values", () => {
         const client = new LiteLLMClient(config, userAgent);
 

--- a/src/adapters/test/client.test.ts
+++ b/src/adapters/test/client.test.ts
@@ -339,6 +339,45 @@ suite("LiteLLM Client Unit Tests", () => {
         assert.ok(!JSON.stringify(retryBody.messages).includes("cache_control"));
     });
 
+    test("chat strips cache_control after Azure AI unrecognized-argument phrasing", async () => {
+        const client = new LiteLLMClient(config, userAgent);
+        const errorResponse = {
+            ok: false,
+            status: 400,
+            statusText: "Bad Request",
+            text: async () =>
+                "Message: litellm.BadRequestError: Azure_aiException - Unrecognized request argument supplied: cache_control. Received Model Group=azure_ai/us-central/gpt-4o-mini Available Model Group Fallbacks=None",
+            clone: function () {
+                return this;
+            },
+        };
+        const successResponse = { ok: true, status: 200, body: new ReadableStream() };
+        const fetchStub = sandbox.stub(global, "fetch");
+        fetchStub.onCall(0).resolves(errorResponse as unknown as Response);
+        fetchStub.onCall(1).resolves(successResponse as unknown as Response);
+
+        await client.chat({
+            model: "azure_ai/us-central/gpt-4o-mini",
+            cache_control: { type: "ephemeral" },
+            extra_body: { cache: { "no-cache": true } },
+            messages: [
+                {
+                    role: "user",
+                    content: [{ type: "text", text: "reuse this prefix", cache_control: { type: "ephemeral" } }],
+                },
+            ],
+        });
+
+        assert.strictEqual(fetchStub.callCount, 2);
+        const retryBody = JSON.parse((fetchStub.getCall(1).args[1] as RequestInit).body as string) as Record<
+            string,
+            unknown
+        >;
+        assert.strictEqual(retryBody.cache_control, undefined);
+        assert.deepStrictEqual(retryBody.extra_body, { cache: { "no-cache": true } });
+        assert.ok(!JSON.stringify(retryBody.messages).includes("cache_control"));
+    });
+
     test("parseRetryAfterDelayMs handles seconds, future date, and invalid values", () => {
         const client = new LiteLLMClient(config, userAgent);
 

--- a/src/adapters/test/responsesAdapter.test.ts
+++ b/src/adapters/test/responsesAdapter.test.ts
@@ -14,6 +14,16 @@ suite("Responses Adapter Unit Tests", () => {
         assert.deepStrictEqual(body.extra_body, { cache: { "no-cache": true } });
     });
 
+    test("transformToResponsesFormat preserves top-level prompt cache control", () => {
+        const body = transformToResponsesFormat({
+            model: "claude-opus-5",
+            messages: [{ role: "user", content: "reuse this prefix" }],
+            cache_control: { type: "ephemeral" },
+        });
+
+        assert.deepStrictEqual(body.cache_control, { type: "ephemeral" });
+    });
+
     test("transformToResponsesFormat never creates a cache_control carrier object", () => {
         const body = transformToResponsesFormat({
             model: "cache-capable-model",

--- a/src/adapters/v2OpenAIMessageConverter.ts
+++ b/src/adapters/v2OpenAIMessageConverter.ts
@@ -53,7 +53,7 @@ export function convertV2MessagesToOpenAI(
                 return;
             }
 
-            if (hasCacheControlMarker && Array.isArray(content)) {
+            if (options.attachPromptCacheControl === true && hasCacheControlMarker && Array.isArray(content)) {
                 applyEphemeralCacheControl(content);
             }
 
@@ -77,7 +77,7 @@ export function convertV2MessagesToOpenAI(
             }
 
             const content = buildMessageContent(textParts, contentItems, hasCacheControlMarker);
-            if (hasCacheControlMarker && Array.isArray(content)) {
+            if (options.attachPromptCacheControl === true && hasCacheControlMarker && Array.isArray(content)) {
                 applyEphemeralCacheControl(content);
             }
             const emittedIndex = out.length;
@@ -110,7 +110,8 @@ export function convertV2MessagesToOpenAI(
                     textParts.push(part.text);
                     break;
                 case "data":
-                    hasCacheControlMarker = appendDataPart(part, textParts, contentItems, options) || hasCacheControlMarker;
+                    hasCacheControlMarker =
+                        appendDataPart(part, textParts, contentItems, options) || hasCacheControlMarker;
                     break;
                 case "thinking":
                     textParts.push(Array.isArray(part.value) ? part.value.join("") : part.value);

--- a/src/adapters/v2OpenAIMessageConverter.ts
+++ b/src/adapters/v2OpenAIMessageConverter.ts
@@ -3,10 +3,12 @@ import { StructuredLogger } from "../observability/structuredLogger";
 import { sanitizeToolName } from "../utils/toolNameUtils";
 import type { V2ChatMessage, V2MessagePart } from "../providers/v2Types";
 import type { OpenAIChatMessage, OpenAIChatMessageContentItem, OpenAIChatRole, OpenAIToolCall } from "../types";
+import { applyEphemeralCacheControl } from "../utils/promptCacheControl";
 
 interface V2OpenAIConversionOptions {
     normalizeToolCallId: (id: string) => string;
     isCacheControlMimeType: (mimeType: string) => boolean;
+    attachPromptCacheControl?: boolean;
 }
 
 interface TextLikeContent {
@@ -43,11 +45,16 @@ export function convertV2MessagesToOpenAI(
         const textParts: string[] = [];
         const contentItems: OpenAIChatMessageContentItem[] = [];
         const toolCalls: OpenAIToolCall[] = [];
+        let hasCacheControlMarker = false;
 
         const flushTextMessage = (): void => {
-            const content = buildMessageContent(textParts, contentItems);
+            const content = buildMessageContent(textParts, contentItems, hasCacheControlMarker);
             if (!content) {
                 return;
+            }
+
+            if (hasCacheControlMarker && Array.isArray(content)) {
+                applyEphemeralCacheControl(content);
             }
 
             const emittedIndex = out.length;
@@ -61,6 +68,7 @@ export function convertV2MessagesToOpenAI(
             });
             textParts.length = 0;
             contentItems.length = 0;
+            hasCacheControlMarker = false;
         };
 
         const flushAssistantToolCalls = (): void => {
@@ -68,7 +76,10 @@ export function convertV2MessagesToOpenAI(
                 return;
             }
 
-            const content = buildMessageContent(textParts, contentItems);
+            const content = buildMessageContent(textParts, contentItems, hasCacheControlMarker);
+            if (hasCacheControlMarker && Array.isArray(content)) {
+                applyEphemeralCacheControl(content);
+            }
             const emittedIndex = out.length;
             out.push({ role: "assistant", content, name: message.name, tool_calls: [...toolCalls] });
             StructuredLogger.trace("v2.convert.message_emitted", {
@@ -83,6 +94,7 @@ export function convertV2MessagesToOpenAI(
             textParts.length = 0;
             contentItems.length = 0;
             toolCalls.length = 0;
+            hasCacheControlMarker = false;
         };
 
         message.content.forEach((part, partIndex) => {
@@ -98,7 +110,7 @@ export function convertV2MessagesToOpenAI(
                     textParts.push(part.text);
                     break;
                 case "data":
-                    appendDataPart(part, textParts, contentItems, options);
+                    hasCacheControlMarker = appendDataPart(part, textParts, contentItems, options) || hasCacheControlMarker;
                     break;
                 case "thinking":
                     textParts.push(Array.isArray(part.value) ? part.value.join("") : part.value);
@@ -115,8 +127,15 @@ export function convertV2MessagesToOpenAI(
 
                     const emittedIndex = out.length;
                     const normalizedCallId = options.normalizeToolCallId(part.callId);
-                    const content = serializeToolResultContent(part.content, options);
-                    out.push({ role: "tool", tool_call_id: normalizedCallId, content });
+                    const serialized = serializeToolResultContent(part.content, options);
+                    const toolContent: string | OpenAIChatMessageContentItem[] =
+                        options.attachPromptCacheControl === true && serialized.hasCacheControlMarker
+                            ? [{ type: "text", text: serialized.content }]
+                            : serialized.content;
+                    if (Array.isArray(toolContent)) {
+                        applyEphemeralCacheControl(toolContent);
+                    }
+                    out.push({ role: "tool", tool_call_id: normalizedCallId, content: toolContent });
                     StructuredLogger.trace("v2.convert.message_emitted", {
                         messageIndex,
                         partIndex,
@@ -126,7 +145,7 @@ export function convertV2MessagesToOpenAI(
                         rawCallId: part.callId,
                         normalizedCallId,
                         itemCount: part.content.length,
-                        preview: previewText(content),
+                        preview: previewText(serialized.content),
                     });
                     break;
                 }
@@ -181,10 +200,10 @@ function appendDataPart(
     textParts: string[],
     contentItems: OpenAIChatMessageContentItem[],
     options: V2OpenAIConversionOptions
-): void {
+): boolean {
     if (options.isCacheControlMimeType(part.mimeType)) {
         StructuredLogger.trace("v2.convert.cache_control_dropped", { mimeType: part.mimeType });
-        return;
+        return options.attachPromptCacheControl === true;
     }
 
     if (part.mimeType.startsWith("image/")) {
@@ -194,20 +213,22 @@ function appendDataPart(
                 url: `data:${part.mimeType};base64,${Buffer.from(part.data).toString("base64")}`,
             },
         });
-        return;
+        return false;
     }
 
     if (part.mimeType.startsWith("text/") || part.mimeType.includes("json")) {
         textParts.push(Buffer.from(part.data).toString("utf-8"));
     }
+    return false;
 }
 
 function buildMessageContent(
     textParts: readonly string[],
-    contentItems: readonly OpenAIChatMessageContentItem[]
+    contentItems: readonly OpenAIChatMessageContentItem[],
+    forceContentItems = false
 ): string | OpenAIChatMessageContentItem[] | undefined {
     const text = textParts.join("");
-    if (contentItems.length === 0) {
+    if (contentItems.length === 0 && !forceContentItems) {
         return text || undefined;
     }
 
@@ -219,20 +240,26 @@ function buildMessageContent(
     return items;
 }
 
-function serializeToolResultContent(content: readonly unknown[], options: V2OpenAIConversionOptions): string {
+function serializeToolResultContent(
+    content: readonly unknown[],
+    options: V2OpenAIConversionOptions
+): { content: string; hasCacheControlMarker: boolean } {
+    const hasCacheControlMarker = content.some(
+        (item) => item instanceof vscode.LanguageModelDataPart && options.isCacheControlMimeType(item.mimeType)
+    );
     const serialized = content
         .map((item) => serializeToolResultItem(item, options))
         .filter((item): item is SerializedToolResultContent => !!item);
 
     if (serialized.length === 0) {
-        return "Success";
+        return { content: "Success", hasCacheControlMarker };
     }
 
     if (serialized.length === 1 && serialized[0].type === "text") {
-        return serialized[0].text;
+        return { content: serialized[0].text, hasCacheControlMarker };
     }
 
-    return JSON.stringify({ type: "tool_result", content: serialized });
+    return { content: JSON.stringify({ type: "tool_result", content: serialized }), hasCacheControlMarker };
 }
 
 function serializeToolResultItem(

--- a/src/providers/base/requestBuilder.ts
+++ b/src/providers/base/requestBuilder.ts
@@ -78,7 +78,7 @@ export class RequestBuilder {
             rawModelId
         );
 
-        const promptCachePolicy = applyPromptCachePolicy(requestBody.messages, modelInfo);
+        const promptCachePolicy = applyPromptCachePolicy(requestBody.messages, rawModelId, modelInfo);
         if (promptCachePolicy.path1) {
             requestBody.cache_control = { type: "ephemeral" };
         }
@@ -114,7 +114,7 @@ export class RequestBuilder {
         const toolConfig = convertTools({ ...options, tools: toolRedaction.tools });
         const messagesToUse = trimMessagesToFitBudget(messages, toolConfig.tools, model, modelInfo);
         const openaiMessages = convertMessages(messagesToUse, {
-            attachPromptCacheControl: modelSupportsPromptCacheControl(modelInfo),
+            attachPromptCacheControl: modelSupportsPromptCacheControl(rawModelId, modelInfo),
         });
         validateRequest(messagesToUse);
 
@@ -214,7 +214,7 @@ export class RequestBuilder {
         const mo = (options.modelOptions as Record<string, unknown>) ?? {};
 
         const openaiMessages = convertV2MessagesToOpenAI(trimmedMessages, {
-            attachPromptCacheControl: modelSupportsPromptCacheControl(modelInfo),
+            attachPromptCacheControl: modelSupportsPromptCacheControl(rawModelId, modelInfo),
         });
         const requestBody: OpenAIChatCompletionRequest = {
             model: rawModelId,

--- a/src/providers/base/requestBuilder.ts
+++ b/src/providers/base/requestBuilder.ts
@@ -12,6 +12,7 @@ import type { RequestBuilderDeps } from "./types";
 import type { V2ChatMessage } from "../v2Types";
 import { resolveChatReasoningTransport } from "./reasoningTransport";
 import { applyPromptCachePolicy, modelSupportsPromptCacheControl } from "../../utils/promptCacheControl";
+import type { PromptCachePolicySummary } from "../../utils/promptCacheControl";
 
 export class RequestBuilder {
     private readonly configManager: RequestBuilderDeps["configManager"];
@@ -46,6 +47,42 @@ export class RequestBuilder {
                 "no-cache": true,
             },
         };
+    }
+
+    /**
+     * Applies the shared finalization tail every chat request body needs,
+     * regardless of which message pipeline produced it.
+     *
+     * Order is load-bearing and must not be rearranged:
+     *
+     * 1. LiteLLM response-cache bypass goes on first so the parameter strip can
+     *    remove `cache` for backends that reject it.
+     * 2. Unsupported parameters are stripped against the model card.
+     * 3. Anthropic prompt caching is applied *after* the strip, because the
+     *    strip only knows the card's advertised parameters and would otherwise
+     *    drop a `cache_control` field it does not recognize.
+     *
+     * Returns the sanitized policy summary so callers can log the decision
+     * without re-deriving it.
+     */
+    private finalizeRequestBody(
+        requestBody: OpenAIChatCompletionRequest,
+        rawModelId: string,
+        disableCaching: boolean,
+        modelInfo?: LiteLLMModelInfo
+    ): PromptCachePolicySummary {
+        this.addCacheBypassIfEnabled(requestBody, disableCaching);
+        this.stripUnsupportedParametersFromRequest(
+            requestBody as unknown as Record<string, unknown>,
+            modelInfo,
+            rawModelId
+        );
+
+        const promptCachePolicy = applyPromptCachePolicy(requestBody.messages, modelInfo);
+        if (promptCachePolicy.path1) {
+            requestBody.cache_control = { type: "ephemeral" };
+        }
+        return promptCachePolicy;
     }
 
     public async buildOpenAIChatRequest(
@@ -147,16 +184,7 @@ export class RequestBuilder {
             // If model doesn't support tool_choice, omit it entirely
         }
 
-        this.addCacheBypassIfEnabled(requestBody, config.disableCaching === true);
-        this.stripUnsupportedParametersFromRequest(
-            requestBody as unknown as Record<string, unknown>,
-            modelInfo,
-            rawModelId
-        );
-        const promptCachePolicy = applyPromptCachePolicy(requestBody.messages, modelInfo);
-        if (promptCachePolicy.path1) {
-            requestBody.cache_control = { type: "ephemeral" };
-        }
+        this.finalizeRequestBody(requestBody, rawModelId, config.disableCaching === true, modelInfo);
         return requestBody;
     }
 
@@ -238,16 +266,7 @@ export class RequestBuilder {
             // If model doesn't support tool_choice, omit it entirely
         }
 
-        this.addCacheBypassIfEnabled(requestBody, config.disableCaching === true);
-        this.stripUnsupportedParametersFromRequest(
-            requestBody as unknown as Record<string, unknown>,
-            modelInfo,
-            rawModelId
-        );
-        const promptCachePolicy = applyPromptCachePolicy(requestBody.messages, modelInfo);
-        if (promptCachePolicy.path1) {
-            requestBody.cache_control = { type: "ephemeral" };
-        }
+        this.finalizeRequestBody(requestBody, rawModelId, config.disableCaching === true, modelInfo);
         return requestBody;
     }
 }

--- a/src/providers/base/requestBuilder.ts
+++ b/src/providers/base/requestBuilder.ts
@@ -11,6 +11,7 @@ import type { LiteLLMModelInfo, OpenAIChatCompletionRequest, OpenAIFunctionToolD
 import type { RequestBuilderDeps } from "./types";
 import type { V2ChatMessage } from "../v2Types";
 import { resolveChatReasoningTransport } from "./reasoningTransport";
+import { applyPromptCachePolicy, modelSupportsPromptCacheControl } from "../../utils/promptCacheControl";
 
 export class RequestBuilder {
     private readonly configManager: RequestBuilderDeps["configManager"];
@@ -75,7 +76,9 @@ export class RequestBuilder {
         // this call site only needs the (possibly redacted) tool list.
         const toolConfig = convertTools({ ...options, tools: toolRedaction.tools });
         const messagesToUse = trimMessagesToFitBudget(messages, toolConfig.tools, model, modelInfo);
-        const openaiMessages = convertMessages(messagesToUse);
+        const openaiMessages = convertMessages(messagesToUse, {
+            attachPromptCacheControl: modelSupportsPromptCacheControl(modelInfo),
+        });
         validateRequest(messagesToUse);
 
         const reasoningEffort = this.getReasoningEffort(options, model, modelInfo);
@@ -150,6 +153,10 @@ export class RequestBuilder {
             modelInfo,
             rawModelId
         );
+        const promptCachePolicy = applyPromptCachePolicy(requestBody.messages, modelInfo);
+        if (promptCachePolicy.path1) {
+            requestBody.cache_control = { type: "ephemeral" };
+        }
         return requestBody;
     }
 
@@ -178,9 +185,12 @@ export class RequestBuilder {
         );
         const mo = (options.modelOptions as Record<string, unknown>) ?? {};
 
+        const openaiMessages = convertV2MessagesToOpenAI(trimmedMessages, {
+            attachPromptCacheControl: modelSupportsPromptCacheControl(modelInfo),
+        });
         const requestBody: OpenAIChatCompletionRequest = {
             model: rawModelId,
-            messages: convertV2MessagesToOpenAI(trimmedMessages),
+            messages: openaiMessages,
             stream: true,
             max_tokens:
                 typeof options.modelOptions?.max_tokens === "number"
@@ -234,6 +244,10 @@ export class RequestBuilder {
             modelInfo,
             rawModelId
         );
+        const promptCachePolicy = applyPromptCachePolicy(requestBody.messages, modelInfo);
+        if (promptCachePolicy.path1) {
+            requestBody.cache_control = { type: "ephemeral" };
+        }
         return requestBody;
     }
 }

--- a/src/providers/base/transport.ts
+++ b/src/providers/base/transport.ts
@@ -110,7 +110,7 @@ export class Transport {
             `[transport.sendRequestToLiteLLM] Sending request to LiteLLM: model=${request.model} caller=${caller} streaming=true`
         );
         const reasoningState = readReasoningRetryState(request);
-        const promptCacheSupported = modelSupportsPromptCacheControl(modelInfo);
+        const promptCacheSupported = modelSupportsPromptCacheControl(request.model, modelInfo);
         const promptCacheExplicitCount = countCacheBreakpoints(request.messages);
         StructuredLogger.info("transport.http_request_start", {
             model: request.model,

--- a/src/providers/base/transport.ts
+++ b/src/providers/base/transport.ts
@@ -5,6 +5,7 @@ import { StructuredLogger } from "../../observability/structuredLogger";
 import type { LiteLLMModelInfo, OpenAIChatCompletionRequest } from "../../types";
 import type { SendRequestArgs, TransportDeps } from "./types";
 import { readReasoningRetryState } from "./reasoningRetryState";
+import { countCacheBreakpoints, modelSupportsPromptCacheControl } from "../../utils/promptCacheControl";
 
 /**
  * Sends a LiteLLM request to the configured endpoint.
@@ -109,6 +110,8 @@ export class Transport {
             `[transport.sendRequestToLiteLLM] Sending request to LiteLLM: model=${request.model} caller=${caller} streaming=true`
         );
         const reasoningState = readReasoningRetryState(request);
+        const promptCacheSupported = modelSupportsPromptCacheControl(modelInfo);
+        const promptCacheExplicitCount = countCacheBreakpoints(request.messages);
         StructuredLogger.info("transport.http_request_start", {
             model: request.model,
             caller,
@@ -122,6 +125,9 @@ export class Transport {
             max_tokens: request.max_tokens,
             temperature: request.temperature,
             top_p: request.top_p,
+            prompt_cache_supported: promptCacheSupported,
+            prompt_cache_path1: request.cache_control !== undefined,
+            prompt_cache_explicit_count: promptCacheExplicitCount,
         });
 
         // Read the per-call fallback flag from the per-group configuration.

--- a/src/providers/test/liteLLMProviderBase.requestBuilder.test.ts
+++ b/src/providers/test/liteLLMProviderBase.requestBuilder.test.ts
@@ -127,6 +127,36 @@ suite("RequestBuilder", () => {
         assert.ok(!JSON.stringify(request.messages).includes("cache_control"));
     });
 
+    test("buildOpenAIChatRequest omits Path 1 after four explicit cache markers", async () => {
+        configManager.getConfig.resolves({});
+        const model = {
+            id: "anthropic/claude-opus-5",
+            maxInputTokens: 100,
+            maxOutputTokens: 50,
+        } as vscode.LanguageModelChatInformation;
+        const messages = Array.from({ length: 4 }, (_, index) => ({
+            role: vscode.LanguageModelChatMessageRole.User,
+            content: [
+                new vscode.LanguageModelTextPart(`message ${index}`),
+                new vscode.LanguageModelDataPart(Buffer.from("ephemeral"), "cache_control"),
+            ],
+            name: undefined,
+        }));
+
+        const request = await builder.buildOpenAIChatRequest(
+            messages,
+            model,
+            { modelOptions: {} } as vscode.ProvideLanguageModelChatResponseOptions,
+            { supported_openai_params: ["cache_control"] }
+        );
+
+        assert.strictEqual(request.cache_control, undefined);
+        const explicitCount = request.messages.flatMap((message) =>
+            Array.isArray(message.content) ? message.content.filter((content) => content.cache_control !== undefined) : []
+        ).length;
+        assert.strictEqual(explicitCount, 4);
+    });
+
     test("buildV2ChatRequest preserves tool_choice", async () => {
         configManager.getConfig.resolves({});
         const model = { id: "gpt-v2", maxInputTokens: 100, maxOutputTokens: 20 } as vscode.LanguageModelChatInformation;

--- a/src/providers/test/liteLLMProviderBase.requestBuilder.test.ts
+++ b/src/providers/test/liteLLMProviderBase.requestBuilder.test.ts
@@ -107,6 +107,57 @@ suite("RequestBuilder", () => {
         assert.deepStrictEqual(v2Request.cache_control, { type: "ephemeral" });
     });
 
+    test("buildOpenAIChatRequest leaves a lying GPT cache_control card unstamped", async () => {
+        configManager.getConfig.resolves({});
+        const model = {
+            id: "azure_ai/us-central/gpt-4o-mini",
+            maxInputTokens: 100,
+            maxOutputTokens: 50,
+        } as vscode.LanguageModelChatInformation;
+        const messages: vscode.LanguageModelChatRequestMessage[] = [
+            {
+                role: vscode.LanguageModelChatMessageRole.User,
+                content: [new vscode.LanguageModelTextPart("do not cache")],
+                name: undefined,
+            },
+        ];
+
+        const request = await builder.buildOpenAIChatRequest(
+            messages,
+            model,
+            { modelOptions: {} } as vscode.ProvideLanguageModelChatResponseOptions,
+            { supported_openai_params: ["cache_control", "prompt_cache_key"], litellm_provider: "openai" }
+        );
+
+        assert.strictEqual(request.cache_control, undefined);
+        assert.ok(!JSON.stringify(request.messages).includes("cache_control"));
+    });
+
+    test("buildOpenAIChatRequest still stamps Azure-hosted Claude cards", async () => {
+        configManager.getConfig.resolves({});
+        const model = {
+            id: "azure_ai/claude-haiku-4-5",
+            maxInputTokens: 100,
+            maxOutputTokens: 50,
+        } as vscode.LanguageModelChatInformation;
+        const messages: vscode.LanguageModelChatRequestMessage[] = [
+            {
+                role: vscode.LanguageModelChatMessageRole.User,
+                content: [new vscode.LanguageModelTextPart("reuse this prefix")],
+                name: undefined,
+            },
+        ];
+
+        const request = await builder.buildOpenAIChatRequest(
+            messages,
+            model,
+            { modelOptions: {} } as vscode.ProvideLanguageModelChatResponseOptions,
+            { supported_openai_params: ["cache_control"], litellm_provider: "azure_ai" }
+        );
+
+        assert.deepStrictEqual(request.cache_control, { type: "ephemeral" });
+    });
+
     test("buildOpenAIChatRequest leaves cards without cache_control unstamped", async () => {
         configManager.getConfig.resolves({});
         const model = {

--- a/src/providers/test/liteLLMProviderBase.requestBuilder.test.ts
+++ b/src/providers/test/liteLLMProviderBase.requestBuilder.test.ts
@@ -54,6 +54,79 @@ suite("RequestBuilder", () => {
         sinon.assert.match(req.stream, true);
     });
 
+    test("buildOpenAIChatRequest attaches top-level cache_control for eligible cards without markers", async () => {
+        configManager.getConfig.resolves({});
+        const model = {
+            id: "anthropic/claude-opus-5",
+            maxInputTokens: 100,
+            maxOutputTokens: 50,
+        } as vscode.LanguageModelChatInformation;
+        const messages: vscode.LanguageModelChatRequestMessage[] = [
+            {
+                role: vscode.LanguageModelChatMessageRole.User,
+                content: [new vscode.LanguageModelTextPart("reuse this prefix")],
+                name: undefined,
+            },
+        ];
+
+        const request = await builder.buildOpenAIChatRequest(
+            messages,
+            model,
+            { modelOptions: {} } as vscode.ProvideLanguageModelChatResponseOptions,
+            { supported_openai_params: ["cache_control"] }
+        );
+
+        assert.deepStrictEqual(request.cache_control, { type: "ephemeral" });
+        assert.ok(!JSON.stringify(request.messages).includes("cache_control"));
+    });
+
+    test("V1 and V2 builders share the cache_control eligibility gate", async () => {
+        configManager.getConfig.resolves({});
+        const model = {
+            id: "anthropic/claude-opus-5",
+            maxInputTokens: 100,
+            maxOutputTokens: 50,
+        } as vscode.LanguageModelChatInformation;
+        const messages: vscode.LanguageModelChatRequestMessage[] = [
+            {
+                role: vscode.LanguageModelChatMessageRole.User,
+                content: [new vscode.LanguageModelTextPart("same request")],
+                name: undefined,
+            },
+        ];
+        const options = { modelOptions: {} } as vscode.ProvideLanguageModelChatResponseOptions;
+
+        const [v1Request, v2Request] = await Promise.all([
+            builder.buildOpenAIChatRequest(messages, model, options, { supported_openai_params: ["cache_control"] }),
+            builder.buildV2ChatRequest(messages as never, model, options, { supported_openai_params: ["cache_control"] }),
+        ]);
+
+        assert.deepStrictEqual(v1Request.cache_control, { type: "ephemeral" });
+        assert.deepStrictEqual(v2Request.cache_control, { type: "ephemeral" });
+    });
+
+    test("buildOpenAIChatRequest leaves cards without cache_control unstamped", async () => {
+        configManager.getConfig.resolves({});
+        const model = { id: "bedrock/claude", maxInputTokens: 100, maxOutputTokens: 50 } as vscode.LanguageModelChatInformation;
+        const messages: vscode.LanguageModelChatRequestMessage[] = [
+            {
+                role: vscode.LanguageModelChatMessageRole.User,
+                content: [new vscode.LanguageModelTextPart("do not cache")],
+                name: undefined,
+            },
+        ];
+
+        const request = await builder.buildOpenAIChatRequest(
+            messages,
+            model,
+            { modelOptions: {} } as vscode.ProvideLanguageModelChatResponseOptions,
+            { supports_prompt_caching: true }
+        );
+
+        assert.strictEqual(request.cache_control, undefined);
+        assert.ok(!JSON.stringify(request.messages).includes("cache_control"));
+    });
+
     test("buildV2ChatRequest preserves tool_choice", async () => {
         configManager.getConfig.resolves({});
         const model = { id: "gpt-v2", maxInputTokens: 100, maxOutputTokens: 20 } as vscode.LanguageModelChatInformation;

--- a/src/providers/test/liteLLMProviderBase.requestBuilder.test.ts
+++ b/src/providers/test/liteLLMProviderBase.requestBuilder.test.ts
@@ -98,7 +98,9 @@ suite("RequestBuilder", () => {
 
         const [v1Request, v2Request] = await Promise.all([
             builder.buildOpenAIChatRequest(messages, model, options, { supported_openai_params: ["cache_control"] }),
-            builder.buildV2ChatRequest(messages as never, model, options, { supported_openai_params: ["cache_control"] }),
+            builder.buildV2ChatRequest(messages as never, model, options, {
+                supported_openai_params: ["cache_control"],
+            }),
         ]);
 
         assert.deepStrictEqual(v1Request.cache_control, { type: "ephemeral" });
@@ -107,7 +109,11 @@ suite("RequestBuilder", () => {
 
     test("buildOpenAIChatRequest leaves cards without cache_control unstamped", async () => {
         configManager.getConfig.resolves({});
-        const model = { id: "bedrock/claude", maxInputTokens: 100, maxOutputTokens: 50 } as vscode.LanguageModelChatInformation;
+        const model = {
+            id: "bedrock/claude",
+            maxInputTokens: 100,
+            maxOutputTokens: 50,
+        } as vscode.LanguageModelChatInformation;
         const messages: vscode.LanguageModelChatRequestMessage[] = [
             {
                 role: vscode.LanguageModelChatMessageRole.User,
@@ -152,7 +158,9 @@ suite("RequestBuilder", () => {
 
         assert.strictEqual(request.cache_control, undefined);
         const explicitCount = request.messages.flatMap((message) =>
-            Array.isArray(message.content) ? message.content.filter((content) => content.cache_control !== undefined) : []
+            Array.isArray(message.content)
+                ? message.content.filter((content) => content.cache_control !== undefined)
+                : []
         ).length;
         assert.strictEqual(explicitCount, 4);
     });

--- a/src/providers/test/liteLLMProviderBase.transport.test.ts
+++ b/src/providers/test/liteLLMProviderBase.transport.test.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import * as sinon from "sinon";
 import { Transport } from "../base/transport";
 import { ConfigManager } from "../../config/configManager";
+import { StructuredLogger } from "../../observability/structuredLogger";
 
 suite("Transport", () => {
     let sandbox: sinon.SinonSandbox;
@@ -122,5 +123,50 @@ suite("Transport", () => {
         assert.strictEqual(factoryCalls.length, 1);
         assert.strictEqual(factoryCalls[0].url, "https://wolfram.example");
         assert.strictEqual(factoryCalls[0].key, "sk-test");
+    });
+
+    test("sendRequestToLiteLLM logs sanitized prompt-cache policy fields", async () => {
+        const token = new vscode.CancellationTokenSource().token;
+        const progress = { report: () => {} } as vscode.Progress<vscode.LanguageModelResponsePart>;
+        const infoStub = sandbox.stub(StructuredLogger, "info");
+        const localTransport = new Transport({
+            configManager,
+            userAgent: "ua",
+            logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {}, trace: () => {} },
+            liteLLMClientFactory: (() => ({ chat: () => new ReadableStream() }) as never) as never,
+        });
+
+        await localTransport.sendRequestToLiteLLM(
+            {
+                model: "claude-opus-5",
+                messages: [
+                    {
+                        role: "user",
+                        content: [{ type: "text", text: "private prompt", cache_control: { type: "ephemeral" } }],
+                    },
+                ],
+                cache_control: { type: "ephemeral" },
+            },
+            progress,
+            token,
+            "test",
+            { mode: "chat", supported_openai_params: ["cache_control"] },
+            { baseUrl: "https://example.com", apiKey: "test-key" }
+        );
+
+        const call = infoStub
+            .getCalls()
+            .find((entry) => entry.args[0] === "transport.http_request_start");
+        assert.ok(call);
+        const data = call?.args[1] as Record<string, unknown>;
+        assert.deepStrictEqual(
+            {
+                supported: data.prompt_cache_supported,
+                path1: data.prompt_cache_path1,
+                explicitCount: data.prompt_cache_explicit_count,
+            },
+            { supported: true, path1: true, explicitCount: 1 }
+        );
+        assert.ok(!JSON.stringify(data).includes("private prompt"));
     });
 });

--- a/src/providers/test/liteLLMProviderBase.transport.test.ts
+++ b/src/providers/test/liteLLMProviderBase.transport.test.ts
@@ -154,9 +154,7 @@ suite("Transport", () => {
             { baseUrl: "https://example.com", apiKey: "test-key" }
         );
 
-        const call = infoStub
-            .getCalls()
-            .find((entry) => entry.args[0] === "transport.http_request_start");
+        const call = infoStub.getCalls().find((entry) => entry.args[0] === "transport.http_request_start");
         assert.ok(call);
         const data = call?.args[1] as Record<string, unknown>;
         assert.deepStrictEqual(

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,11 @@ export interface OpenAIFunctionToolDef {
     function: { name: string; description?: string; parameters?: object };
 }
 
+/** Anthropic prompt-caching control accepted by LiteLLM's OpenAI-compatible API. */
+export interface OpenAICacheControl {
+    type: "ephemeral";
+}
+
 /**
  * Content item for vision/image support in OpenAI messages
  */
@@ -24,6 +29,8 @@ export interface OpenAIChatMessageContentItem {
     image_url?: {
         url: string;
     };
+    /** Explicit host-provided cache breakpoint. Never created automatically. */
+    cache_control?: OpenAICacheControl;
 }
 
 /**
@@ -423,6 +430,8 @@ export interface LiteLLMTokenCounterResponse {
 export interface OpenAIChatCompletionRequest {
     model: string;
     messages: OpenAIChatMessage[];
+    /** Anthropic Path 1: ask the provider to advance the automatic cache point. */
+    cache_control?: OpenAICacheControl;
     stream?: boolean;
     max_tokens?: number;
     temperature?: number;
@@ -476,6 +485,8 @@ export interface OpenAIChatCompletionRequest {
 export interface LiteLLMResponsesRequest {
     model: string;
     input: (OpenAIChatMessageContentItem | LiteLLMResponseInputItem)[];
+    /** Preserved from the chat-shaped request for eligible responses-routed cards. */
+    cache_control?: OpenAICacheControl;
     instructions?: string;
     stream?: boolean;
     max_tokens?: number;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -488,7 +488,7 @@ export function convertMessages(
                 contentItems,
                 options.attachPromptCacheControl === true && hasCacheControlMarker
             );
-            if (hasCacheControlMarker && Array.isArray(messageContent)) {
+            if (options.attachPromptCacheControl === true && hasCacheControlMarker && Array.isArray(messageContent)) {
                 applyEphemeralCacheControl(messageContent);
             }
             out.push({
@@ -520,7 +520,11 @@ export function convertMessages(
                     contentItems,
                     options.attachPromptCacheControl === true && hasCacheControlMarker
                 );
-                if (hasCacheControlMarker && Array.isArray(messageContent)) {
+                if (
+                    options.attachPromptCacheControl === true &&
+                    hasCacheControlMarker &&
+                    Array.isArray(messageContent)
+                ) {
                     applyEphemeralCacheControl(messageContent);
                 }
                 if (messageContent || (role === "assistant" && thinkingBlocks.length > 0)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,7 @@ import type {
     OpenAIChatMessageContentItem,
     OpenAIThinkingBlock,
 } from "./types";
+import { applyEphemeralCacheControl } from "./utils/promptCacheControl";
 import { Logger } from "./utils/logger";
 
 /**
@@ -381,7 +382,10 @@ function extractOpaqueThinkingBlock(part: unknown, precedingThinkingText: string
  * @param messages The VS Code chat messages to convert.
  * @returns OpenAI-compatible messages array.
  */
-export function convertMessages(messages: readonly vscode.LanguageModelChatRequestMessage[]): OpenAIChatMessage[] {
+export function convertMessages(
+    messages: readonly vscode.LanguageModelChatRequestMessage[],
+    options: { attachPromptCacheControl?: boolean } = {}
+): OpenAIChatMessage[] {
     const out: OpenAIChatMessage[] = [];
     for (const m of messages) {
         // `lmcr_toString` returns "system" | "user" | "assistant" for the supported
@@ -392,8 +396,9 @@ export function convertMessages(messages: readonly vscode.LanguageModelChatReque
         const textParts: string[] = [];
         const contentItems: OpenAIChatMessageContentItem[] = [];
         const toolCalls: OpenAIToolCall[] = [];
-        const toolResults: { callId: string; content: string }[] = [];
+        const toolResults: { callId: string; content: string; hasCacheControlMarker: boolean }[] = [];
         const thinkingBlocks: OpenAIThinkingBlock[] = [];
+        let hasCacheControlMarker = false;
         // Streaming splits a thinking block into adjacent visible-text deltas
         // followed by a signature metadata part. This accumulator binds a
         // signature back to the immediately preceding visible text only; any
@@ -414,6 +419,7 @@ export function convertMessages(messages: readonly vscode.LanguageModelChatReque
                     // BEFORE the JSON branch so that MIME types like
                     // "application/vnd.cache-control+json" cannot slip through.
                     Logger.trace(`[convertMessages] Dropping cache_control part (mimeType: ${part.mimeType})`);
+                    hasCacheControlMarker = true;
                 } else if (part.mimeType.startsWith("image/")) {
                     // Convert image data to base64 for OpenAI vision API
                     let base64Data: string;
@@ -458,8 +464,8 @@ export function convertMessages(messages: readonly vscode.LanguageModelChatReque
                 Logger.trace(
                     `[convertMessages] Tool result: (orig: ${(part as { callId?: string }).callId}, norm: ${callId})`
                 );
-                const content = collectToolResultText(part as { content?: readonly unknown[] });
-                toolResults.push({ callId, content });
+                const result = collectToolResultText(part as { content?: readonly unknown[] });
+                toolResults.push({ callId, ...result });
             } else {
                 const thinkingBlock = extractOpaqueThinkingBlock(part, pendingThinkingText);
                 if (thinkingBlock) {
@@ -477,7 +483,14 @@ export function convertMessages(messages: readonly vscode.LanguageModelChatReque
 
         let emittedAssistantToolCall = false;
         if (toolCalls.length > 0) {
-            const messageContent = buildMessageContent(textParts, contentItems);
+            const messageContent = buildMessageContent(
+                textParts,
+                contentItems,
+                options.attachPromptCacheControl === true && hasCacheControlMarker
+            );
+            if (hasCacheControlMarker && Array.isArray(messageContent)) {
+                applyEphemeralCacheControl(messageContent);
+            }
             out.push({
                 role: "assistant",
                 content: messageContent || undefined,
@@ -488,13 +501,28 @@ export function convertMessages(messages: readonly vscode.LanguageModelChatReque
         }
 
         for (const tr of toolResults) {
-            out.push({ role: "tool", tool_call_id: tr.callId, content: tr.content || "Success" });
+            const content = tr.content || "Success";
+            const toolContent: string | OpenAIChatMessageContentItem[] =
+                options.attachPromptCacheControl === true && tr.hasCacheControlMarker
+                    ? [{ type: "text", text: content }]
+                    : content;
+            if (Array.isArray(toolContent)) {
+                applyEphemeralCacheControl(toolContent);
+            }
+            out.push({ role: "tool", tool_call_id: tr.callId, content: toolContent });
         }
 
         const text = textParts.join("");
         if (text || contentItems.length > 0 || thinkingBlocks.length > 0) {
             if (role === "system" || role === "user" || (role === "assistant" && !emittedAssistantToolCall)) {
-                const messageContent = buildMessageContent(textParts, contentItems);
+                const messageContent = buildMessageContent(
+                    textParts,
+                    contentItems,
+                    options.attachPromptCacheControl === true && hasCacheControlMarker
+                );
+                if (hasCacheControlMarker && Array.isArray(messageContent)) {
+                    applyEphemeralCacheControl(messageContent);
+                }
                 if (messageContent || (role === "assistant" && thinkingBlocks.length > 0)) {
                     out.push({
                         role: role || "user",
@@ -671,10 +699,14 @@ export function convertV2MessagesToProviderMessages(
     return downgraded;
 }
 
-export function convertV2MessagesToOpenAI(messages: readonly V2ChatMessage[]): OpenAIChatMessage[] {
+export function convertV2MessagesToOpenAI(
+    messages: readonly V2ChatMessage[],
+    options: { attachPromptCacheControl?: boolean } = {}
+): OpenAIChatMessage[] {
     return convertV2MessagesToOpenAIDirect(messages, {
         normalizeToolCallId,
         isCacheControlMimeType,
+        attachPromptCacheControl: options.attachPromptCacheControl,
     });
 }
 
@@ -797,11 +829,12 @@ export function validateV2Messages(messages: readonly V2ChatMessage[]): void {
  */
 function buildMessageContent(
     textParts: string[],
-    contentItems: OpenAIChatMessageContentItem[]
+    contentItems: OpenAIChatMessageContentItem[],
+    forceContentItems = false
 ): string | OpenAIChatMessageContentItem[] | undefined {
     const text = textParts.join("");
 
-    if (contentItems.length === 0) {
+    if (contentItems.length === 0 && !forceContentItems) {
         return text || undefined;
     }
 
@@ -981,14 +1014,19 @@ export function mapRole(
  * Concatenate tool result content into a single text string.
  * @param pr Tool result-like object with content array.
  */
-function collectToolResultText(pr: { content?: readonly unknown[] }): string {
+function collectToolResultText(pr: { content?: readonly unknown[] }): {
+    content: string;
+    hasCacheControlMarker: boolean;
+} {
     let text = "";
+    let hasCacheControlMarker = false;
     for (const c of pr.content ?? []) {
         if (c instanceof vscode.LanguageModelTextPart) {
             text += c.value;
         } else if (c instanceof vscode.LanguageModelDataPart) {
             if (isCacheControlMimeType(c.mimeType)) {
                 Logger.trace(`[collectToolResultText] Dropping cache_control part (mimeType: ${c.mimeType})`);
+                hasCacheControlMarker = true;
                 continue;
             }
             if (c.mimeType.startsWith("text/") || c.mimeType.includes("json")) {
@@ -1004,7 +1042,7 @@ function collectToolResultText(pr: { content?: readonly unknown[] }): string {
             }
         }
     }
-    return text;
+    return { content: text, hasCacheControlMarker };
 }
 
 /**

--- a/src/utils/promptCacheControl.ts
+++ b/src/utils/promptCacheControl.ts
@@ -1,9 +1,4 @@
-import type {
-    LiteLLMModelInfo,
-    OpenAICacheControl,
-    OpenAIChatMessage,
-    OpenAIChatMessageContentItem,
-} from "../types";
+import type { LiteLLMModelInfo, OpenAICacheControl, OpenAIChatMessage, OpenAIChatMessageContentItem } from "../types";
 
 const EPHEMERAL_CACHE_CONTROL: OpenAICacheControl = { type: "ephemeral" };
 const MAX_EXPLICIT_CACHE_BREAKPOINTS = 4;

--- a/src/utils/promptCacheControl.ts
+++ b/src/utils/promptCacheControl.ts
@@ -1,0 +1,104 @@
+import type {
+    LiteLLMModelInfo,
+    OpenAICacheControl,
+    OpenAIChatMessage,
+    OpenAIChatMessageContentItem,
+} from "../types";
+
+const EPHEMERAL_CACHE_CONTROL: OpenAICacheControl = { type: "ephemeral" };
+const MAX_EXPLICIT_CACHE_BREAKPOINTS = 4;
+
+/** Sanitized request-shape data suitable for the transport start event. */
+export interface PromptCachePolicySummary {
+    supported: boolean;
+    path1: boolean;
+    explicitCount: number;
+}
+
+/**
+ * Returns whether a model card accepts Anthropic's OpenAI-compatible
+ * `cache_control` parameter. `supports_prompt_caching` is intentionally not
+ * considered because it also describes incompatible provider contracts.
+ */
+export function modelSupportsPromptCacheControl(modelInfo?: LiteLLMModelInfo): boolean {
+    return modelInfo?.supported_openai_params?.includes("cache_control") === true;
+}
+
+/**
+ * Adds a host-requested explicit breakpoint to the final eligible content
+ * block. The converter calls this only after it sees a cache-marker DataPart;
+ * no automatic content breakpoints are ever invented here.
+ */
+export function applyEphemeralCacheControl(content: OpenAIChatMessageContentItem[]): boolean {
+    for (let index = content.length - 1; index >= 0; index--) {
+        const item = content[index];
+        if (item.type === "text" || item.type === "image_url") {
+            item.cache_control = { ...EPHEMERAL_CACHE_CONTROL };
+            return true;
+        }
+    }
+    return false;
+}
+
+/** Counts explicit message-content cache breakpoints in message order. */
+export function countCacheBreakpoints(messages: readonly OpenAIChatMessage[]): number {
+    return messages.reduce(
+        (count, message) =>
+            count +
+            (Array.isArray(message.content)
+                ? message.content.filter((content) => content.cache_control !== undefined).length
+                : 0),
+        0
+    );
+}
+
+/** Removes all explicit content breakpoints without modifying prompt text. */
+export function stripCacheBreakpoints(messages: readonly OpenAIChatMessage[]): void {
+    for (const message of messages) {
+        if (!Array.isArray(message.content)) {
+            continue;
+        }
+        for (const content of message.content) {
+            delete content.cache_control;
+        }
+    }
+}
+
+/**
+ * Applies the cache-control contract after message conversion. Eligible cards
+ * receive Path 1 unless all four explicit host breakpoints are occupied. An
+ * ineligible card is completely unstamped to avoid cross-provider leakage.
+ */
+export function applyPromptCachePolicy(
+    messages: OpenAIChatMessage[],
+    modelInfo?: LiteLLMModelInfo
+): PromptCachePolicySummary {
+    const supported = modelSupportsPromptCacheControl(modelInfo);
+    if (!supported) {
+        stripCacheBreakpoints(messages);
+        return { supported: false, path1: false, explicitCount: 0 };
+    }
+
+    let retained = 0;
+    for (const message of messages) {
+        if (!Array.isArray(message.content)) {
+            continue;
+        }
+        for (const content of message.content) {
+            if (!content.cache_control) {
+                continue;
+            }
+            if (retained >= MAX_EXPLICIT_CACHE_BREAKPOINTS) {
+                delete content.cache_control;
+                continue;
+            }
+            retained++;
+        }
+    }
+
+    return {
+        supported: true,
+        path1: retained < MAX_EXPLICIT_CACHE_BREAKPOINTS,
+        explicitCount: retained,
+    };
+}

--- a/src/utils/promptCacheControl.ts
+++ b/src/utils/promptCacheControl.ts
@@ -1,4 +1,5 @@
 import type { LiteLLMModelInfo, OpenAICacheControl, OpenAIChatMessage, OpenAIChatMessageContentItem } from "../types";
+import { isAnthropicModel } from "./modelUtils";
 
 const EPHEMERAL_CACHE_CONTROL: OpenAICacheControl = { type: "ephemeral" };
 const MAX_EXPLICIT_CACHE_BREAKPOINTS = 4;
@@ -11,12 +12,20 @@ export interface PromptCachePolicySummary {
 }
 
 /**
- * Returns whether a model card accepts Anthropic's OpenAI-compatible
- * `cache_control` parameter. `supports_prompt_caching` is intentionally not
- * considered because it also describes incompatible provider contracts.
+ * Returns whether this request may carry Anthropic Path 1 `cache_control`.
+ *
+ * Both checks are required:
+ * - the card must list `cache_control` in `supported_openai_params`
+ * - the model must be Anthropic/Claude (`isAnthropicModel`)
+ *
+ * `supports_prompt_caching` and OpenAI's `prompt_cache_key` are intentionally
+ * ignored: they describe incompatible contracts. A GPT card that falsely
+ * advertises `cache_control` must stay unstamped.
  */
-export function modelSupportsPromptCacheControl(modelInfo?: LiteLLMModelInfo): boolean {
-    return modelInfo?.supported_openai_params?.includes("cache_control") === true;
+export function modelSupportsPromptCacheControl(modelId: string, modelInfo?: LiteLLMModelInfo): boolean {
+    return (
+        modelInfo?.supported_openai_params?.includes("cache_control") === true && isAnthropicModel(modelId, modelInfo)
+    );
 }
 
 /**
@@ -66,9 +75,10 @@ export function stripCacheBreakpoints(messages: readonly OpenAIChatMessage[]): v
  */
 export function applyPromptCachePolicy(
     messages: OpenAIChatMessage[],
+    modelId: string,
     modelInfo?: LiteLLMModelInfo
 ): PromptCachePolicySummary {
-    const supported = modelSupportsPromptCacheControl(modelInfo);
+    const supported = modelSupportsPromptCacheControl(modelId, modelInfo);
     if (!supported) {
         stripCacheBreakpoints(messages);
         return { supported: false, path1: false, explicitCount: 0 };

--- a/src/utils/test/promptCacheControl.test.ts
+++ b/src/utils/test/promptCacheControl.test.ts
@@ -1,0 +1,82 @@
+import * as assert from "assert";
+import type { LiteLLMModelInfo, OpenAIChatMessage, OpenAIChatMessageContentItem } from "../../types";
+import {
+    applyEphemeralCacheControl,
+    applyPromptCachePolicy,
+    countCacheBreakpoints,
+    modelSupportsPromptCacheControl,
+} from "../promptCacheControl";
+
+suite("Prompt cache control policy", () => {
+    const eligibleModel: LiteLLMModelInfo = {
+        supported_openai_params: ["stream", "cache_control"],
+    };
+
+    test("enables top-level Path 1 only for cards that advertise cache_control", () => {
+        const messages: OpenAIChatMessage[] = [{ role: "user", content: "keep this prefix" }];
+
+        const summary = applyPromptCachePolicy(messages, eligibleModel);
+
+        assert.strictEqual(modelSupportsPromptCacheControl(eligibleModel), true);
+        assert.deepStrictEqual(summary, { supported: true, path1: true, explicitCount: 0 });
+        assert.ok(!JSON.stringify(messages).includes("cache_control"));
+    });
+
+    test("does not enable Path 1 from supports_prompt_caching alone", () => {
+        const messages: OpenAIChatMessage[] = [{ role: "user", content: "do not stamp" }];
+        const bedrockShapedModel: LiteLLMModelInfo = { supports_prompt_caching: true };
+
+        const summary = applyPromptCachePolicy(messages, bedrockShapedModel);
+
+        assert.strictEqual(modelSupportsPromptCacheControl(bedrockShapedModel), false);
+        assert.deepStrictEqual(summary, { supported: false, path1: false, explicitCount: 0 });
+        assert.ok(!JSON.stringify(messages).includes("cache_control"));
+    });
+
+    test("stamps the last eligible content block only for an explicit host marker", () => {
+        const content: OpenAIChatMessageContentItem[] = [
+            { type: "text" as const, text: "first block" },
+            { type: "image_url" as const, image_url: { url: "data:image/png;base64,aW1hZ2U=" } },
+            { type: "text" as const, text: "last block" },
+        ];
+
+        const applied = applyEphemeralCacheControl(content);
+
+        assert.strictEqual(applied, true);
+        assert.strictEqual(content[0].cache_control, undefined);
+        assert.strictEqual(content[1].cache_control, undefined);
+        assert.deepStrictEqual(content[2].cache_control, { type: "ephemeral" });
+    });
+
+    test("keeps four explicit block stamps but omits Path 1", () => {
+        const messages: OpenAIChatMessage[] = Array.from({ length: 5 }, (_, index) => ({
+            role: "user",
+            content: [{ type: "text", text: `message ${index}`, cache_control: { type: "ephemeral" } }],
+        }));
+
+        const summary = applyPromptCachePolicy(messages, eligibleModel);
+
+        assert.deepStrictEqual(summary, { supported: true, path1: false, explicitCount: 4 });
+        assert.strictEqual(countCacheBreakpoints(messages), 4);
+        assert.deepStrictEqual(
+            messages.map((message) =>
+                Array.isArray(message.content) ? message.content[0].cache_control : undefined
+            ),
+            [{ type: "ephemeral" }, { type: "ephemeral" }, { type: "ephemeral" }, { type: "ephemeral" }, undefined]
+        );
+    });
+
+    test("removes explicit stamps from ineligible cards", () => {
+        const messages: OpenAIChatMessage[] = [
+            {
+                role: "user",
+                content: [{ type: "text", text: "not eligible", cache_control: { type: "ephemeral" } }],
+            },
+        ];
+
+        const summary = applyPromptCachePolicy(messages, { supported_openai_params: ["stream"] });
+
+        assert.deepStrictEqual(summary, { supported: false, path1: false, explicitCount: 0 });
+        assert.strictEqual(countCacheBreakpoints(messages), 0);
+    });
+});

--- a/src/utils/test/promptCacheControl.test.ts
+++ b/src/utils/test/promptCacheControl.test.ts
@@ -59,9 +59,7 @@ suite("Prompt cache control policy", () => {
         assert.deepStrictEqual(summary, { supported: true, path1: false, explicitCount: 4 });
         assert.strictEqual(countCacheBreakpoints(messages), 4);
         assert.deepStrictEqual(
-            messages.map((message) =>
-                Array.isArray(message.content) ? message.content[0].cache_control : undefined
-            ),
+            messages.map((message) => (Array.isArray(message.content) ? message.content[0].cache_control : undefined)),
             [{ type: "ephemeral" }, { type: "ephemeral" }, { type: "ephemeral" }, { type: "ephemeral" }, undefined]
         );
     });

--- a/src/utils/test/promptCacheControl.test.ts
+++ b/src/utils/test/promptCacheControl.test.ts
@@ -8,29 +8,86 @@ import {
 } from "../promptCacheControl";
 
 suite("Prompt cache control policy", () => {
+    const claudeId = "claude-opus-5";
     const eligibleModel: LiteLLMModelInfo = {
         supported_openai_params: ["stream", "cache_control"],
+        litellm_provider: "anthropic",
     };
 
-    test("enables top-level Path 1 only for cards that advertise cache_control", () => {
+    test("enables top-level Path 1 only for Anthropic cards that advertise cache_control", () => {
         const messages: OpenAIChatMessage[] = [{ role: "user", content: "keep this prefix" }];
 
-        const summary = applyPromptCachePolicy(messages, eligibleModel);
+        const summary = applyPromptCachePolicy(messages, claudeId, eligibleModel);
 
-        assert.strictEqual(modelSupportsPromptCacheControl(eligibleModel), true);
+        assert.strictEqual(modelSupportsPromptCacheControl(claudeId, eligibleModel), true);
         assert.deepStrictEqual(summary, { supported: true, path1: true, explicitCount: 0 });
         assert.ok(!JSON.stringify(messages).includes("cache_control"));
+    });
+
+    test("keeps Azure-hosted Claude eligible when the card lists cache_control", () => {
+        const azureClaude: LiteLLMModelInfo = {
+            supported_openai_params: ["cache_control"],
+            litellm_provider: "azure_ai",
+        };
+
+        assert.strictEqual(modelSupportsPromptCacheControl("azure_ai/claude-haiku-4-5", azureClaude), true);
+        assert.deepStrictEqual(
+            applyPromptCachePolicy([{ role: "user", content: "prefix" }], "azure_ai/claude-haiku-4-5", azureClaude),
+            {
+                supported: true,
+                path1: true,
+                explicitCount: 0,
+            }
+        );
     });
 
     test("does not enable Path 1 from supports_prompt_caching alone", () => {
         const messages: OpenAIChatMessage[] = [{ role: "user", content: "do not stamp" }];
         const bedrockShapedModel: LiteLLMModelInfo = { supports_prompt_caching: true };
 
-        const summary = applyPromptCachePolicy(messages, bedrockShapedModel);
+        const summary = applyPromptCachePolicy(messages, "global.anthropic.claude-opus-4-7", bedrockShapedModel);
 
-        assert.strictEqual(modelSupportsPromptCacheControl(bedrockShapedModel), false);
+        assert.strictEqual(
+            modelSupportsPromptCacheControl("global.anthropic.claude-opus-4-7", bedrockShapedModel),
+            false
+        );
         assert.deepStrictEqual(summary, { supported: false, path1: false, explicitCount: 0 });
         assert.ok(!JSON.stringify(messages).includes("cache_control"));
+    });
+
+    test("does not enable Path 1 from prompt_cache_key", () => {
+        const openaiCard: LiteLLMModelInfo = {
+            supported_openai_params: ["prompt_cache_key", "prompt_cache_retention"],
+            supports_prompt_caching: true,
+            litellm_provider: "openai",
+        };
+
+        assert.strictEqual(modelSupportsPromptCacheControl("gpt-4o-mini", openaiCard), false);
+        assert.deepStrictEqual(
+            applyPromptCachePolicy([{ role: "user", content: "no stamp" }], "gpt-4o-mini", openaiCard),
+            {
+                supported: false,
+                path1: false,
+                explicitCount: 0,
+            }
+        );
+    });
+
+    test("ignores a lying GPT card that advertises cache_control", () => {
+        const lyingGptCard: LiteLLMModelInfo = {
+            supported_openai_params: ["cache_control", "prompt_cache_key"],
+            litellm_provider: "openai",
+        };
+
+        assert.strictEqual(modelSupportsPromptCacheControl("azure_ai/us-central/gpt-4o-mini", lyingGptCard), false);
+        assert.deepStrictEqual(
+            applyPromptCachePolicy(
+                [{ role: "user", content: "do not stamp" }],
+                "azure_ai/us-central/gpt-4o-mini",
+                lyingGptCard
+            ),
+            { supported: false, path1: false, explicitCount: 0 }
+        );
     });
 
     test("stamps the last eligible content block only for an explicit host marker", () => {
@@ -54,7 +111,7 @@ suite("Prompt cache control policy", () => {
             content: [{ type: "text", text: `message ${index}`, cache_control: { type: "ephemeral" } }],
         }));
 
-        const summary = applyPromptCachePolicy(messages, eligibleModel);
+        const summary = applyPromptCachePolicy(messages, claudeId, eligibleModel);
 
         assert.deepStrictEqual(summary, { supported: true, path1: false, explicitCount: 4 });
         assert.strictEqual(countCacheBreakpoints(messages), 4);
@@ -72,7 +129,7 @@ suite("Prompt cache control policy", () => {
             },
         ];
 
-        const summary = applyPromptCachePolicy(messages, { supported_openai_params: ["stream"] });
+        const summary = applyPromptCachePolicy(messages, claudeId, { supported_openai_params: ["stream"] });
 
         assert.deepStrictEqual(summary, { supported: false, path1: false, explicitCount: 0 });
         assert.strictEqual(countCacheBreakpoints(messages), 0);

--- a/src/utils/test/utils.test.ts
+++ b/src/utils/test/utils.test.ts
@@ -658,6 +658,51 @@ suite("Utility Unit Tests", () => {
             assert.strictEqual(out[0].content, "visible");
         });
 
+        test("V1 translates an explicit cache marker onto the last content block when enabled", () => {
+            const messages: vscode.LanguageModelChatMessage[] = [
+                {
+                    role: vscode.LanguageModelChatMessageRole.User,
+                    name: undefined,
+                    content: [
+                        new vscode.LanguageModelTextPart("visible"),
+                        new vscode.LanguageModelDataPart(
+                            Buffer.from('{"$mid":24,"data":"ZXBoZW1lcmFs"}'),
+                            "application/vnd.cache-control+json"
+                        ),
+                    ],
+                },
+            ];
+
+            const out = convertMessages(messages, { attachPromptCacheControl: true });
+
+            assert.deepStrictEqual(out[0].content, [
+                { type: "text", text: "visible", cache_control: { type: "ephemeral" } },
+            ]);
+            const serialized = JSON.stringify(out);
+            assert.ok(!serialized.includes("$mid"));
+            assert.ok(!serialized.includes("ZXBoZW1lcmFs"));
+        });
+
+        test("V2 translates an explicit cache marker onto the last content block when enabled", () => {
+            const messages = normalizeMessagesForV2Pipeline([
+                {
+                    role: vscode.LanguageModelChatMessageRole.User,
+                    name: undefined,
+                    content: [
+                        new vscode.LanguageModelTextPart("visible"),
+                        new vscode.LanguageModelDataPart(Buffer.from("ephemeral"), "cache_control"),
+                    ],
+                } as unknown as vscode.LanguageModelChatMessage,
+            ]);
+
+            const out = convertV2MessagesToOpenAI(messages, { attachPromptCacheControl: true });
+
+            assert.deepStrictEqual(out[0].content, [
+                { type: "text", text: "visible", cache_control: { type: "ephemeral" } },
+            ]);
+            assert.ok(!JSON.stringify(out).includes("ZXBoZW1lcmFs"));
+        });
+
         test("V2 transport preserves legitimate text/plain and application/json data parts", () => {
             // Sanity guard: while stripping cache_control, we must NOT accidentally
             // strip real JSON / text data parts that carry actual model context.


### PR DESCRIPTION
## Summary

Adds request-root `cache_control: {type: "ephemeral"}` for models whose card advertises `cache_control` in `supported_openai_params`. Anthropic then maintains a single auto-advancing cache breakpoint.

**Measured over 70 Claude Opus 5 turns: 90.2% cache read, 76% cost reduction ($12.20 vs $51.78 uncached).**

| Session style          | Turns | Read rate | Cost  | Uncached | Saved |
| ---------------------- | ----- | --------- | ----- | -------- | ----- |
| Long agentic loop      | 38    | 94.2%     | $6.40 | $33.92   | 81%   |
| Interactive multi-turn | 32    | 82.5%     | $5.80 | $17.86   | 68%   |

## Design

- **Eligibility:** `cache_control` in `supported_openai_params`. Deliberately *not* `supports_prompt_caching` — that's also true for providers with incompatible contracts.
- **Ordering is load-bearing:** `finalizeRequestBody()` enforces bypass → strip → prompt-cache. Applying it before the strip would silently drop the field.
- **Kept separate from gateway caching.** `extra_body.cache` (LiteLLM response-cache bypass) and `cache_control` (Anthropic prompt cache) are unrelated despite the shared word — see #135 for the history here.
- **Retry-safe:** rejection paths strip `cache_control` from both chat and `/responses` shapes, so a retry doesn't repeat the same failure.
- **Ineligible models are fully unstamped** to avoid cross-provider leakage.

## Also included

- Anthropic root usage fields (`cache_creation_input_tokens` / `cache_read_input_tokens`) mapped into the token snapshot — previously ignored, so cache activity was invisible in telemetry.
- `finalizeRequestBody()` de-duplicates a byte-identical tail across both request builders.
- `xvfb-run -a` in `test-coverage.mjs` — without it the suite cannot start when a stale X lock is present.

## Validation

| Gate          | Result                      |
| ------------- | --------------------------- |
| compile       | clean                       |
| lint          | 0 errors                    |
| format        | clean                       |
| test:coverage | **1029 passing** (main: 1012) |

| Coverage   | main   | branch     |
| ---------- | ------ | ---------- |
| Statements | 91.10% | **91.20%** |
| Branches   | 82.37% | 82.37%     |
| Functions  | 88.77% | **88.92%** |
| Lines      | 91.10% | **91.20%** |

## Deliberately excluded

- **Per-block (Path 2) stamping** — extension providers receive zero host breakpoints (verified: 23 requests, 470 tool-result parts, none at any depth). Upstream: microsoft/vscode#312940.
- **Extended 1h TTL** — modelled at 2.0x vs 1.25x write cost: 0.1% better on real traffic. Not worth it.
- **Own-stamp placement for turn boundaries** — boundary busts proved intermittent and the trigger isn't isolated. Upstream: microsoft/vscode#323641, #323642.

Closes #135
