### PR TITLE
📄 Proposal: send PDFs as file_data (#89)

### DIFF
--- a/src/adapters/dataUriContentItem.ts
+++ b/src/adapters/dataUriContentItem.ts
@@ -1,0 +1,36 @@
+import type { OpenAIChatMessageContentItem } from "../types";
+
+/**
+ * Binary MIME types that Copilot data parts should keep as OpenAI
+ * `image_url` data URIs. PDFs reuse the image content-item shape so
+ * `/chat/completions` and `/responses` copy-through stay unchanged.
+ */
+export function isDataUriMimeType(mimeType: string): boolean {
+    return mimeType.startsWith("image/") || mimeType === "application/pdf";
+}
+
+/**
+ * Encode a Copilot data part as an OpenAI `image_url` content item.
+ * Images and PDFs share this shape: `data:<mime>;base64,<bytes>`.
+ */
+export function toImageUrlContentItem(
+    mimeType: string,
+    data: Uint8Array | string | ArrayBuffer
+): OpenAIChatMessageContentItem {
+    return {
+        type: "image_url",
+        image_url: {
+            url: `data:${mimeType};base64,${encodeAsBase64(data)}`,
+        },
+    };
+}
+
+function encodeAsBase64(data: Uint8Array | string | ArrayBuffer): string {
+    if (data instanceof Uint8Array) {
+        return Buffer.from(data).toString("base64");
+    }
+    if (typeof data === "string") {
+        return Buffer.from(data, "utf-8").toString("base64");
+    }
+    return Buffer.from(data).toString("base64");
+}

--- a/src/adapters/dataUriContentItem.ts
+++ b/src/adapters/dataUriContentItem.ts
@@ -1,67 +1,39 @@
 import type { OpenAIChatMessageContentItem } from "../types";
 
-/** Image MIME types that Copilot data parts should keep as OpenAI `image_url` data URIs. */
-export function isDataUriMimeType(mimeType: string): boolean {
-    return mimeType.startsWith("image/");
-}
+const PDF_MIME_TYPE = "application/pdf";
 
-/** PDF MIME type encoded as an OpenAI `file` content item, not `image_url`. */
-export function isPdfMimeType(mimeType: string): boolean {
-    return mimeType === "application/pdf";
-}
+/** Filename LiteLLM/providers echo back for inline PDF bytes; they key off the MIME, not this name. */
+const PDF_FILENAME = "document.pdf";
 
 /**
- * Binary MIME types that converters should keep instead of dropping.
- * Images use `image_url`; PDFs use `file.file_data`.
+ * Binary data parts the converters encode inline instead of dropping.
+ * Everything else (audio, octet-stream, …) has no agreed OpenAI shape.
  */
 export function isBinaryContentMimeType(mimeType: string): boolean {
-    return isDataUriMimeType(mimeType) || isPdfMimeType(mimeType);
+    return mimeType.startsWith("image/") || mimeType === PDF_MIME_TYPE;
 }
 
 /**
- * Encode a Copilot data part as an OpenAI `image_url` content item.
- * Images use this shape: `data:<mime>;base64,<bytes>`.
+ * Encode a binary data part as an OpenAI content item carrying a
+ * `data:<mime>;base64,<bytes>` URI.
+ *
+ * The two shapes are not interchangeable: Azure rejects `application/pdf`
+ * inside `image_url` ("Expected … an image MIME type"), so PDFs must use
+ * `file.file_data`. That shape is the only one accepted by Azure, Vertex
+ * Gemini, and Bedrock/Vertex Claude alike, so it is applied for every
+ * backend rather than branched per provider.
  */
-export function toImageUrlContentItem(
-    mimeType: string,
-    data: Uint8Array | string | ArrayBuffer
-): OpenAIChatMessageContentItem {
-    return {
-        type: "image_url",
-        image_url: {
-            url: `data:${mimeType};base64,${encodeAsBase64(data)}`,
-        },
-    };
-}
-
-/**
- * Encode a Copilot PDF data part as an OpenAI `file` content item.
- * Azure, Gemini, and Claude all accepted `file.file_data` as a
- * `data:application/pdf;base64,...` URI on `/chat/completions`.
- */
-export function toFileContentItem(
-    mimeType: string,
-    data: Uint8Array | string | ArrayBuffer,
-    filename = "document.pdf"
-): OpenAIChatMessageContentItem {
-    return {
-        type: "file",
-        file: {
-            filename,
-            file_data: `data:${mimeType};base64,${encodeAsBase64(data)}`,
-        },
-    };
-}
-
-/** Route a kept binary MIME type to the matching OpenAI content-item shape. */
 export function toBinaryContentItem(
     mimeType: string,
     data: Uint8Array | string | ArrayBuffer
 ): OpenAIChatMessageContentItem {
-    if (isPdfMimeType(mimeType)) {
-        return toFileContentItem(mimeType, data);
+    const dataUri = `data:${mimeType};base64,${encodeAsBase64(data)}`;
+
+    if (mimeType === PDF_MIME_TYPE) {
+        return { type: "file", file: { filename: PDF_FILENAME, file_data: dataUri } };
     }
-    return toImageUrlContentItem(mimeType, data);
+
+    return { type: "image_url", image_url: { url: dataUri } };
 }
 
 function encodeAsBase64(data: Uint8Array | string | ArrayBuffer): string {

--- a/src/adapters/dataUriContentItem.ts
+++ b/src/adapters/dataUriContentItem.ts
@@ -1,17 +1,26 @@
 import type { OpenAIChatMessageContentItem } from "../types";
 
-/**
- * Binary MIME types that Copilot data parts should keep as OpenAI
- * `image_url` data URIs. PDFs reuse the image content-item shape so
- * `/chat/completions` and `/responses` copy-through stay unchanged.
- */
+/** Image MIME types that Copilot data parts should keep as OpenAI `image_url` data URIs. */
 export function isDataUriMimeType(mimeType: string): boolean {
-    return mimeType.startsWith("image/") || mimeType === "application/pdf";
+    return mimeType.startsWith("image/");
+}
+
+/** PDF MIME type encoded as an OpenAI `file` content item, not `image_url`. */
+export function isPdfMimeType(mimeType: string): boolean {
+    return mimeType === "application/pdf";
+}
+
+/**
+ * Binary MIME types that converters should keep instead of dropping.
+ * Images use `image_url`; PDFs use `file.file_data`.
+ */
+export function isBinaryContentMimeType(mimeType: string): boolean {
+    return isDataUriMimeType(mimeType) || isPdfMimeType(mimeType);
 }
 
 /**
  * Encode a Copilot data part as an OpenAI `image_url` content item.
- * Images and PDFs share this shape: `data:<mime>;base64,<bytes>`.
+ * Images use this shape: `data:<mime>;base64,<bytes>`.
  */
 export function toImageUrlContentItem(
     mimeType: string,
@@ -23,6 +32,36 @@ export function toImageUrlContentItem(
             url: `data:${mimeType};base64,${encodeAsBase64(data)}`,
         },
     };
+}
+
+/**
+ * Encode a Copilot PDF data part as an OpenAI `file` content item.
+ * Azure, Gemini, and Claude all accepted `file.file_data` as a
+ * `data:application/pdf;base64,...` URI on `/chat/completions`.
+ */
+export function toFileContentItem(
+    mimeType: string,
+    data: Uint8Array | string | ArrayBuffer,
+    filename = "document.pdf"
+): OpenAIChatMessageContentItem {
+    return {
+        type: "file",
+        file: {
+            filename,
+            file_data: `data:${mimeType};base64,${encodeAsBase64(data)}`,
+        },
+    };
+}
+
+/** Route a kept binary MIME type to the matching OpenAI content-item shape. */
+export function toBinaryContentItem(
+    mimeType: string,
+    data: Uint8Array | string | ArrayBuffer
+): OpenAIChatMessageContentItem {
+    if (isPdfMimeType(mimeType)) {
+        return toFileContentItem(mimeType, data);
+    }
+    return toImageUrlContentItem(mimeType, data);
 }
 
 function encodeAsBase64(data: Uint8Array | string | ArrayBuffer): string {

--- a/src/adapters/messageConverter.ts
+++ b/src/adapters/messageConverter.ts
@@ -3,7 +3,7 @@ import type { OpenAIChatMessage, OpenAIChatMessageContentItem, OpenAIToolCall, O
 import { Logger } from "../utils/logger";
 import { isCacheControlMimeType } from "../utils";
 import { sanitizeToolName, logToolNameTruncationLegacy } from "../utils/toolNameUtils";
-import { isDataUriMimeType, toImageUrlContentItem } from "./dataUriContentItem";
+import { isBinaryContentMimeType, toBinaryContentItem } from "./dataUriContentItem";
 
 /**
  * Options for message conversion from V2 format to OpenAI format.
@@ -259,8 +259,8 @@ function toOpenAIToolCall(
 /**
  * Appends a V2 data part to text or content items.
  *
- * Handles cache-control MIME parts (dropped), image/PDF MIME parts (converted
- * to image_url content items), and text/json MIME parts (appended to text parts).
+ * Handles cache-control MIME parts (dropped), image MIME parts (image_url),
+ * PDF MIME parts (file.file_data), and text/json MIME parts (appended to text).
  *
  * @param part - V2 data part
  * @param textParts - Buffer for text-only content
@@ -278,8 +278,8 @@ function appendDataPart(
         return;
     }
 
-    if (isDataUriMimeType(part.mimeType)) {
-        contentItems.push(toImageUrlContentItem(part.mimeType, part.data));
+    if (isBinaryContentMimeType(part.mimeType)) {
+        contentItems.push(toBinaryContentItem(part.mimeType, part.data));
         return;
     }
 

--- a/src/adapters/messageConverter.ts
+++ b/src/adapters/messageConverter.ts
@@ -29,7 +29,7 @@ export interface MessageConversionOptions {
  * - Supports V2ChatMessage part types: text, data, thinking, tool_call, tool_result
  * - Uses V2ChatMessage role for language model detection (preserves HCP role mapping)
  * - Normalizes tool calls via normalizeToolCallId before emitting
- * - Handles images and PDFs via data MIME parts (base64 encoded as OpenAI image_url)
+ * - Handles images as `image_url` and PDFs as `file.file_data` data URIs
  * - Drops cache-control MIME parts (they're opaque metadata, not content)
  * - Emits tool-result messages flush before regular messages (maintains ordering)
  *

--- a/src/adapters/messageConverter.ts
+++ b/src/adapters/messageConverter.ts
@@ -3,6 +3,7 @@ import type { OpenAIChatMessage, OpenAIChatMessageContentItem, OpenAIToolCall, O
 import { Logger } from "../utils/logger";
 import { isCacheControlMimeType } from "../utils";
 import { sanitizeToolName, logToolNameTruncationLegacy } from "../utils/toolNameUtils";
+import { isDataUriMimeType, toImageUrlContentItem } from "./dataUriContentItem";
 
 /**
  * Options for message conversion from V2 format to OpenAI format.
@@ -28,7 +29,7 @@ export interface MessageConversionOptions {
  * - Supports V2ChatMessage part types: text, data, thinking, tool_call, tool_result
  * - Uses V2ChatMessage role for language model detection (preserves HCP role mapping)
  * - Normalizes tool calls via normalizeToolCallId before emitting
- * - Handles images via data MIME parts (base64 encoded for OpenAI image_url format)
+ * - Handles images and PDFs via data MIME parts (base64 encoded as OpenAI image_url)
  * - Drops cache-control MIME parts (they're opaque metadata, not content)
  * - Emits tool-result messages flush before regular messages (maintains ordering)
  *
@@ -258,7 +259,7 @@ function toOpenAIToolCall(
 /**
  * Appends a V2 data part to text or content items.
  *
- * Handles cache-control MIME parts (dropped), image MIME parts (converted
+ * Handles cache-control MIME parts (dropped), image/PDF MIME parts (converted
  * to image_url content items), and text/json MIME parts (appended to text parts).
  *
  * @param part - V2 data part
@@ -277,13 +278,8 @@ function appendDataPart(
         return;
     }
 
-    if (part.mimeType.startsWith("image/")) {
-        contentItems.push({
-            type: "image_url",
-            image_url: {
-                url: `data:${part.mimeType};base64,${Buffer.from(part.data).toString("base64")}`,
-            },
-        });
+    if (isDataUriMimeType(part.mimeType)) {
+        contentItems.push(toImageUrlContentItem(part.mimeType, part.data));
         return;
     }
 

--- a/src/adapters/responsesAdapter.ts
+++ b/src/adapters/responsesAdapter.ts
@@ -15,6 +15,28 @@ function getResponsesReasoningEffort(effort: OpenAIChatCompletionRequest["reason
     return effort?.effort === "none" ? undefined : effort?.effort;
 }
 
+/** Inline binary content (image data URI or PDF `file_data`) that must survive the transform. */
+function isBinaryContentItem(item: OpenAIChatMessageContentItem): boolean {
+    return (
+        (item.type === "image_url" && typeof item.image_url?.url === "string") ||
+        (item.type === "file" && typeof item.file?.file_data === "string")
+    );
+}
+
+/**
+ * LiteLLM `/responses` requires message content to be a string or an array —
+ * a bare dict raises `ValueError: Invalid content type: <class 'dict'>`, so the
+ * content item is always array-wrapped.
+ */
+function toBinaryInputItem(role: "user" | "assistant", item: OpenAIChatMessageContentItem): LiteLLMResponseInputItem {
+    Logger.debug(`[responsesAdapter] ${role} binary content item: type=${item.type}`);
+    return {
+        type: "message",
+        role,
+        content: [item],
+    } as unknown as LiteLLMResponseInputItem;
+}
+
 /**
  * Transform a chat/completions request body to the responses API format.
  * The responses API uses "input" (array format) instead of "messages".
@@ -76,26 +98,8 @@ export function transformToResponsesFormat(requestBody: OpenAIChatCompletionRequ
                             role: "user",
                             content: contentItem.text,
                         });
-                    } else if (contentItem.type === "image_url" && contentItem.image_url?.url) {
-                        Logger.debug(
-                            `[responsesAdapter] User image: type=${contentItem.type}, url=${contentItem.image_url.url.substring(0, 50)}...`
-                        );
-                        // LiteLLM /responses requires content to be a string or array — NOT a bare dict.
-                        // Wrap the content item in an array to avoid ValueError: Invalid content type: <class 'dict'>
-                        inputArray.push({
-                            type: "message",
-                            role: "user",
-                            content: [contentItem],
-                        } as unknown as LiteLLMResponseInputItem);
-                    } else if (contentItem.type === "file" && contentItem.file?.file_data) {
-                        Logger.debug(
-                            `[responsesAdapter] User file: type=${contentItem.type}, filename=${contentItem.file.filename}`
-                        );
-                        inputArray.push({
-                            type: "message",
-                            role: "user",
-                            content: [contentItem],
-                        } as unknown as LiteLLMResponseInputItem);
+                    } else if (isBinaryContentItem(contentItem)) {
+                        inputArray.push(toBinaryInputItem("user", contentItem));
                     }
                 }
             }
@@ -113,26 +117,8 @@ export function transformToResponsesFormat(requestBody: OpenAIChatCompletionRequ
                             role: "assistant",
                             content: contentItem.text,
                         });
-                    } else if (contentItem.type === "image_url" && contentItem.image_url?.url) {
-                        Logger.debug(
-                            `[responsesAdapter] Assistant image: type=${contentItem.type}, url=${contentItem.image_url.url.substring(0, 50)}...`
-                        );
-                        // LiteLLM /responses requires content to be a string or array — NOT a bare dict.
-                        // Wrap the content item in an array to avoid ValueError: Invalid content type: <class 'dict'>
-                        inputArray.push({
-                            type: "message",
-                            role: "assistant",
-                            content: [contentItem],
-                        } as unknown as LiteLLMResponseInputItem);
-                    } else if (contentItem.type === "file" && contentItem.file?.file_data) {
-                        Logger.debug(
-                            `[responsesAdapter] Assistant file: type=${contentItem.type}, filename=${contentItem.file.filename}`
-                        );
-                        inputArray.push({
-                            type: "message",
-                            role: "assistant",
-                            content: [contentItem],
-                        } as unknown as LiteLLMResponseInputItem);
+                    } else if (isBinaryContentItem(contentItem)) {
+                        inputArray.push(toBinaryInputItem("assistant", contentItem));
                     }
                 }
             }

--- a/src/adapters/responsesAdapter.ts
+++ b/src/adapters/responsesAdapter.ts
@@ -29,7 +29,7 @@ function isBinaryContentItem(item: OpenAIChatMessageContentItem): boolean {
  * content item is always array-wrapped.
  */
 function toBinaryInputItem(role: "user" | "assistant", item: OpenAIChatMessageContentItem): LiteLLMResponseInputItem {
-    Logger.debug(`[responsesAdapter] ${role} binary content item: type=${item.type}`);
+    Logger.trace(`[responsesAdapter] ${role} binary content item: type=${item.type}`);
     return {
         type: "message",
         role,

--- a/src/adapters/responsesAdapter.ts
+++ b/src/adapters/responsesAdapter.ts
@@ -87,6 +87,15 @@ export function transformToResponsesFormat(requestBody: OpenAIChatCompletionRequ
                             role: "user",
                             content: [contentItem],
                         } as unknown as LiteLLMResponseInputItem);
+                    } else if (contentItem.type === "file" && contentItem.file?.file_data) {
+                        Logger.debug(
+                            `[responsesAdapter] User file: type=${contentItem.type}, filename=${contentItem.file.filename}`
+                        );
+                        inputArray.push({
+                            type: "message",
+                            role: "user",
+                            content: [contentItem],
+                        } as unknown as LiteLLMResponseInputItem);
                     }
                 }
             }
@@ -110,6 +119,15 @@ export function transformToResponsesFormat(requestBody: OpenAIChatCompletionRequ
                         );
                         // LiteLLM /responses requires content to be a string or array — NOT a bare dict.
                         // Wrap the content item in an array to avoid ValueError: Invalid content type: <class 'dict'>
+                        inputArray.push({
+                            type: "message",
+                            role: "assistant",
+                            content: [contentItem],
+                        } as unknown as LiteLLMResponseInputItem);
+                    } else if (contentItem.type === "file" && contentItem.file?.file_data) {
+                        Logger.debug(
+                            `[responsesAdapter] Assistant file: type=${contentItem.type}, filename=${contentItem.file.filename}`
+                        );
                         inputArray.push({
                             type: "message",
                             role: "assistant",

--- a/src/adapters/test/dataUriContentItem.test.ts
+++ b/src/adapters/test/dataUriContentItem.test.ts
@@ -1,21 +1,24 @@
 import * as assert from "assert";
-import { isDataUriMimeType, toImageUrlContentItem } from "../dataUriContentItem";
+import { isDataUriMimeType, isPdfMimeType, toFileContentItem, toImageUrlContentItem } from "../dataUriContentItem";
 
 suite("dataUriContentItem", () => {
-    test("recognizes image and PDF MIME types", () => {
+    test("recognizes image MIME types separately from PDF", () => {
         assert.strictEqual(isDataUriMimeType("image/png"), true);
-        assert.strictEqual(isDataUriMimeType("application/pdf"), true);
+        assert.strictEqual(isDataUriMimeType("application/pdf"), false);
+        assert.strictEqual(isPdfMimeType("application/pdf"), true);
+        assert.strictEqual(isPdfMimeType("image/png"), false);
         assert.strictEqual(isDataUriMimeType("application/octet-stream"), false);
         assert.strictEqual(isDataUriMimeType("text/plain"), false);
     });
 
-    test("encodes PDF bytes as an image_url data URI", () => {
+    test("encodes PDF bytes as a file data URI", () => {
         const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
-        const item = toImageUrlContentItem("application/pdf", pdfBytes);
+        const item = toFileContentItem("application/pdf", pdfBytes);
 
-        assert.strictEqual(item.type, "image_url");
+        assert.strictEqual(item.type, "file");
+        assert.strictEqual(item.file?.filename, "document.pdf");
         assert.strictEqual(
-            item.image_url?.url,
+            item.file?.file_data,
             `data:application/pdf;base64,${Buffer.from(pdfBytes).toString("base64")}`
         );
     });

--- a/src/adapters/test/dataUriContentItem.test.ts
+++ b/src/adapters/test/dataUriContentItem.test.ts
@@ -1,21 +1,28 @@
 import * as assert from "assert";
-import { isDataUriMimeType, isPdfMimeType, toFileContentItem, toImageUrlContentItem } from "../dataUriContentItem";
+import { isBinaryContentMimeType, toBinaryContentItem } from "../dataUriContentItem";
 
 suite("dataUriContentItem", () => {
-    test("recognizes image MIME types separately from PDF", () => {
-        assert.strictEqual(isDataUriMimeType("image/png"), true);
-        assert.strictEqual(isDataUriMimeType("application/pdf"), false);
-        assert.strictEqual(isPdfMimeType("application/pdf"), true);
-        assert.strictEqual(isPdfMimeType("image/png"), false);
-        assert.strictEqual(isDataUriMimeType("application/octet-stream"), false);
-        assert.strictEqual(isDataUriMimeType("text/plain"), false);
+    test("keeps image and PDF MIME types and drops everything else", () => {
+        assert.strictEqual(isBinaryContentMimeType("image/png"), true);
+        assert.strictEqual(isBinaryContentMimeType("application/pdf"), true);
+        assert.strictEqual(isBinaryContentMimeType("application/octet-stream"), false);
+        assert.strictEqual(isBinaryContentMimeType("text/plain"), false);
     });
 
-    test("encodes PDF bytes as a file data URI", () => {
+    test("encodes images as an image_url data URI", () => {
+        const bytes = new Uint8Array([0x89, 0x50]);
+        const item = toBinaryContentItem("image/png", bytes);
+
+        assert.strictEqual(item.type, "image_url");
+        assert.strictEqual(item.image_url?.url, `data:image/png;base64,${Buffer.from(bytes).toString("base64")}`);
+    });
+
+    test("encodes PDFs as file_data because Azure rejects them inside image_url", () => {
         const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
-        const item = toFileContentItem("application/pdf", pdfBytes);
+        const item = toBinaryContentItem("application/pdf", pdfBytes);
 
         assert.strictEqual(item.type, "file");
+        assert.strictEqual(item.image_url, undefined);
         assert.strictEqual(item.file?.filename, "document.pdf");
         assert.strictEqual(
             item.file?.file_data,
@@ -25,11 +32,9 @@ suite("dataUriContentItem", () => {
 
     test("encodes string and ArrayBuffer data the same way as Uint8Array", () => {
         const bytes = new Uint8Array([0x61, 0x62, 0x63]);
-        const expected = toImageUrlContentItem("image/png", bytes).image_url?.url;
-        const asString = toImageUrlContentItem("image/png", "abc");
-        const asBuffer = toImageUrlContentItem("image/png", bytes.buffer);
+        const expected = toBinaryContentItem("image/png", bytes).image_url?.url;
 
-        assert.strictEqual(asString.image_url?.url, expected);
-        assert.strictEqual(asBuffer.image_url?.url, expected);
+        assert.strictEqual(toBinaryContentItem("image/png", "abc").image_url?.url, expected);
+        assert.strictEqual(toBinaryContentItem("image/png", bytes.buffer).image_url?.url, expected);
     });
 });

--- a/src/adapters/test/dataUriContentItem.test.ts
+++ b/src/adapters/test/dataUriContentItem.test.ts
@@ -1,0 +1,32 @@
+import * as assert from "assert";
+import { isDataUriMimeType, toImageUrlContentItem } from "../dataUriContentItem";
+
+suite("dataUriContentItem", () => {
+    test("recognizes image and PDF MIME types", () => {
+        assert.strictEqual(isDataUriMimeType("image/png"), true);
+        assert.strictEqual(isDataUriMimeType("application/pdf"), true);
+        assert.strictEqual(isDataUriMimeType("application/octet-stream"), false);
+        assert.strictEqual(isDataUriMimeType("text/plain"), false);
+    });
+
+    test("encodes PDF bytes as an image_url data URI", () => {
+        const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
+        const item = toImageUrlContentItem("application/pdf", pdfBytes);
+
+        assert.strictEqual(item.type, "image_url");
+        assert.strictEqual(
+            item.image_url?.url,
+            `data:application/pdf;base64,${Buffer.from(pdfBytes).toString("base64")}`
+        );
+    });
+
+    test("encodes string and ArrayBuffer data the same way as Uint8Array", () => {
+        const bytes = new Uint8Array([0x61, 0x62, 0x63]);
+        const expected = toImageUrlContentItem("image/png", bytes).image_url?.url;
+        const asString = toImageUrlContentItem("image/png", "abc");
+        const asBuffer = toImageUrlContentItem("image/png", bytes.buffer);
+
+        assert.strictEqual(asString.image_url?.url, expected);
+        assert.strictEqual(asBuffer.image_url?.url, expected);
+    });
+});

--- a/src/adapters/test/messageConverter.test.ts
+++ b/src/adapters/test/messageConverter.test.ts
@@ -680,12 +680,34 @@ suite("Message Converters — appendDataPart (via convertMessagesToOpenAI)", () 
         assert.strictEqual(result.length, 0);
     });
 
-    test("silently drops data part with application/pdf MIME type", () => {
-        const result = convertMessagesToOpenAI(
-            [dataMessage("application/pdf", new Uint8Array([0x25, 0x50, 0x44, 0x46]))],
-            defaultOptions
-        );
-        assert.strictEqual(result.length, 0);
+    test("encodes application/pdf data part as an image_url data URI", () => {
+        const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
+        const result = convertMessagesToOpenAI([dataMessage("application/pdf", pdfBytes)], defaultOptions);
+        assert.strictEqual(result.length, 1);
+        const item = (result[0].content as { type: string; image_url: { url: string } }[])[0];
+        assert.strictEqual(item.type, "image_url");
+        assert.ok(item.image_url.url.startsWith("data:application/pdf;base64,"));
+        assert.strictEqual(item.image_url.url, `data:application/pdf;base64,${Buffer.from(pdfBytes).toString("base64")}`);
+    });
+
+    test("keeps text and encoded PDF in the same outbound message", () => {
+        const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
+        const message: V2ChatMessage = {
+            role: "user",
+            name: undefined,
+            content: [
+                { type: "text", text: "See attached PDF" },
+                { type: "data", mimeType: "application/pdf", data: pdfBytes },
+            ],
+        };
+        const result = convertMessagesToOpenAI([message], defaultOptions);
+        assert.strictEqual(result.length, 1);
+        const items = result[0].content as { type: string; text?: string; image_url?: { url: string } }[];
+        assert.strictEqual(items.length, 2);
+        assert.strictEqual(items[0].type, "text");
+        assert.strictEqual(items[0].text, "See attached PDF");
+        assert.strictEqual(items[1].type, "image_url");
+        assert.ok(items[1].image_url?.url.startsWith("data:application/pdf;base64,"));
     });
 
     // ── Mixed content: data + text in same message ────────────────────────

--- a/src/adapters/test/messageConverter.test.ts
+++ b/src/adapters/test/messageConverter.test.ts
@@ -680,14 +680,18 @@ suite("Message Converters — appendDataPart (via convertMessagesToOpenAI)", () 
         assert.strictEqual(result.length, 0);
     });
 
-    test("encodes application/pdf data part as an image_url data URI", () => {
+    test("encodes application/pdf data part as a file data URI", () => {
         const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
         const result = convertMessagesToOpenAI([dataMessage("application/pdf", pdfBytes)], defaultOptions);
         assert.strictEqual(result.length, 1);
-        const item = (result[0].content as { type: string; image_url: { url: string } }[])[0];
-        assert.strictEqual(item.type, "image_url");
-        assert.ok(item.image_url.url.startsWith("data:application/pdf;base64,"));
-        assert.strictEqual(item.image_url.url, `data:application/pdf;base64,${Buffer.from(pdfBytes).toString("base64")}`);
+        const item = (result[0].content as { type: string; file: { filename: string; file_data: string } }[])[0];
+        assert.strictEqual(item.type, "file");
+        assert.strictEqual(item.file.filename, "document.pdf");
+        assert.ok(item.file.file_data.startsWith("data:application/pdf;base64,"));
+        assert.strictEqual(
+            item.file.file_data,
+            `data:application/pdf;base64,${Buffer.from(pdfBytes).toString("base64")}`
+        );
     });
 
     test("keeps text and encoded PDF in the same outbound message", () => {
@@ -702,12 +706,16 @@ suite("Message Converters — appendDataPart (via convertMessagesToOpenAI)", () 
         };
         const result = convertMessagesToOpenAI([message], defaultOptions);
         assert.strictEqual(result.length, 1);
-        const items = result[0].content as { type: string; text?: string; image_url?: { url: string } }[];
+        const items = result[0].content as {
+            type: string;
+            text?: string;
+            file?: { filename: string; file_data: string };
+        }[];
         assert.strictEqual(items.length, 2);
         assert.strictEqual(items[0].type, "text");
         assert.strictEqual(items[0].text, "See attached PDF");
-        assert.strictEqual(items[1].type, "image_url");
-        assert.ok(items[1].image_url?.url.startsWith("data:application/pdf;base64,"));
+        assert.strictEqual(items[1].type, "file");
+        assert.ok(items[1].file?.file_data.startsWith("data:application/pdf;base64,"));
     });
 
     // ── Mixed content: data + text in same message ────────────────────────

--- a/src/adapters/test/responsesAdapter.test.ts
+++ b/src/adapters/test/responsesAdapter.test.ts
@@ -347,6 +347,26 @@ suite("Responses Adapter Unit Tests", () => {
         assert.deepStrictEqual(content[0].image_url, { url: "https://example.com/image.png" });
     });
 
+    test("transformToResponsesFormat does not strip a PDF image_url data URI", () => {
+        const pdfUrl = "data:application/pdf;base64,JVBERi0=";
+        const body = transformToResponsesFormat({
+            model: "gpt-4o",
+            messages: [
+                {
+                    role: "user",
+                    content: [{ type: "image_url", image_url: { url: pdfUrl } }],
+                },
+            ],
+        });
+
+        const input = body.input as Record<string, unknown>[];
+        assert.strictEqual(input.length, 1);
+        const content = input[0].content as Record<string, unknown>[];
+        assert.ok(Array.isArray(content), "PDF image_url content must stay array-wrapped");
+        assert.strictEqual(content[0].type, "image_url");
+        assert.deepStrictEqual(content[0].image_url, { url: pdfUrl });
+    });
+
     test("transformToResponsesFormat wraps assistant image_url content item in array (not bare dict)", () => {
         // Companion to the user image test — assistant vision messages have the same bug
         const body = transformToResponsesFormat({

--- a/src/adapters/test/responsesAdapter.test.ts
+++ b/src/adapters/test/responsesAdapter.test.ts
@@ -347,14 +347,14 @@ suite("Responses Adapter Unit Tests", () => {
         assert.deepStrictEqual(content[0].image_url, { url: "https://example.com/image.png" });
     });
 
-    test("transformToResponsesFormat does not strip a PDF image_url data URI", () => {
+    test("transformToResponsesFormat does not strip a PDF file data URI", () => {
         const pdfUrl = "data:application/pdf;base64,JVBERi0=";
         const body = transformToResponsesFormat({
             model: "gpt-4o",
             messages: [
                 {
                     role: "user",
-                    content: [{ type: "image_url", image_url: { url: pdfUrl } }],
+                    content: [{ type: "file", file: { filename: "document.pdf", file_data: pdfUrl } }],
                 },
             ],
         });
@@ -362,9 +362,9 @@ suite("Responses Adapter Unit Tests", () => {
         const input = body.input as Record<string, unknown>[];
         assert.strictEqual(input.length, 1);
         const content = input[0].content as Record<string, unknown>[];
-        assert.ok(Array.isArray(content), "PDF image_url content must stay array-wrapped");
-        assert.strictEqual(content[0].type, "image_url");
-        assert.deepStrictEqual(content[0].image_url, { url: pdfUrl });
+        assert.ok(Array.isArray(content), "PDF file content must stay array-wrapped");
+        assert.strictEqual(content[0].type, "file");
+        assert.deepStrictEqual(content[0].file, { filename: "document.pdf", file_data: pdfUrl });
     });
 
     test("transformToResponsesFormat wraps assistant image_url content item in array (not bare dict)", () => {

--- a/src/adapters/v2OpenAIMessageConverter.ts
+++ b/src/adapters/v2OpenAIMessageConverter.ts
@@ -4,7 +4,7 @@ import { sanitizeToolName } from "../utils/toolNameUtils";
 import type { V2ChatMessage, V2MessagePart } from "../providers/v2Types";
 import type { OpenAIChatMessage, OpenAIChatMessageContentItem, OpenAIChatRole, OpenAIToolCall } from "../types";
 import { applyEphemeralCacheControl } from "../utils/promptCacheControl";
-import { isDataUriMimeType, toImageUrlContentItem } from "./dataUriContentItem";
+import { isBinaryContentMimeType, toBinaryContentItem } from "./dataUriContentItem";
 
 interface V2OpenAIConversionOptions {
     normalizeToolCallId: (id: string) => string;
@@ -208,8 +208,8 @@ function appendDataPart(
         return options.attachPromptCacheControl === true;
     }
 
-    if (isDataUriMimeType(part.mimeType)) {
-        contentItems.push(toImageUrlContentItem(part.mimeType, part.data));
+    if (isBinaryContentMimeType(part.mimeType)) {
+        contentItems.push(toBinaryContentItem(part.mimeType, part.data));
         return false;
     }
 

--- a/src/adapters/v2OpenAIMessageConverter.ts
+++ b/src/adapters/v2OpenAIMessageConverter.ts
@@ -4,6 +4,7 @@ import { sanitizeToolName } from "../utils/toolNameUtils";
 import type { V2ChatMessage, V2MessagePart } from "../providers/v2Types";
 import type { OpenAIChatMessage, OpenAIChatMessageContentItem, OpenAIChatRole, OpenAIToolCall } from "../types";
 import { applyEphemeralCacheControl } from "../utils/promptCacheControl";
+import { isDataUriMimeType, toImageUrlContentItem } from "./dataUriContentItem";
 
 interface V2OpenAIConversionOptions {
     normalizeToolCallId: (id: string) => string;
@@ -207,13 +208,8 @@ function appendDataPart(
         return options.attachPromptCacheControl === true;
     }
 
-    if (part.mimeType.startsWith("image/")) {
-        contentItems.push({
-            type: "image_url",
-            image_url: {
-                url: `data:${part.mimeType};base64,${Buffer.from(part.data).toString("base64")}`,
-            },
-        });
+    if (isDataUriMimeType(part.mimeType)) {
+        contentItems.push(toImageUrlContentItem(part.mimeType, part.data));
         return false;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,13 +21,19 @@ export interface OpenAICacheControl {
 }
 
 /**
- * Content item for vision/image support in OpenAI messages
+ * Content item for vision/image and file support in OpenAI messages.
+ * PDFs use the `file` shape (`file.file_data` data URI) rather than `image_url`,
+ * because Azure rejects `application/pdf` inside `image_url`.
  */
 export interface OpenAIChatMessageContentItem {
-    type: "text" | "image_url";
+    type: "text" | "image_url" | "file";
     text?: string;
     image_url?: {
         url: string;
+    };
+    file?: {
+        filename: string;
+        file_data: string;
     };
     /** Explicit host-provided cache breakpoint. Never created automatically. */
     cache_control?: OpenAICacheControl;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,7 @@ import type {
 } from "./types";
 import { applyEphemeralCacheControl } from "./utils/promptCacheControl";
 import { Logger } from "./utils/logger";
+import { isDataUriMimeType, toImageUrlContentItem } from "./adapters/dataUriContentItem";
 
 /**
  * Normalize tool call IDs to be compatible with OpenAI-compatible providers
@@ -420,22 +421,9 @@ export function convertMessages(
                     // "application/vnd.cache-control+json" cannot slip through.
                     Logger.trace(`[convertMessages] Dropping cache_control part (mimeType: ${part.mimeType})`);
                     hasCacheControlMarker = true;
-                } else if (part.mimeType.startsWith("image/")) {
-                    // Convert image data to base64 for OpenAI vision API
-                    let base64Data: string;
-                    if (part.data instanceof Uint8Array) {
-                        base64Data = Buffer.from(part.data).toString("base64");
-                    } else if (typeof part.data === "string") {
-                        base64Data = Buffer.from(part.data, "utf-8").toString("base64");
-                    } else {
-                        base64Data = Buffer.from(part.data as unknown as ArrayBuffer).toString("base64");
-                    }
-                    contentItems.push({
-                        type: "image_url",
-                        image_url: {
-                            url: `data:${part.mimeType};base64,${base64Data}`,
-                        },
-                    });
+                } else if (isDataUriMimeType(part.mimeType)) {
+                    // Images and PDFs share the OpenAI image_url data-URI shape.
+                    contentItems.push(toImageUrlContentItem(part.mimeType, part.data));
                 } else if (part.mimeType.startsWith("application/json")) {
                     // Handle JSON data parts by decoding and appending as text
                     const jsonStr = Buffer.from(part.data).toString("utf-8");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@ import type {
 } from "./types";
 import { applyEphemeralCacheControl } from "./utils/promptCacheControl";
 import { Logger } from "./utils/logger";
-import { isDataUriMimeType, toImageUrlContentItem } from "./adapters/dataUriContentItem";
+import { isBinaryContentMimeType, toBinaryContentItem } from "./adapters/dataUriContentItem";
 
 /**
  * Normalize tool call IDs to be compatible with OpenAI-compatible providers
@@ -421,9 +421,10 @@ export function convertMessages(
                     // "application/vnd.cache-control+json" cannot slip through.
                     Logger.trace(`[convertMessages] Dropping cache_control part (mimeType: ${part.mimeType})`);
                     hasCacheControlMarker = true;
-                } else if (isDataUriMimeType(part.mimeType)) {
-                    // Images and PDFs share the OpenAI image_url data-URI shape.
-                    contentItems.push(toImageUrlContentItem(part.mimeType, part.data));
+                } else if (isBinaryContentMimeType(part.mimeType)) {
+                    // Images stay as image_url; PDFs use file.file_data so Azure
+                    // does not reject application/pdf inside image_url.
+                    contentItems.push(toBinaryContentItem(part.mimeType, part.data));
                 } else if (part.mimeType.startsWith("application/json")) {
                     // Handle JSON data parts by decoding and appending as text
                     const jsonStr = Buffer.from(part.data).toString("utf-8");

--- a/src/utils/promptCacheControl.ts
+++ b/src/utils/promptCacheControl.ts
@@ -36,7 +36,7 @@ export function modelSupportsPromptCacheControl(modelId: string, modelInfo?: Lit
 export function applyEphemeralCacheControl(content: OpenAIChatMessageContentItem[]): boolean {
     for (let index = content.length - 1; index >= 0; index--) {
         const item = content[index];
-        if (item.type === "text" || item.type === "image_url") {
+        if (item.type === "text" || item.type === "image_url" || item.type === "file") {
             item.cache_control = { ...EPHEMERAL_CACHE_CONTROL };
             return true;
         }

--- a/src/utils/test/promptCacheControl.test.ts
+++ b/src/utils/test/promptCacheControl.test.ts
@@ -105,6 +105,25 @@ suite("Prompt cache control policy", () => {
         assert.deepStrictEqual(content[2].cache_control, { type: "ephemeral" });
     });
 
+    test("stamps cache_control on a trailing PDF file item", () => {
+        const content: OpenAIChatMessageContentItem[] = [
+            { type: "text" as const, text: "analyze this PDF" },
+            {
+                type: "file" as const,
+                file: {
+                    filename: "secret.pdf",
+                    file_data: "data:application/pdf;base64,JVBERi0=",
+                },
+            },
+        ];
+
+        const applied = applyEphemeralCacheControl(content);
+
+        assert.strictEqual(applied, true);
+        assert.strictEqual(content[0].cache_control, undefined);
+        assert.deepStrictEqual(content[1].cache_control, { type: "ephemeral" });
+    });
+
     test("keeps four explicit block stamps but omits Path 1", () => {
         const messages: OpenAIChatMessage[] = Array.from({ length: 5 }, (_, index) => ({
             role: "user",

--- a/src/utils/test/utils.test.ts
+++ b/src/utils/test/utils.test.ts
@@ -104,11 +104,11 @@ suite("Utility Unit Tests", () => {
 
         const out = convertMessages(messages) as unknown as Record<string, unknown>[];
         assert.strictEqual(out.length, 1);
-        const content = out[0].content as { type: string; image_url: { url: string } }[];
+        const content = out[0].content as { type: string; file: { filename: string; file_data: string } }[];
         assert.ok(Array.isArray(content));
         assert.strictEqual(content.length, 1);
-        assert.strictEqual(content[0].type, "image_url");
-        assert.ok(content[0].image_url.url.startsWith("data:application/pdf;base64,"));
+        assert.strictEqual(content[0].type, "file");
+        assert.ok(content[0].file.file_data.startsWith("data:application/pdf;base64,"));
     });
 
     test("convertMessages keeps text and encoded PDF together", () => {
@@ -125,12 +125,16 @@ suite("Utility Unit Tests", () => {
         ];
 
         const out = convertMessages(messages) as unknown as Record<string, unknown>[];
-        const content = out[0].content as { type: string; text?: string; image_url?: { url: string } }[];
+        const content = out[0].content as {
+            type: string;
+            text?: string;
+            file?: { filename: string; file_data: string };
+        }[];
         assert.strictEqual(content.length, 2);
         assert.strictEqual(content[0].type, "text");
         assert.strictEqual(content[0].text, "Please read this");
-        assert.strictEqual(content[1].type, "image_url");
-        assert.ok(content[1].image_url?.url.startsWith("data:application/pdf;base64,"));
+        assert.strictEqual(content[1].type, "file");
+        assert.ok(content[1].file?.file_data.startsWith("data:application/pdf;base64,"));
     });
 
     test("convertMessages still drops unrecognized octet-stream data parts", () => {
@@ -498,10 +502,10 @@ suite("Utility Unit Tests", () => {
         ]);
 
         assert.strictEqual(openai.length, 1);
-        const content = openai[0].content as { type: string; image_url: { url: string } }[];
+        const content = openai[0].content as { type: string; file: { filename: string; file_data: string } }[];
         assert.ok(Array.isArray(content));
-        assert.strictEqual(content[0].type, "image_url");
-        assert.ok(content[0].image_url.url.startsWith("data:application/pdf;base64,"));
+        assert.strictEqual(content[0].type, "file");
+        assert.ok(content[0].file.file_data.startsWith("data:application/pdf;base64,"));
     });
 
     test("convertV2MessagesToOpenAI keeps text and encoded PDF together", () => {
@@ -517,11 +521,15 @@ suite("Utility Unit Tests", () => {
             },
         ]);
 
-        const content = openai[0].content as { type: string; text?: string; image_url?: { url: string } }[];
+        const content = openai[0].content as {
+            type: string;
+            text?: string;
+            file?: { filename: string; file_data: string };
+        }[];
         assert.strictEqual(content.length, 2);
         assert.strictEqual(content[0].type, "text");
         assert.strictEqual(content[0].text, "Please read this");
-        assert.ok(content[1].image_url?.url.startsWith("data:application/pdf;base64,"));
+        assert.ok(content[1].file?.file_data.startsWith("data:application/pdf;base64,"));
     });
 
     test("convertV2MessagesToOpenAI still drops unrecognized octet-stream data parts", () => {

--- a/src/utils/test/utils.test.ts
+++ b/src/utils/test/utils.test.ts
@@ -92,6 +92,60 @@ suite("Utility Unit Tests", () => {
         assert.ok(url.startsWith("data:image/png;base64,"));
     });
 
+    test("convertMessages encodes a PDF-only message instead of dropping it", () => {
+        const pdfData = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
+        const messages: vscode.LanguageModelChatMessage[] = [
+            {
+                role: vscode.LanguageModelChatMessageRole.User,
+                content: [new vscode.LanguageModelDataPart(pdfData, "application/pdf")],
+                name: undefined,
+            },
+        ];
+
+        const out = convertMessages(messages) as unknown as Record<string, unknown>[];
+        assert.strictEqual(out.length, 1);
+        const content = out[0].content as { type: string; image_url: { url: string } }[];
+        assert.ok(Array.isArray(content));
+        assert.strictEqual(content.length, 1);
+        assert.strictEqual(content[0].type, "image_url");
+        assert.ok(content[0].image_url.url.startsWith("data:application/pdf;base64,"));
+    });
+
+    test("convertMessages keeps text and encoded PDF together", () => {
+        const pdfData = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
+        const messages: vscode.LanguageModelChatMessage[] = [
+            {
+                role: vscode.LanguageModelChatMessageRole.User,
+                content: [
+                    new vscode.LanguageModelTextPart("Please read this"),
+                    new vscode.LanguageModelDataPart(pdfData, "application/pdf"),
+                ],
+                name: undefined,
+            },
+        ];
+
+        const out = convertMessages(messages) as unknown as Record<string, unknown>[];
+        const content = out[0].content as { type: string; text?: string; image_url?: { url: string } }[];
+        assert.strictEqual(content.length, 2);
+        assert.strictEqual(content[0].type, "text");
+        assert.strictEqual(content[0].text, "Please read this");
+        assert.strictEqual(content[1].type, "image_url");
+        assert.ok(content[1].image_url?.url.startsWith("data:application/pdf;base64,"));
+    });
+
+    test("convertMessages still drops unrecognized octet-stream data parts", () => {
+        const messages: vscode.LanguageModelChatMessage[] = [
+            {
+                role: vscode.LanguageModelChatMessageRole.User,
+                content: [new vscode.LanguageModelDataPart(new Uint8Array([1, 2, 3]), "application/octet-stream")],
+                name: undefined,
+            },
+        ];
+
+        const out = convertMessages(messages);
+        assert.strictEqual(out.length, 0);
+    });
+
     test("convertMessages emits tool calls and tool results", () => {
         const callId = "call-1";
         const messages: vscode.LanguageModelChatMessage[] = [
@@ -431,6 +485,55 @@ suite("Utility Unit Tests", () => {
         assert.strictEqual(openai[0].role, "assistant");
         assert.ok(openai[0].tool_calls);
         assert.strictEqual(openai[1].role, "tool");
+    });
+
+    test("convertV2MessagesToOpenAI encodes a PDF-only message instead of dropping it", () => {
+        const pdfData = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
+        const openai = convertV2MessagesToOpenAI([
+            {
+                role: "user",
+                name: undefined,
+                content: [{ type: "data", mimeType: "application/pdf", data: pdfData }],
+            },
+        ]);
+
+        assert.strictEqual(openai.length, 1);
+        const content = openai[0].content as { type: string; image_url: { url: string } }[];
+        assert.ok(Array.isArray(content));
+        assert.strictEqual(content[0].type, "image_url");
+        assert.ok(content[0].image_url.url.startsWith("data:application/pdf;base64,"));
+    });
+
+    test("convertV2MessagesToOpenAI keeps text and encoded PDF together", () => {
+        const pdfData = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
+        const openai = convertV2MessagesToOpenAI([
+            {
+                role: "user",
+                name: undefined,
+                content: [
+                    { type: "text", text: "Please read this" },
+                    { type: "data", mimeType: "application/pdf", data: pdfData },
+                ],
+            },
+        ]);
+
+        const content = openai[0].content as { type: string; text?: string; image_url?: { url: string } }[];
+        assert.strictEqual(content.length, 2);
+        assert.strictEqual(content[0].type, "text");
+        assert.strictEqual(content[0].text, "Please read this");
+        assert.ok(content[1].image_url?.url.startsWith("data:application/pdf;base64,"));
+    });
+
+    test("convertV2MessagesToOpenAI still drops unrecognized octet-stream data parts", () => {
+        const openai = convertV2MessagesToOpenAI([
+            {
+                role: "user",
+                name: undefined,
+                content: [{ type: "data", mimeType: "application/octet-stream", data: new Uint8Array([1, 2, 3]) }],
+            },
+        ]);
+
+        assert.strictEqual(openai.length, 0);
     });
 
     test("V2 validation allows tool results followed by adjacent user text", () => {


### PR DESCRIPTION
## Change Log / Overview

📄 Proposed PDF pass-through for #89. `editTools` stays override-only after review: a non-empty hint short-circuits Copilot Chat's own edit-tool preferences, so derived capabilities no longer guess a list.

### 1. PDF data parts reach LiteLLM (`file.file_data`)

Both message converters silently dropped `application/pdf` data parts, even though the token estimators already counted them and the gateway advertises `supports_pdf_input: true` for Claude, Gemini, and Azure GPT routes.

The issue text suggested reusing the image shape. I probed that against a real one-page PDF on `/chat/completions` and it doesn't hold up:

| Content shape                                         | Vertex Gemini | Bedrock/Vertex Claude | Azure GPT     |
|-------------------------------------------------------|---------------|-----------------------|---------------|
| `image_url` with `data:application/pdf;base64,…`      | reads PDF     | reads PDF             | **400**       |
| `file.file_data` with `data:application/pdf;base64,…` | reads PDF     | reads PDF             | **reads PDF** |
| `file.file_data` with bare base64 (no `data:` prefix) | 400           | 500                   | 400           |
| `input_file`                                          | 500           | 500                   | 500           |
| Anthropic-native `document.source.base64`             | 200, ignored  | reads PDF             | 400           |

Azure is explicit: `Invalid image URL … Expected a base64-encoded data URL with an image MIME type … but got unsupported MIME type 'application/pdf'`.

So PDFs use `{ type: "file", file: { filename, file_data } }` and images keep `image_url`. `file.file_data` is the only shape all three families accept, which is why it's applied unconditionally rather than branched per provider.

### 2. Removed duplicated capability mapping

`buildCapabilities()` in the provider base was unused outside its own tests, and the commit provider hardcoded `{ toolCalling: true, imageInput: false }`. Both now go through the shared registry derivation. `editTools` is still only emitted when `modelCapabilitiesOverrides` lists recognized tool ids.

---

### ⚠️ What is **not** verified

VS Code has not been observed handing this provider an `application/pdf` `LanguageModelDataPart` at all. Copilot Chat resolves attached PDFs with workspace/terminal tools first (`read_file`, `cat`, even `pdfplumber`), and `LanguageModelChatCapabilities` has no PDF/document capability a BYOK provider could advertise — so the host has no way to know the model would accept one. Tested on WSL remote and Windows local, drag-drop and attach.

The conversion path is therefore verified by running the **compiled converter's own output** against the gateway rather than through the chat UI:

```
gpt-5.6-luna                       HTTP 200 ok=true :: ORANGE-MANGO-PROTOCOL-42
vertex_ai/gemini-3.1-flash-lite    HTTP 200 ok=true :: ORANGE-MANGO-PROTOCOL-42
claude-haiku-4-5                   HTTP 200 ok=true :: ORANGE-MANGO-PROTOCOL-42
```

`/responses`-routed PDFs are forwarded by the adapter and covered by a unit test, but have not been live-probed.

So the PDF change is best read as removing a guaranteed Azure 400 the moment a PDF part ever does arrive, rather than as a user-visible fix today.

Copilot Chat's PDF attach path still gates on `supportsVision` plus a hardcoded `family` allowlist. That is tracked upstream as microsoft/vscode#324961; this PR does not attempt to spoof `family`.

## Related Issues, Builds, Pipeline Runs, etc.

- #89
- microsoft/vscode#324961

## Pull Request Pre-check

- [x] Linting Validation Passed — 0 errors (31 pre-existing warnings, none in touched files)
- [x] Formatting Validation Passed
- [x] Unit Testing Passes — 1047 passing; S 91.31 / B 82.60 / F 89.17 / L 91.31
- [ ] Documentation Updated — no user-facing docs changed; `editTools` override syntax in `README.md` is unchanged
